### PR TITLE
Update release scripts

### DIFF
--- a/test_release
+++ b/test_release
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 
-echo "Publish Release"
+echo "Testing Publish Release"
 version=$1 # first argument is the current release
 echo "Releasing version:$1"
 #########################################
@@ -30,5 +30,10 @@ python setup.py sdist bdist_wheel --new_version $1
 #########################################
 # Upload to pypi server
 #########################################
-twine upload --repository pypi dist/*
+twine upload --repository testpypi dist/*
+#########################################
+# Remove tag from local and origin
+#########################################
+git tag -d $version
+git push --delete origin $version
 


### PR DESCRIPTION
This commit changes the release script to use the PyPi server for publishing
the package. Also, this commit adds a script to test the release on testpypi.
The test script generates a tag, pushes it, uploads the package to testpypi
and removes the tag (as the actual release will need this tag).