### PR TITLE
fix negative shift substitution constant shape to match input_shape

### DIFF
--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
@@ -136,8 +136,7 @@ def create_add_node(add_value: float,
             NODE_OP: NODE_ADD_OPERATOR,
             NODE_INPUT: [prev_node_name, add_node_name + INPUT_VARIABLE_SUFFIX],
         },
-        CONSTANTS: {1: np.array([[[[add_value]]]],
-                                dtype=np.float32)}}
+        CONSTANTS: {1: np.array(add_value, dtype=np.float32).reshape([1]*len(input_shape))}}
 
     add_node = common.graph.BaseNode(add_node_name,
                                      fw_attr,

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -226,7 +226,7 @@ class FeatureNetworkTest(unittest.TestCase):
 
     def test_shift_neg_activation_dense(self):
         ShiftNegActivationTest(self, linear_op_to_test=layers.Dense(3),
-                               activation_op_to_test=tf.nn.leaky_relu).run_test()
+                               activation_op_to_test=tf.nn.leaky_relu, input_shape=(8, 3)).run_test()
         ShiftNegActivationTest(self, linear_op_to_test=layers.Dense(4),
                                activation_op_to_test=layers.ReLU(negative_slope=0.1)).run_test()
 


### PR DESCRIPTION
fix the shape of constant y in the shift negative activation to broadcast correctly to input_shape