### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install twine
       - name: Push tag
         run: |


### PR DESCRIPTION
Use requierments file for installing packages in workflow's enviorment,
so reading the version from __init__.py will work properly.