### PR TITLE
Add correlation weighting and a configurable number of images

### DIFF
--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -20,7 +20,7 @@ from model_compression_toolkit.common.mixed_precision import mixed_precision_qua
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig, \
     ThresholdSelectionMethod, QuantizationMethod, DEFAULTCONFIG
 from model_compression_toolkit.common.mixed_precision.kpi import KPI
-from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig, MixedPrecisionMetricsWeighting
+from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.common.logger import set_log_folder
 from model_compression_toolkit.common.data_loader import FolderImageLoader
 from model_compression_toolkit.common.framework_info import FrameworkInfo

--- a/model_compression_toolkit/common/mixed_precision/distance_weighting.py
+++ b/model_compression_toolkit/common/mixed_precision/distance_weighting.py
@@ -15,47 +15,69 @@
 
 import numpy as np
 
-from model_compression_toolkit.common import Graph
 
-from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
-    MixedPrecisionMetricsWeighting
-
-
-def _get_average_weights(graph: Graph) -> np.ndarray:
+def get_average_weights(distance_matrix: np.ndarray) -> np.ndarray:
     """
     Get weights for weighting the sensitivity among different layers when evaluating MP configurations on
     model's sensitivity. This function returns equal weights for each layer, such that the sensitivity
     is averaged over all layers.
     Args:
-        graph: Graph to compute the weights for its sensitivity evaluation.
+        distance_matrix: Numpy array at shape (L,M): L -number of interest points, M number of samples.
+        The matrix contain the distance for each interest point at each sample.
 
     Returns:
         Numpy array containing equal weights for sensitivity weighting.
     """
 
-    num_nodes = len(graph.get_configurable_sorted_nodes())
-    return np.asarray([1/num_nodes for _ in range(num_nodes)])
+    num_nodes = len(distance_matrix)
+    return np.asarray([1 / num_nodes for _ in range(num_nodes)])
 
 
-def _get_last_layer_weights(graph: Graph) -> np.ndarray:
+def get_last_layer_weights(distance_matrix: np.ndarray) -> np.ndarray:
     """
     Get weights for weighting the sensitivity among different layers when evaluating MP configurations on
     model's sensitivity. This function returns weights for each layer, such that the sensitivity
     is computed using only the last layer of the model (all other weights are zero).
 
     Args:
-        graph: Graph to compute the weights for its sensitivity evaluation.
+        distance_matrix: Numpy array at shape (L,M): L -number of interest points, M number of samples.
+        The matrix contain the distance for each interest point at each sample.
 
     Returns:
         Numpy array containing weights for sensitivity weighting (all zero but the last one).
     """
-    num_nodes = len(graph.get_configurable_sorted_nodes())
+    num_nodes = len(distance_matrix)
     w = np.asarray([0 for _ in range(num_nodes)])
     w[-1] = 1
     return w
 
 
-# Factory for weighting functions.
-metric_weighting_dict = {MixedPrecisionMetricsWeighting.AVERAGE: _get_average_weights,
-                         MixedPrecisionMetricsWeighting.LAST_LAYER: _get_last_layer_weights}
+def get_correlation_to_last_weights(distance_matrix: np.ndarray):
+    """
+    Get weights for weighting the sensitivity among different layers when evaluating MP configurations on
+    model's sensitivity. This function returns weights for each layer, such that the sensitivity
+    is computed using the correlation between each layer and the last layer.
+
+    Args:
+        distance_matrix: Numpy array at shape (L,M): L -number of interest points, M number of samples.
+        The matrix contain the distance for each interest point at each sample.
+
+    Returns:
+        Numpy array containing weights for sensitivity weighting.
+    """
+
+    # distance_matrix D[L,M]: L -number of layers, M number of samples
+    ncs_matrix = distance_matrix.transpose() - distance_matrix.mean(axis=1)  # D[M,L]
+    std_vector = np.sqrt(np.power(ncs_matrix, 2.0).mean(axis=0))
+    normalization_matrix = np.matmul(std_vector[:, np.newaxis], std_vector[np.newaxis, :])
+    num_samples = distance_matrix.shape[1]
+    num_interest_points = distance_matrix.shape[0]
+    cross_matrix = (np.matmul(ncs_matrix.transpose(), ncs_matrix) / num_samples) / normalization_matrix
+    correlation_to_last_layer = cross_matrix[:, num_interest_points - 1]
+
+    def _softmax(x):
+        e_x = np.exp(x - np.max(x))
+        return e_x / e_x.sum(axis=0)
+
+    return _softmax(correlation_to_last_layer)
 

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_search_facade.py
@@ -84,9 +84,6 @@ def search_bit_width(graph_to_search_cfg: Graph,
     else:
         raise NotImplemented
 
-    # Evaluate the expected KPI for each node and for each bitwidth (in the search_methods space).
-    # layer_to_kpi_mapping = graph.get_node_to_kpi_mapping(search_manager.layer_to_bitwidth_mapping)
-
     # Search for the desired mixed-precision configuration
     result_bit_cfg = search_method_fn(search_manager.layer_to_bitwidth_mapping,
                                       search_manager.compute_metric_fn,

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_search_manager.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import numpy as np
+
 from typing import Callable
 from typing import Dict, List
 
 from model_compression_toolkit.common.graph.base_graph import Graph
-from model_compression_toolkit.common.mixed_precision.distance_weighting import metric_weighting_dict
 from model_compression_toolkit.common.mixed_precision.kpi import KPI
 from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
     MixedPrecisionQuantizationConfig
@@ -47,7 +46,7 @@ class MixedPrecisionSearchManager(object):
         self.qc = qc
         self.fw_info = fw_info
         self.get_sensitivity_evaluation = get_sensitivity_evaluation
-        self.metrics_weights = self.get_metrics_weights()
+        self.metrics_weights = self.qc.distance_weighting_method
         self.layer_to_bitwidth_mapping = self.get_search_space()
         self.compute_metric_fn = self.get_sensitivity_metric()
 
@@ -68,15 +67,6 @@ class MixedPrecisionSearchManager(object):
             indices_mapping[idx] = list(range(len(n.candidates_weights_quantization_cfg)))  # all search_methods space
         return indices_mapping
 
-    def get_metrics_weights(self) -> np.ndarray:
-        """
-
-        Returns: Weights for weighting the sensitivity for each layer.
-
-        """
-        # Get weights for weighting the sensitivity for each layer.
-        metrics_weights_by_node_index = metric_weighting_dict.get(self.qc.distance_weighting_method)
-        return metrics_weights_by_node_index(self.graph)
 
     def get_sensitivity_metric(self) -> Callable:
         """

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_percision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_percision_test.py
@@ -44,7 +44,7 @@ class MixedPercisionBaseTest(BaseFeatureNetworkTest):
                                     relu_unbound_correction=True,
                                     input_scaling=True)
 
-        return MixedPrecisionQuantizationConfig(qc, weights_n_bits=[2, 8, 4])
+        return MixedPrecisionQuantizationConfig(qc, weights_n_bits=[2, 8, 4], num_of_images=100)
 
     def get_bit_widths_config(self):
         return None

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -78,10 +78,16 @@ class FeatureNetworkTest(unittest.TestCase):
     def test_reuse_separable(self):
         ReusedSeparableTest(self).run_test()
 
-    def test_mixed_percision(self):
+    def test_mixed_precision_search_kpi_2bits_avg(self):
         MixedPercisionSearchKPI2BitsAvgTest(self).run_test()
+
+    def test_mixed_precision_search_kpi_4bits_avg(self):
         MixedPercisionSearchKPI4BitsAvgTest(self).run_test()
+
+    def test_mixed_precision_search(self):
         MixedPercisionSearchTest(self).run_test()
+
+    def test_mixed_precision_dw(self):
         MixedPercisionDepthwiseTest(self).run_test()
 
     def test_name_filter(self):


### PR DESCRIPTION
Similarity analyzer changes:
- Added NMSE and NMAE.
- Changed names in similarity_analyzer to float and fxp tensors instead of a and b.

Mixed-precision changes:
- Added a new function to compute weights of the metrics based on a correlation
of each layer to the last layer of the model.
- Changed DEFAULT_MIXEDPRECISION_CONFIG to use 2, 4 and 8 bits for searching a mixed-precision configuration.
- Removed MixedPrecisionMetricsWeighting enum and factory, and used functions to
pass to the MixedPrecisionQuantizationConfig as weighting methods.
- Changed the distance matrix type to be numpy array instead of dictionary.
- Changed the average and last_layer weighting methods to receive distance matrix instead
of receiving a graph.