### PR TITLE
Fix graph and function tests

### DIFF
--- a/tests/keras_tests/function_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/function_tests/test_lp_search_bitwidth.py
@@ -75,6 +75,12 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
         in_model = MobileNetV2()
         keras_impl = KerasImplementation()
         graph = keras_impl.model_reader(in_model)  # model reading
+        graph = set_quantization_configuration_to_graph(graph=graph,
+                                                        quant_config=qc,
+                                                        fw_info=fw_info)
+        for node in graph.nodes:
+            node.prior_info = keras_impl.get_node_prior_info(node=node,
+                                                             fw_info=fw_info)
         analyzer_graph(keras_impl.attach_sc_to_node,
                        graph,
                        fw_info)
@@ -83,7 +89,6 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
         for i in range(10):
             mi.infer([np.random.randn(1, 224, 224, 3)])
 
-        graph = set_quantization_configuration_to_graph(graph, qc, fw_info)
         calculate_quantization_params(graph,
                                       fw_info,
                                       fw_impl=keras_impl)

--- a/tests/keras_tests/graph_tests/test_graph_quantization_and_export.py
+++ b/tests/keras_tests/graph_tests/test_graph_quantization_and_export.py
@@ -45,15 +45,19 @@ class TestGraphQuantization(unittest.TestCase):
         graph = model_reader(model)  # model pharsing
         fw_impl = KerasImplementation()
         tg = substitute(graph, fw_impl.get_substitutions_pre_statistics_collection())
+        for node in tg.nodes:
+            node.prior_info = fw_impl.get_node_prior_info(node=node,
+                                                          fw_info=DEFAULT_KERAS_INFO)
+
+        tg = set_quantization_configuration_to_graph(graph=tg,
+                                                     quant_config=DEFAULTCONFIG,
+                                                     fw_info=DEFAULT_KERAS_INFO)
         analyzer_graph(fw_impl.attach_sc_to_node, tg, DEFAULT_KERAS_INFO)  # mark tensors and quantization point
         mi = ModelCollector(tg, fw_impl, DEFAULT_KERAS_INFO)
 
         for i in range(10):
             mi.infer([np.random.randn(1, 224, 224, 3)])
 
-        tg = set_quantization_configuration_to_graph(tg,
-                                                     DEFAULTCONFIG,
-                                                     DEFAULT_KERAS_INFO)
         calculate_quantization_params(tg,
                                       DEFAULT_KERAS_INFO,
                                       fw_impl=fw_impl)


### PR DESCRIPTION
In graph and function tests in keras tests, we need to set
quantization configuration to nodes before building the graph
back to a model.
This commit adds it and fixes these tests.