### PR TITLE
Support TF 2.6 and 2.7

### DIFF
--- a/.github/workflows/run_tests_suite.yml
+++ b/.github/workflows/run_tests_suite.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 on:
+  workflow_dispatch: # Allow manual triggers
+    schedule:
+      - cron: 0 0 * * *
   pull_request:
     branches:
       - main

--- a/.github/workflows/run_tests_suite_tf26.yml
+++ b/.github/workflows/run_tests_suite_tf26.yml
@@ -1,4 +1,4 @@
-name: Run Tests - Tensorflow 2.7
+name: Run Tests - Tensorflow 2.6
 on:
   workflow_dispatch: # Allow manual triggers
     schedule:
@@ -15,7 +15,7 @@ jobs:
           python-version: 3.8
       - name: Edit requirements
         run: |
-          sed -i "s/tensorflow==2.5/tensorflow==2.7/g" requirements.txt
+          sed -i "s/tensorflow==2.5/tensorflow==2.6/g" requirements.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/model_compression_toolkit/keras/back2framework/model_builder.py
+++ b/model_compression_toolkit/keras/back2framework/model_builder.py
@@ -17,9 +17,17 @@
 from enum import Enum
 
 import tensorflow as tf
+
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.keras.layers import Input
+    from tensorflow.python.keras.layers.core import TFOpLambda
+else:
+    from keras import Input
+    from keras.layers.core import TFOpLambda
+
 from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
 from tensorflow.python.keras.layers import Layer
-from tensorflow.python.keras.layers.core import TFOpLambda
 from tensorflow_model_optimization.python.core.quantization.keras.quantize_wrapper import QuantizeWrapper
 from typing import Tuple, Any, Dict, List
 from tensorflow.python.util.object_identity import Reference as TFReference
@@ -214,7 +222,7 @@ def model_builder(graph: common.Graph,
     # Hold a dictionary from an input node to its corresponding input tensor. It is needed for when
     # building the model. Initially input nodes with input tensors are added to the dictionary,
     # as they're not added later.
-    input_nodes_to_input_tensors = {inode: tf.keras.layers.Input(inode.framework_attr[BATCH_INPUT_SHAPE][1:]) for
+    input_nodes_to_input_tensors = {inode: Input(inode.framework_attr[BATCH_INPUT_SHAPE][1:]) for
                                     inode in graph.get_inputs()}
 
     # Build a list of the model's input tensors. Switching from a dictionary to a list

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
@@ -13,13 +13,19 @@
 # limitations under the License.
 # ==============================================================================
 
+import tensorflow as tf
+
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
+else:
+    from keras.engine.base_layer import TensorFlowOpLayer
 
 import copy
 
 import numpy as np
 from tensorflow.keras.layers import Activation, Conv2D, Dense, DepthwiseConv2D, ZeroPadding2D, Reshape, \
     GlobalAveragePooling2D, Dropout, ReLU, PReLU, ELU
-from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
 from typing import Tuple, Any
 
 from model_compression_toolkit import common

--- a/model_compression_toolkit/keras/reader/common.py
+++ b/model_compression_toolkit/keras/reader/common.py
@@ -15,14 +15,22 @@
 
 
 import tensorflow as tf
+
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.node import Node as KerasNode
+    from tensorflow.keras.layers import InputLayer
+else:
+    from keras.engine.input_layer import InputLayer
+    from keras.engine.node import Node as KerasNode
+
+
 from tensorflow.python.keras.engine.functional import Functional
-from tensorflow.python.keras.engine.node import Node as KerasNode
+
 from tensorflow.python.keras.engine.sequential import Sequential
 
 from model_compression_toolkit.common.graph.node import Node
 
-keras = tf.keras
-layers = keras.layers
 
 
 def is_node_an_input_layer(node: Node) -> bool:
@@ -35,12 +43,11 @@ def is_node_an_input_layer(node: Node) -> bool:
         Whether the node represents an input layer or not.
     """
     if isinstance(node, Node):
-        return node.layer_class == layers.InputLayer
+        return node.layer_class == InputLayer
     elif isinstance(node, KerasNode):
-        return isinstance(node.layer, layers.InputLayer)
+        return isinstance(node.layer, InputLayer)
     else:
         raise Exception('Node to check has to be either a graph node or a keras node')
-
 
 def is_node_a_model(node: Node) -> bool:
     """


### PR DESCRIPTION
Fixed imports to support Tensorflow 2.6 and 2.7.
Added a workflow to check the tests suite using TF2.6.
Changed tests suite running to run also nigthly and manually (and not just upon a PR).
For different TF versions - changed to run nightly as well.