### PR TITLE
Fix unflatten inner Keras models

### DIFF
--- a/model_compression_toolkit/keras/back2framework/model_builder.py
+++ b/model_compression_toolkit/keras/back2framework/model_builder.py
@@ -16,18 +16,20 @@
 
 import tensorflow as tf
 
-
 # As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
 if tf.__version__ < "2.6":
     from tensorflow.keras.layers import Input
     from tensorflow.python.keras.layers.core import TFOpLambda
+    from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
+    from tensorflow.python.keras.layers import Layer
 else:
     from keras import Input
     from keras.layers.core import TFOpLambda
+    from keras.engine.base_layer import TensorFlowOpLayer, Layer
+
+
 
 from model_compression_toolkit.common.model_builder_mode import ModelBuilderMode
-from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
-from tensorflow.python.keras.layers import Layer
 from tensorflow_model_optimization.python.core.quantization.keras.quantize_wrapper import QuantizeWrapper
 from typing import Tuple, Any, Dict, List
 from tensorflow.python.util.object_identity import Reference as TFReference

--- a/model_compression_toolkit/keras/gradient_ptq/graph_update.py
+++ b/model_compression_toolkit/keras/gradient_ptq/graph_update.py
@@ -15,8 +15,14 @@
 
 
 import copy
+import tensorflow as tf
 
-from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
+else:
+    from keras.engine.base_layer import TensorFlowOpLayer
+
 from tensorflow_model_optimization.python.core.quantization.keras.quantize_wrapper import QuantizeWrapper
 
 from model_compression_toolkit import common

--- a/model_compression_toolkit/keras/quantizer/gradient_ptq/activation_quantizer_gptq_config.py
+++ b/model_compression_toolkit/keras/quantizer/gradient_ptq/activation_quantizer_gptq_config.py
@@ -20,7 +20,12 @@ from tensorflow.python.training.tracking.data_structures import ListWrapper
 from model_compression_toolkit.common.constants import THRESHOLD
 from model_compression_toolkit.keras.quantizer.gradient_ptq.activation_quantizer import TrainableQuantizer
 from model_compression_toolkit.keras.quantizer.gradient_ptq.base_quantizer_gptq_config import BaseQuantizeConfig
-from tensorflow.python.keras.layers import Layer
+import tensorflow as tf
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.layers import Layer
+else:
+    from keras.engine.base_layer import Layer
 from tensorflow import Tensor
 from tensorflow_model_optimization.python.core.quantization.keras.quantizers import Quantizer
 

--- a/model_compression_toolkit/keras/quantizer/gradient_ptq/activation_weight_quantizer_gptq_config.py
+++ b/model_compression_toolkit/keras/quantizer/gradient_ptq/activation_weight_quantizer_gptq_config.py
@@ -16,7 +16,12 @@
 from typing import List, Tuple, Any, Dict
 
 from tensorflow import Tensor
-from tensorflow.python.keras.layers import Layer
+import tensorflow as tf
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.layers import Layer
+else:
+    from keras.engine.base_layer import Layer
 from tensorflow.python.training.tracking.data_structures import ListWrapper
 from tensorflow_model_optimization.python.core.quantization.keras.quantizers import Quantizer
 

--- a/model_compression_toolkit/keras/quantizer/gradient_ptq/weight_quantizer_gptq_config.py
+++ b/model_compression_toolkit/keras/quantizer/gradient_ptq/weight_quantizer_gptq_config.py
@@ -16,7 +16,15 @@
 from typing import List, Tuple, Any, Dict
 
 from tensorflow import Tensor
-from tensorflow.python.keras.layers import Layer
+import tensorflow as tf
+
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.layers import Layer
+else:
+    from keras.engine.base_layer import Layer
+
+
 from tensorflow.python.training.tracking.data_structures import ListWrapper
 from tensorflow_model_optimization.python.core.quantization.keras.quantizers import Quantizer
 

--- a/model_compression_toolkit/keras/quantizer/mixed_precision/selective_weights_quantize_config.py
+++ b/model_compression_toolkit/keras/quantizer/mixed_precision/selective_weights_quantize_config.py
@@ -17,7 +17,12 @@ from typing import List, Tuple, Any, Dict
 
 import numpy as np
 from tensorflow import Tensor
-from tensorflow.python.keras.layers import Layer
+import tensorflow as tf
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.layers import Layer
+else:
+    from keras.engine.base_layer import Layer
 from tensorflow.python.training.tracking.data_structures import ListWrapper
 from tensorflow_model_optimization.python.core.quantization.keras.quantize_config import QuantizeConfig
 

--- a/model_compression_toolkit/keras/reader/common.py
+++ b/model_compression_toolkit/keras/reader/common.py
@@ -20,14 +20,13 @@ import tensorflow as tf
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.node import Node as KerasNode
     from tensorflow.keras.layers import InputLayer
+    from tensorflow.python.keras.engine.functional import Functional
+    from tensorflow.python.keras.engine.sequential import Sequential
 else:
     from keras.engine.input_layer import InputLayer
     from keras.engine.node import Node as KerasNode
-
-
-from tensorflow.python.keras.engine.functional import Functional
-
-from tensorflow.python.keras.engine.sequential import Sequential
+    from keras.engine.functional import Functional
+    from keras.engine.sequential import Sequential
 
 from model_compression_toolkit.common.graph.base_node import BaseNode
 
@@ -65,4 +64,3 @@ def is_node_a_model(node: BaseNode) -> bool:
     else:
         raise Exception('Node to check has to be either a graph node or a keras node')
 
-    # return node.layer_class in [Functional, Sequential]

--- a/model_compression_toolkit/keras/reader/connectivity_handler.py
+++ b/model_compression_toolkit/keras/reader/connectivity_handler.py
@@ -15,7 +15,13 @@
 
 
 import tensorflow as tf
-from tensorflow.python.keras.engine.node import Node as KerasNode
+# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.node import Node as KerasNode
+else:
+    from keras.engine.node import Node as KerasNode
+
+
 from tensorflow.python.util.object_identity import Reference as TFReference
 from typing import List, Tuple
 

--- a/model_compression_toolkit/keras/reader/node_builder.py
+++ b/model_compression_toolkit/keras/reader/node_builder.py
@@ -19,11 +19,12 @@ import tensorflow as tf
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda, SlicingOpLambda
     from tensorflow.python.keras.engine.keras_tensor import KerasTensor
+    from tensorflow.python.keras.engine.node import Node as KerasNode
 else:
     from keras.layers.core import TFOpLambda, SlicingOpLambda
     from keras.engine.keras_tensor import KerasTensor
+    from keras.engine.node import Node as KerasNode
 
-from tensorflow.python.keras.engine.node import Node as KerasNode
 from model_compression_toolkit.common.graph.base_node import BaseNode
 from model_compression_toolkit.common.graph.functional_node import FunctionalNode
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_output_nodes_multiple_tensors_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_output_nodes_multiple_tensors_test.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
+import tensorflow as tf
 
-from tensorflow.python.keras.engine.functional import Functional
-from tensorflow.python.keras.engine.sequential import Sequential
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.functional import Functional
+    from tensorflow.python.keras.engine.sequential import Sequential
+else:
+    from keras.models import Functional, Sequential
+
 from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -14,11 +14,14 @@
 # ==============================================================================
 
 
-from tensorflow.python.keras.engine.functional import Functional
-from tensorflow.python.keras.engine.sequential import Sequential
 from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.functional import Functional
+    from tensorflow.python.keras.engine.sequential import Sequential
+else:
+    from keras.models import Functional, Sequential
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -14,11 +14,14 @@
 # ==============================================================================
 
 
-from tensorflow.python.keras.engine.functional import Functional
-from tensorflow.python.keras.engine.sequential import Sequential
 from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.functional import Functional
+    from tensorflow.python.keras.engine.sequential import Sequential
+else:
+    from keras.models import Functional, Sequential
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -14,11 +14,14 @@
 # ==============================================================================
 
 
-from tensorflow.python.keras.engine.functional import Functional
-from tensorflow.python.keras.engine.sequential import Sequential
 from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+if tf.__version__ < "2.6":
+    from tensorflow.python.keras.engine.functional import Functional
+    from tensorflow.python.keras.engine.sequential import Sequential
+else:
+    from keras.models import Functional, Sequential
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 
@@ -80,6 +83,13 @@ class NestedTest(BaseFeatureNetworkTest):
                 self.unit_test.assertFalse(isinstance(l.layer, Functional) or isinstance(l.layer, Sequential))
             else:
                 self.unit_test.assertFalse(isinstance(l, Functional) or isinstance(l, Sequential))
+        if self.is_inner_functional:
+            num_layers = 8
+            num_fq_layers = 5
+        else:
+            num_layers = 5
+            num_fq_layers = 3
+        self.unit_test.assertTrue(len(quantized_model.layers) == (num_layers+num_fq_layers))
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)
         cs = cosine_similarity(y, y_hat)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/output_in_middle_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/output_in_middle_test.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 
 
-from tensorflow.python.keras.engine.functional import Functional
-from tensorflow.python.keras.engine.sequential import Sequential
 from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf


### PR DESCRIPTION
Fixed an issue in case the model to quantize contains
other inner models. The inner models should get flatten
and an import issue of Functional and Sequential from
keras caused it to fail when working with TF>2.5.