### PR TITLE
Fix long runtime of tests suite

### DIFF
--- a/.github/workflows/run_tests_suite.yml
+++ b/.github/workflows/run_tests_suite.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       COVERAGE_THRESHOlD: 80
     steps:

--- a/.github/workflows/run_tests_suite_tf26.yml
+++ b/.github/workflows/run_tests_suite_tf26.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/run_tests_suite_tf27.yml
+++ b/.github/workflows/run_tests_suite_tf27.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_percision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_percision_test.py
@@ -44,7 +44,7 @@ class MixedPercisionBaseTest(BaseFeatureNetworkTest):
                                     relu_unbound_correction=True,
                                     input_scaling=True)
 
-        return MixedPrecisionQuantizationConfig(qc, weights_n_bits=[2, 8, 4], num_of_images=100)
+        return MixedPrecisionQuantizationConfig(qc, weights_n_bits=[2, 8, 4], num_of_images=1)
 
     def get_bit_widths_config(self):
         return None


### PR DESCRIPTION
Added a timeout to github actions that run tests suite - 10 minutes.
Changed mixed-precision tests to use a single image when computing
metrics (instead of 100).