### PR TITLE
Fix year and library version in sphinx configuration file

### DIFF
--- a/docs/.buildinfo
+++ b/docs/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: a9511307f9dc9743db81479300fa516e
+config: df9f0de8eaf4b8cae80f3b8edf3b45b0
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/docs/_static/bizstyle.js
+++ b/docs/_static/bizstyle.js
@@ -36,6 +36,6 @@ $(window).resize(function(){
         $("li.nav-item-0 a").text("Top");
     }
     else {
-        $("li.nav-item-0 a").text("MCT Documentation: ver 1.0.0");
+        $("li.nav-item-0 a").text("MCT Documentation: ver 1.1.0");
     }
 });

--- a/docs/_static/documentation_options.js
+++ b/docs/_static/documentation_options.js
@@ -1,6 +1,6 @@
 var DOCUMENTATION_OPTIONS = {
     URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
-    VERSION: '1.0.0',
+    VERSION: '1.1.0',
     LANGUAGE: 'None',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',

--- a/docs/api/api_docs/classes/DefaultDict.html
+++ b/docs/api/api_docs/classes/DefaultDict.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>DefaultDict Class &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>DefaultDict Class &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">DefaultDict Class</a></li> 
       </ul>
     </div>  
@@ -106,12 +106,12 @@ If default_factory was not passed at initialization, it returns None.</p>
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">DefaultDict Class</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/classes/FolderImageLoader.html
+++ b/docs/api/api_docs/classes/FolderImageLoader.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>Folder Image Loader API &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Folder Image Loader API &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Folder Image Loader API</a></li> 
       </ul>
     </div>  
@@ -124,12 +124,12 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Folder Image Loader API</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/classes/FrameworkInfo.html
+++ b/docs/api/api_docs/classes/FrameworkInfo.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>FrameworkInfo Class &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>FrameworkInfo Class &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">FrameworkInfo Class</a></li> 
       </ul>
     </div>  
@@ -156,12 +156,12 @@ set, and we know it’s kernel out/in channel indices are (3, 2) respectivly:</p
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">FrameworkInfo Class</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/classes/GradientPTQConfig.html
+++ b/docs/api/api_docs/classes/GradientPTQConfig.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>GradientPTQConfig Class &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>GradientPTQConfig Class &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">GradientPTQConfig Class</a></li> 
       </ul>
     </div>  
@@ -107,12 +107,12 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">GradientPTQConfig Class</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/index.html
+++ b/docs/api/api_docs/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>API Docs &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>API Docs &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../_static/css/custom.css" />
@@ -34,7 +34,7 @@
         <li class="right" >
           <a href="../../guidelines/quickstart_keras.html" title="MCT Quickstart Guideline"
              accesskey="P">previous</a> |</li>
-        <li class="nav-item nav-item-0"><a href="../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">API Docs</a></li> 
       </ul>
     </div>  
@@ -131,12 +131,12 @@
         <li class="right" >
           <a href="../../guidelines/quickstart_keras.html" title="MCT Quickstart Guideline"
              >previous</a> |</li>
-        <li class="nav-item nav-item-0"><a href="../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">API Docs</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/methods/keras_post_training_quantization.html
+++ b/docs/api/api_docs/methods/keras_post_training_quantization.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>Keras Post Training Quantization &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Keras Post Training Quantization &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Keras Post Training Quantization</a></li> 
       </ul>
     </div>  
@@ -118,12 +118,12 @@ training quantization by comparing points between the float and quantized models
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Keras Post Training Quantization</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/methods/keras_post_training_quantization_mixed_precision.html
+++ b/docs/api/api_docs/methods/keras_post_training_quantization_mixed_precision.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>Keras Post Training Mixed Precision Quantization (Experimental) &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Keras Post Training Mixed Precision Quantization (Experimental) &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Keras Post Training Mixed Precision Quantization (Experimental)</a></li> 
       </ul>
     </div>  
@@ -137,12 +137,12 @@ Here, each layer can be quantized by 2, 4 or 8 bits:</p>
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Keras Post Training Mixed Precision Quantization (Experimental)</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/methods/set_logger_path.html
+++ b/docs/api/api_docs/methods/set_logger_path.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>Enable a Logger &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Enable a Logger &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Enable a Logger</a></li> 
       </ul>
     </div>  
@@ -85,12 +85,12 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Enable a Logger</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/modules/mixed_precision_quantization_config.html
+++ b/docs/api/api_docs/modules/mixed_precision_quantization_config.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>mixed_precision_quantization_config Module &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>mixed_precision_quantization_config Module &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">mixed_precision_quantization_config Module</a></li> 
       </ul>
     </div>  
@@ -121,12 +121,12 @@ support mixed-precision model quantization.</p>
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">mixed_precision_quantization_config Module</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/modules/network_editor.html
+++ b/docs/api/api_docs/modules/network_editor.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>network_editor Module &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>network_editor Module &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">network_editor Module</a></li> 
       </ul>
     </div>  
@@ -241,12 +241,12 @@ to modify the network during the quantization process.</p>
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">network_editor Module</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/api/api_docs/modules/quantization_config.html
+++ b/docs/api/api_docs/modules/quantization_config.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>quantization_config Module &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>quantization_config Module &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../../../_static/css/custom.css" />
@@ -30,7 +30,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">quantization_config Module</a></li> 
       </ul>
     </div>  
@@ -167,12 +167,12 @@ one may pass a desired QuantizationMethod when instantiating a QuantizationConfi
         <li class="right" style="margin-right: 10px">
           <a href="../../../genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../../../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">quantization_config Module</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Index &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Index &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="_static/css/custom.css" />
@@ -29,7 +29,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="#" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Index</a></li> 
       </ul>
     </div>  
@@ -216,12 +216,12 @@
         <li class="right" style="margin-right: 10px">
           <a href="#" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Index</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/guidelines/quickstart_keras.html
+++ b/docs/guidelines/quickstart_keras.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>MCT Quickstart Guideline &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>MCT Quickstart Guideline &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../_static/css/custom.css" />
@@ -38,7 +38,7 @@
         <li class="right" >
           <a href="visualization.html" title="Visualization within TensorBoard"
              accesskey="P">previous</a> |</li>
-        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">MCT Quickstart Guideline</a></li> 
       </ul>
     </div>  
@@ -166,12 +166,12 @@
         <li class="right" >
           <a href="visualization.html" title="Visualization within TensorBoard"
              >previous</a> |</li>
-        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">MCT Quickstart Guideline</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/guidelines/visualization.html
+++ b/docs/guidelines/visualization.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>Visualization within TensorBoard &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Visualization within TensorBoard &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="../_static/css/custom.css" />
@@ -38,7 +38,7 @@
         <li class="right" >
           <a href="../index.html" title="Model Compression Toolkit User Guide"
              accesskey="P">previous</a> |</li>
-        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Visualization within TensorBoard</a></li> 
       </ul>
     </div>  
@@ -159,12 +159,12 @@ the models, and the cosine similarity at the output of different layers are comp
         <li class="right" >
           <a href="../index.html" title="Model Compression Toolkit User Guide"
              >previous</a> |</li>
-        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="../index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Visualization within TensorBoard</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 
-    <title>Model Compression Toolkit User Guide &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Model Compression Toolkit User Guide &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="_static/css/custom.css" />
@@ -34,7 +34,7 @@
         <li class="right" >
           <a href="guidelines/visualization.html" title="Visualization within TensorBoard"
              accesskey="N">next</a> |</li>
-        <li class="nav-item nav-item-0"><a href="#">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="#">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Model Compression Toolkit User Guide</a></li> 
       </ul>
     </div>  
@@ -156,12 +156,12 @@ This project enables researchers, developers and engineers an easily way to opti
         <li class="right" >
           <a href="guidelines/visualization.html" title="Visualization within TensorBoard"
              >next</a> |</li>
-        <li class="nav-item nav-item-0"><a href="#">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="#">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Model Compression Toolkit User Guide</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docs/search.html
+++ b/docs/search.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Search &#8212; MCT Documentation: ver 1.0.0</title>
+    <title>Search &#8212; MCT Documentation: ver 1.1.0</title>
     <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/bizstyle.css" />
     <link rel="stylesheet" type="text/css" href="_static/css/custom.css" />
@@ -35,7 +35,7 @@
         <li class="right" style="margin-right: 10px">
           <a href="genindex.html" title="General Index"
              accesskey="I">index</a></li>
-        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Search</a></li> 
       </ul>
     </div>  
@@ -92,12 +92,12 @@
         <li class="right" style="margin-right: 10px">
           <a href="genindex.html" title="General Index"
              >index</a></li>
-        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.0.0</a> &#187;</li>
+        <li class="nav-item nav-item-0"><a href="index.html">MCT Documentation: ver 1.1.0</a> &#187;</li>
         <li class="nav-item nav-item-this"><a href="">Search</a></li> 
       </ul>
     </div>
     <div class="footer" role="contentinfo">
-        &#169; Copyright 2021, Sony Semiconductors Israel.
+        &#169; Copyright 2022, Sony Semiconductors Israel.
       Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 4.3.2.
     </div>
   </body>

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -19,11 +19,12 @@ sys.path.insert(0, os.path.abspath('../../'))
 # -- Project information -----------------------------------------------------
 
 project = 'MCT'
-copyright = '2021, Sony Semiconductors Israel'
+copyright = '2022, Sony Semiconductors Israel'
 author = 'Sony Semiconductors Israel'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+import model_compression_toolkit as mct
+release = mct.__version__
 
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
This commit fixes several things in sphinx configuration file:
The copyright year to 2022 and the version (which it is now been
taken from the init of MCT).

In addition, the docs pages were regenerated after these changes.