### PR TITLE
Prolong tests suite time-limit

### DIFF
--- a/.github/workflows/run_tests_suite_all_latest_frameworks.yml
+++ b/.github/workflows/run_tests_suite_all_latest_frameworks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       COVERAGE_THRESHOlD: 80
     steps:


### PR DESCRIPTION
Change workflow that runs all tests from
time-limit of 15 minutes to 20 minutes.