### PR TITLE
fixes to negative shift

### DIFF
--- a/model_compression_toolkit/common/network_editors/actions.py
+++ b/model_compression_toolkit/common/network_editors/actions.py
@@ -42,6 +42,11 @@ class EditRule(_EditRule):
 
     """
 
+    def __repr__(self):
+        _str = f'filter={type(self.filter).__name__}{self.filter.__dict__}'
+        _str = f'{_str} ; action={type(self.action).__name__}{self.action.kwargs}'
+        return _str
+
     pass
 
 
@@ -117,6 +122,12 @@ class ChangeFinalWeightsQuantConfigAttr(BaseAction):
         if node.final_weights_quantization_cfg is not None:
             for attr_name, attr_value in self.kwargs.items():
                 node.final_weights_quantization_cfg.set_quant_config_attr(attr_name, attr_value)
+        elif len(node.candidates_weights_quantization_cfg) > 0:
+            for candidate_config in node.candidates_weights_quantization_cfg:
+                for attr_name, attr_value in self.kwargs.items():
+                    candidate_config.set_quant_config_attr(attr_name, attr_value)
+
+
 
 
 

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -58,9 +58,6 @@ from model_compression_toolkit.common.visualization.tensorboard_writer import Te
 from model_compression_toolkit.common.bias_correction.apply_bias_correction_to_graph import apply_bias_correction_to_graph
 
 
-
-
-
 def post_training_quantization(in_model: Any,
                                representative_data_gen: Callable,
                                n_iter: int,
@@ -199,7 +196,7 @@ def _quantize_model(fw_info: FrameworkInfo,
     ######################################
     # Before building a quantized model, first apply some substitutions.
     quantized_tg = substitute(quantized_tg,
-                                                      fw_impl.get_substitutions_pre_build())
+                              fw_impl.get_substitutions_pre_build())
     quantized_model, user_info = fw_impl.model_builder(quantized_tg,
                                                        mode=ModelBuilderMode.QUANTIZED,
                                                        fw_info=fw_info)
@@ -305,12 +302,12 @@ def _quantize_fixed_bit_widths_graph(analyze_similarity: bool,
     # Gradient Based Post Training Quantization
     #############################################
     tg_bias = _apply_gptq(gptq_config,
-                     representative_data_gen,
-                     tb_w,
-                     tg,
-                     tg_bias,
-                     fw_info,
-                     fw_impl)
+                          representative_data_gen,
+                          tb_w,
+                          tg,
+                          tg_bias,
+                          fw_info,
+                          fw_impl)
 
     tg_float = copy.deepcopy(tg)  # Copy graph before quantization (for similarity analyzer)
     ######################################

--- a/model_compression_toolkit/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/node_quantization_config.py
@@ -101,7 +101,7 @@ class NodeActivationQuantizationConfig(BaseNodeNodeQuantizationConfig):
 
         """
         fake_quant = self.activation_quantization_fn(self.activation_n_bits,
-                                               self.activation_quantization_params)
+                                                     self.activation_quantization_params)
 
         if fake_quant is None:
             raise Exception('Layer is meant to be quantized but fake_quant function is None')

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -228,7 +228,8 @@ class FeatureNetworkTest(unittest.TestCase):
         ShiftNegActivationTest(self, linear_op_to_test=layers.Dense(3),
                                activation_op_to_test=tf.nn.leaky_relu, input_shape=(8, 3)).run_test()
         ShiftNegActivationTest(self, linear_op_to_test=layers.Dense(4),
-                               activation_op_to_test=layers.ReLU(negative_slope=0.1)).run_test()
+                               activation_op_to_test=layers.ReLU(negative_slope=0.99),
+                               bypass_op_list=[layers.GlobalAveragePooling2D()]).run_test()
 
     def test_shift_neg_activation_pad_dense(self):
         ShiftNegActivationTest(self, linear_op_to_test=layers.Dense(3),


### PR DESCRIPTION
fixes to negative shift: 
    1. change quantization of bypass nodes to unsigned
    2. change quantization of post-add node to non-linear number of activation bits
network editor: fix weight bits editor