### PR TITLE
Modified uniform & symmetric quantizers

### DIFF
--- a/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_search.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_search.py
@@ -170,7 +170,8 @@ def qparams_tensor_minimization(x, x0, error_function, quant_function, bounds=No
         """
     return optimize.minimize(fun=lambda qparam: error_function(x, quant_function(qparam), qparam),
                              x0=x0,
-                             bounds=bounds)
+                             bounds=bounds,
+                             method='Nelder-Mead')
 
 
 def qparams_histogram_minimization(x, x0, counts, error_function, quant_function, bounds=None):
@@ -202,7 +203,8 @@ def qparams_histogram_minimization(x, x0, counts, error_function, quant_function
                                                                                counts=counts,
                                                                                min_max_range=qparam),
                              x0=x0,
-                             bounds=bounds)
+                             bounds=bounds,
+                             method='Nelder-Mead')
 
 
 def kl_symmetric_qparams_histogram_minimization(x, x0, counts, n_bits, signed, error_function, bounds):
@@ -236,7 +238,8 @@ def kl_symmetric_qparams_histogram_minimization(x, x0, counts, n_bits, signed, e
                                                                                   counts=counts,
                                                                                   min_max_range=np.array([0, threshold]) if not signed else np.array([-threshold, threshold])),
                              x0=x0,
-                             bounds=bounds)
+                             bounds=bounds,
+                             method='Nelder-Mead')
 
 
 def kl_uniform_qparams_histogram_minimization(x, x0, counts, n_bits, error_function, bounds=None):
@@ -269,7 +272,8 @@ def kl_uniform_qparams_histogram_minimization(x, x0, counts, n_bits, error_funct
                                                                                   counts=counts,
                                                                                   min_max_range=min_max_range),
                              x0=x0,
-                             bounds=bounds)
+                             bounds=bounds,
+                             method='Nelder-Mead')
 
 
 def qparams_selection_histogram_search_error_function(error_function: Callable,

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/symmetric_selection.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/symmetric_selection.py
@@ -92,7 +92,8 @@ def symmetric_selection_tensor(tensor_data: np.ndarray,
                                                                              range_max=threshold,
                                                                              n_bits=n_bits),
                                     x0=init_threshold,
-                                    bounds=get_threshold_bounds(min_threshold, init_threshold))
+                                    bounds=get_threshold_bounds(min_threshold, init_threshold),
+                                    method='Nelder-Mead')
             # returned 'x' here is the optimized threshold value
             res = res.x
     else:

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/uniform_selection.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/uniform_selection.py
@@ -62,8 +62,9 @@ def uniform_selection_tensor(tensor_data: np.ndarray,
     Returns:
         Optimal quantization range to quantize the tensor uniformly.
     """
-    tensor_min = get_tensor_min(tensor_data, per_channel, channel_axis)
-    tensor_max = get_tensor_max(tensor_data, per_channel, channel_axis)
+    unsigned_tensor_data = np.abs(tensor_data)
+    tensor_max = get_tensor_max(unsigned_tensor_data, per_channel, channel_axis)
+    tensor_min = -tensor_max  # using minus tensor max for reducing clipping noise in the initial range
 
     if quant_error_method == qc.QuantizationErrorMethod.NOCLIPPING:
         res = tensor_min, tensor_max

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/uniform_selection.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/uniform_selection.py
@@ -89,7 +89,8 @@ def uniform_selection_tensor(tensor_data: np.ndarray,
                                                                                  range_max=min_max_range[1],
                                                                                  n_bits=n_bits),
                                     x0=x0,
-                                    bounds=get_range_bounds(tensor_min, tensor_max))
+                                    bounds=get_range_bounds(tensor_min, tensor_max),
+                                    method='Nelder-Mead')
             # returned 'x' here is an array with min and max range values
             res = res.x[0], res.x[1]
     else:


### PR DESCRIPTION
* Replaced minimization algorithm in parameters selection from original default algorithm (L-BFGS-B) to Nelder-Mead - much better results for the uniform quantizer (minor changes to symmetric accuracy). Changed for both weights and activations quantization (tested sporadically for activations).

* Modified uniform quantizer parameters selection, to use -tensor_max as the min value for the initial quantization range (only for weights quantization, activations quantization remain unchanged)