### PR TITLE
Multi head attention support

### DIFF
--- a/model_compression_toolkit/common/graph/base_graph.py
+++ b/model_compression_toolkit/common/graph/base_graph.py
@@ -319,6 +319,31 @@ class Graph(nx.MultiDiGraph, GraphSearches):
             self.add_edge(ie.source_node, new_node, **ie.get_attributes())
             self.remove_edge(ie.source_node, current_node)
 
+    def add_node_with_in_edges(self, new_node: BaseNode, input_nodes: List[BaseNode],
+                               input_nodes_output_index: List[int] = []):
+        """
+        Add node to graph and connect it to its input nodes
+        (useful when adding a node during substitutions).
+
+        Args:
+            new_node: Node to add.
+            input_nodes: A list of new_node input nodes. The order is the sink_index of the edge
+             between the input node and new_node
+            input_nodes_output_index: A list output indices from input nodes. The order is the
+             source_index of the edge. Deafult is an empty list which means all output indices
+             are zero
+        """
+
+        if len(input_nodes_output_index) == 0:
+            input_nodes_output_index = [0] * len(input_nodes)
+
+        if len(input_nodes_output_index) != len(input_nodes):
+            raise Exception('Graph.add_node_with_in_edges: input_nodes & input_nodes_output_index must be the same length')
+
+        self.add_node(new_node)
+        for sink_index, (in_node, source_index) in enumerate(zip(input_nodes, input_nodes_output_index)):
+            self.add_edge(in_node, new_node, source_index=source_index, sink_index=sink_index)
+
     def replace_output_node(self,
                             current_node: BaseNode,
                             new_node: BaseNode):

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -129,6 +129,7 @@ The values are used for tensor min/max values initialization.
 ACTIVATION2MINMAX = {SOFTMAX: (0, 1),
                      SIGMOID: (0, 1),
                      LINEAR: (None, None),
+                     None: (None, None),
                      IDENTITY: (None, None),
                      TANH: (-1, 1),
                      SWISH: (-0.279, None),

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -56,6 +56,7 @@ NO_QUANTIZATION = [Reshape,
                    ZeroPadding2D,
                    Dropout,
                    MaxPooling2D,
+                   tf.reshape,
                    tf.split,
                    tf.quantization.fake_quant_with_min_max_vars]  # TODO:  replace with marking
 

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -19,12 +19,11 @@ import tensorflow as tf
 if tf.__version__ < "2.6":
     from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, InputLayer, \
-        Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU
+        Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
     Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, \
-    InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU
-
+    InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -52,6 +51,7 @@ KERNEL_OPS = [Conv2D,
 NO_QUANTIZATION = [Reshape,
                    tf.reshape,
                    Flatten,
+                   Permute,
                    Cropping2D,
                    ZeroPadding2D,
                    Dropout,
@@ -88,6 +88,7 @@ ACTIVATION = [Activation,
               tf.nn.selu,
               tf.nn.softplus,
               tf.nn.softmax,
+              Dot,
               tf.add,
               tf.multiply,
               tf.reduce_mean,

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/activation_decomposition.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/activation_decomposition.py
@@ -61,6 +61,9 @@ class ActivationDecomposition(common.BaseSubstitution):
         Returns:
             Graph after applying the substitution.
         """
+        # if op2d_node.framework_attr.get(ACTIVATION) in [None, LINEAR]:
+        #     # skip substitution if there's no activation
+        #     return graph
 
         activation_node_name = op2d_node.name + '_post_activation'
 

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
@@ -14,40 +14,19 @@
 # ==============================================================================
 
 
-import tensorflow as tf
-import numpy as np
-from tensorflow.keras.layers import MultiHeadAttention, Dense, Softmax, Concatenate, Dot, Permute, Multiply
+from tensorflow.keras.layers import MultiHeadAttention, Dense, Softmax, Concatenate, Dot
 
 from model_compression_toolkit import common
 from model_compression_toolkit.common.graph.base_graph import Graph, BaseNode, OutTensor
 from model_compression_toolkit.common.graph.graph_matchers import NodeOperationMatcher
-from model_compression_toolkit.keras.constants import KERNEL, DEPTHWISE_KERNEL, BIAS, KERNEL_SIZE, PADDING, \
-    STRIDES, USE_BIAS, LINEAR, ACTIVATION, TRAINABLE, FILTERS, PAD_VALID
-
-POINTWISE_KERNEL = 'pointwise_kernel'
-DEPTH_MULTIPLIER = 'depth_multiplier'
-DATA_FORMAT = 'data_format'
-DILATION_RATE = 'dilation_rate'
-DEPTHWISE_INITIALIZER = 'depthwise_initializer'
-DEPTHWISE_REGULARIZER = 'depthwise_regularizer'
-DEPTHWISE_CONSTRAINT = 'depthwise_constraint'
-BIAS_INITIALIZER = 'bias_initializer'
-BIAS_REGULARIZER = 'bias_regularizer'
-BIAS_CONSTRAINT = 'bias_constraint'
-ACTIVITY_REGULARIZER = 'activity_regularizer'
-KERNEL_INITIALIZER = 'kernel_initializer'
-SEPARABLE_PW_KERNEL_INITIALIZER = 'pointwise_initializer'
-KERNEL_REGULARIZER = 'kernel_regularizer'
-SEPARABLE_PW_KERNEL_REGULARIZER = 'pointwise_regularizer'
-KERNEL_CONSTRAINT = 'kernel_constraint'
-SEPARABLE_PW_KERNEL_CONSTRAINT = 'pointwise_constraint'
+from model_compression_toolkit.keras.constants import KERNEL, BIAS
 
 
 class MultiHeadAttentionDecomposition(common.BaseSubstitution):
     """
     Removes a MultiHeadAttention node from the graph,
-    and replaces it with a compatible graph that consists Dense, Dot, Softmax and Concatenate layers
-    (and tf.transpose)
+    and replaces it with a compatible graph that consists of Dense,
+     Dot, Softmax and Concatenate layers
     """
 
     def __init__(self):
@@ -60,68 +39,54 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
                    graph: Graph,
                    mha_node: BaseNode) -> Graph:
         """
-        Remove a SeparableConv2D node from the graph, and replace it with two equivalent nodes: DepthwiseConv2D
-        and Conv2D. The SeparableConv2D attributes are split to relevant attributes for each node.
+        Removes a MultiHeadAttention node from the graph, and replaces it with
+         a compatible graph that consists of Dense, Dot, Softmax and Concatenate layers
 
         Args:
             graph: Graph we apply the substitution on.
-            separable_node: Separable node to replace with a depthwise and pointwise nodes.
+            mha_node: MultiHeadAttention node to replace.
 
         Returns:
             Graph after applying the substitution.
         """
-
-        # multi_head_attention_1 / query / kernel: 0(8, 3, 4)
-        # multi_head_attention_1 / query / bias: 0(3, 4)
-        # multi_head_attention_1 / key / kernel: 0(8, 3, 4)
-        # multi_head_attention_1 / key / bias: 0(3, 4)
-        # multi_head_attention_1 / value / kernel: 0(8, 3, 6)
-        # multi_head_attention_1 / value / bias: 0(3, 6)
-        # multi_head_attention_1 / attention_output / kernel: 0(3, 6, 8)
-        # multi_head_attention_1 / attention_output / bias: 0(8, )
 
         query_nodes, key_nodes, value_nodes, att_head_output_nodes = [], [], [], []
 
         # MHA params:
         num_heads = mha_node.framework_attr['num_heads']
         use_bias = mha_node.framework_attr['use_bias']
-        key_dim = mha_node.framework_attr['key_dim']
+        query_key_dim = mha_node.framework_attr['key_dim']
         value_dim = mha_node.framework_attr['value_dim']
-        query_shape = mha_node.framework_attr['query_shape']
-        key_shape = mha_node.framework_attr['key_shape']
-        value_shape = mha_node.framework_attr['value_shape']
-        d_model = value_shape[-1]
+        query_shape = tuple(mha_node.framework_attr['query_shape'])
+        key_shape = tuple(mha_node.framework_attr['key_shape'])
+        value_shape = tuple(mha_node.framework_attr['value_shape'])
+        d_model = query_shape[-1]
         sequence_length = value_shape[1]
-        query_proj_shape = mha_node.framework_attr['query_shape'][:-1] + [key_dim]
-        key_proj_shape = mha_node.framework_attr['key_shape'][:-1] + [key_dim]
-        value_proj_shape = mha_node.framework_attr['value_shape'][:-1] + [value_dim]
-        concat_shape = mha_node.framework_attr['value_shape'][:-1] + [value_dim*num_heads]
+        query_proj_shape = query_shape[:-1] + (query_key_dim,)
+        key_proj_shape = key_shape[:-1] + (query_key_dim,)
+        value_proj_shape = value_shape[:-1] + (value_dim,)
+        concat_shape = value_shape[:-1] + (value_dim*num_heads,)
 
-        reorder = lambda x, order: tuple([x[_i] for _i in order])
-
-        # matmul_output = layers.Dot(axes=(1, 2))([layers.Permute([2, 1])(q), k])
-        # attention_matrix = layers.Softmax()(layers.Multiply()([matmul_output, norm_factor]))
-        # return layers.Permute([2, 1])(layers.Dot(axes=(1, 2))([v, attention_matrix])), attention_matrix
+        get_weight_name = lambda w_str: [k for k in mha_node.weights.keys() if w_str in k][0]
 
         # Generate nodes for attention heads:
-        # TODO: define constant
-        norm_factor = mha_node.weights[mha_node.name + '/query/kernel:0'].shape[-1] ** -0.5
         for h in range(num_heads):
-            qk = mha_node.weights[mha_node.name + '/query/kernel:0'][:, h, :]
-            kk = mha_node.weights[mha_node.name + '/key/kernel:0'][:, h, :]
-            vk = mha_node.weights[mha_node.name + '/value/kernel:0'][:, h, :]
-            qb = mha_node.weights[mha_node.name + '/query/bias:0'][h, :]
-            kb = mha_node.weights[mha_node.name + '/key/bias:0'][h, :]
-            vb = mha_node.weights[mha_node.name + '/value/bias:0'][h, :]
-            # create new nodes:
+            # add norm factor to query kernel and bias
+            qk = mha_node.weights[get_weight_name('/query/kernel')][:, h, :].copy() * (query_key_dim ** -0.5)
+            kk = mha_node.weights[get_weight_name('/key/kernel')][:, h, :].copy()
+            vk = mha_node.weights[get_weight_name('/value/kernel')][:, h, :].copy()
+            qb = mha_node.weights[get_weight_name('/query/bias')][h, :].copy() * (query_key_dim ** -0.5)
+            kb = mha_node.weights[get_weight_name('/key/bias')][h, :].copy()
+            vb = mha_node.weights[get_weight_name('/value/bias')][h, :].copy()
 
-            # project quary, key & value inputs to key_dim, key_dim & value_dim respectively
-            q_node = BaseNode(f'{mha_node.name}_query_{h}', {'units': key_dim, 'use_bias': use_bias},
+            # create new nodes:
+            # project quary, key & value inputs to query_key_dim, query_key_dim & value_dim respectively
+            q_node = BaseNode(f'{mha_node.name}_query_{h}', {'units': query_key_dim, 'use_bias': use_bias},
                               query_shape, query_proj_shape, {KERNEL: qk, BIAS: qb}, Dense,
                               reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
             query_nodes.append(q_node)
             graph.add_node(q_node)
-            k_node = BaseNode(f'{mha_node.name}_key_{h}', {'units': key_dim, 'use_bias': use_bias},
+            k_node = BaseNode(f'{mha_node.name}_key_{h}', {'units': query_key_dim, 'use_bias': use_bias},
                               key_shape, key_proj_shape, {KERNEL: kk, BIAS: kb}, Dense,
                               reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
             key_nodes.append(k_node)
@@ -133,74 +98,55 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
             graph.add_node(v_node)
 
             # calculate attention matrix:
-            # apply tf.matmul(q, tf.transpose(k, perm=[0, 2, 1]) as layers.Dot(axes=(1, 2))([layers.Permute([2, 1])(q), k])
-            permute_node = BaseNode(f'{mha_node.name}_permute_{h}', {'dims': (2, 1)},
-                                    query_shape, reorder(query_shape, (0, 2, 1)), {}, Permute,
-                                    reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
-            graph.add_node_with_in_edges(permute_node, [q_node])
-            # graph.add_node(permute_node)
-            # graph.add_edge(q_node, permute_node, source_index=0, sink_index=0)
-
-            dot_node = BaseNode(f'{mha_node.name}_dot_{h}', {'axes': (1, 2)},
-                                key_shape, tuple([key_shape[0]] + [sequence_length, sequence_length]), {}, Dot,
+            # apply tf.matmul(q, tf.transpose(k, perm=[0, 2, 1]) as layers.Dot(axes=2)([q, k])
+            att_matrix_shape = (key_shape[0],) + (sequence_length, sequence_length)
+            dot_node = BaseNode(f'{mha_node.name}_dot_{h}', {'axes': 2},
+                                (query_proj_shape, key_proj_shape), att_matrix_shape, {}, Dot,
                                 reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
-            graph.add_node_with_in_edges(dot_node, [permute_node, k_node])
-            # graph.add_node(dot_node)
-            # graph.add_edge(permute_node, dot_node, source_index=0, sink_index=0)
-            # graph.add_edge(k_node, dot_node, source_index=0, sink_index=1)
+            graph.add_node_with_in_edges(dot_node, [q_node, k_node])
 
-            # apply softmax on attention matric
+            # apply softmax on attention matrix
             softmax_node = BaseNode(f'{mha_node.name}_softmax_{h}', {},
-                                    tuple([key_shape[0]] + [sequence_length, sequence_length]), tuple([key_shape[0]] + [sequence_length, sequence_length]),
+                                    att_matrix_shape, att_matrix_shape,
                                     {}, Softmax, reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
             graph.add_node_with_in_edges(softmax_node, [dot_node])
-            # graph.add_node(softmax_node)
-            # graph.add_edge(dot_node, softmax_node, source_index=0, sink_index=0)
 
-            # calculate matmul(attention_matrix, projected_value) TODO: how to handle the input shape of a node with 2 inputs??
-            dot_node = BaseNode(f'{mha_node.name}_dotv_{h}', {'axes': (1, 2)},
-                                tuple([key_shape[0]] + [sequence_length, sequence_length]), reorder(value_proj_shape, (0, 2, 1)),
-                                {}, Dot, reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
-            graph.add_node_with_in_edges(dot_node, [v_node, softmax_node])
-            # graph.add_node(dot_node)
-            # graph.add_edge(v_node, dot_node, source_index=0, sink_index=0)
-            # graph.add_edge(softmax_node, dot_node, source_index=0, sink_index=1)
-
-            permute_node = BaseNode(f'{mha_node.name}_permute_out_{h}', {'dims': (2, 1)},
-                                    reorder(value_proj_shape, (0, 2, 1)), value_proj_shape, {}, Permute,
-                                    reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
-            graph.add_node_with_in_edges(permute_node, [dot_node])
-            # graph.add_node(permute_node)
-            # graph.add_edge(dot_node, permute_node, source_index=0, sink_index=0)
-
-            att_head_output_nodes.append(permute_node)
+            dotv_node = BaseNode(f'{mha_node.name}_dotv_{h}', {'axes': (2, 1)},
+                                 (att_matrix_shape, value_proj_shape), value_proj_shape,
+                                 {}, Dot, reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            graph.add_node_with_in_edges(dotv_node, [softmax_node, v_node])
+            att_head_output_nodes.append(dotv_node)
 
         # concatenate all attention heads
-        concat_node = BaseNode(f'{mha_node.name}_concat', {'dims': (2, 1)},
-                               value_proj_shape, concat_shape, {}, Concatenate,
+        concat_node = BaseNode(f'{mha_node.name}_concat', {},
+                               (value_proj_shape,)*num_heads, concat_shape, {}, Concatenate,
                                reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
         graph.add_node_with_in_edges(concat_node, att_head_output_nodes)
-        # graph.add_node(concat_node)
-        # for h in range(num_heads):
-        #     graph.add_edge(att_head_output_nodes[h], concat_node, source_index=0, sink_index=h)
 
-        w_out = mha_node.weights[mha_node.name + '/attention_output/kernel:0'].reshape((-1, d_model))
-        b_out = mha_node.weights[mha_node.name + '/attention_output/bias:0']
+        w_out = mha_node.weights[get_weight_name('/attention_output/kernel')].copy().reshape((-1, d_model))
+        b_out = mha_node.weights[get_weight_name('/attention_output/bias')].copy()
         output_dense = BaseNode(f'{mha_node.name}_output_dense', {'units': d_model, 'use_bias': use_bias},
-                                query_shape, query_proj_shape, {KERNEL: w_out, BIAS: b_out}, Dense,
+                                concat_shape, query_shape, {KERNEL: w_out, BIAS: b_out}, Dense,
                                 reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
         graph.add_node_with_in_edges(output_dense, [concat_node])
-        # graph.add_node(output_dense)
-        # graph.add_edge(concat_node, output_dense, source_index=0, sink_index=0)
 
         # connect edges to new nodes
-        query_in_edge, key_value_in_edge = graph.in_edges(mha_node)
+        mha_in_edges = graph.in_edges(mha_node)
+        if len(mha_in_edges) == 3:
+            # MHA node is called with 3 inputs: Query, Value & Key
+            query_in_edge, value_in_edge, key_in_edge = graph.in_edges(mha_node)
+        else:
+            # MHA node is called with 2 inputs: Query & Value. Key=Value
+            query_in_edge, value_in_edge = graph.in_edges(mha_node)
+            key_in_edge = value_in_edge
         for h in range(num_heads):
             graph.add_edge(query_in_edge[0], query_nodes[h], **graph.get_edge_data(*query_in_edge, 0))
-            graph.add_edge(key_value_in_edge[0], key_nodes[h], **graph.get_edge_data(*key_value_in_edge, 0))
-            graph.add_edge(key_value_in_edge[0], value_nodes[h], **graph.get_edge_data(*key_value_in_edge, 0))
+            graph.add_edge(key_in_edge[0], key_nodes[h], **graph.get_edge_data(*key_in_edge, 0))
+            graph.add_edge(value_in_edge[0], value_nodes[h], **graph.get_edge_data(*value_in_edge, 0))
         graph.remove_edge(query_in_edge[0], mha_node)
-        graph.remove_edge(key_value_in_edge[0], mha_node)
+        graph.remove_edge(key_in_edge[0], mha_node)
+        if key_in_edge is not value_in_edge:
+            graph.remove_edge(value_in_edge[0], mha_node)
         graph.reconnect_out_edges(current_node=mha_node, new_node=output_dense)
 
         graph.remove_node(mha_node, new_graph_outputs=[OutTensor(output_dense, 0)])

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
@@ -1,0 +1,208 @@
+# Copyright 2021 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import tensorflow as tf
+import numpy as np
+from tensorflow.keras.layers import MultiHeadAttention, Dense, Softmax, Concatenate, Dot, Permute, Multiply
+
+from model_compression_toolkit import common
+from model_compression_toolkit.common.graph.base_graph import Graph, BaseNode, OutTensor
+from model_compression_toolkit.common.graph.graph_matchers import NodeOperationMatcher
+from model_compression_toolkit.keras.constants import KERNEL, DEPTHWISE_KERNEL, BIAS, KERNEL_SIZE, PADDING, \
+    STRIDES, USE_BIAS, LINEAR, ACTIVATION, TRAINABLE, FILTERS, PAD_VALID
+
+POINTWISE_KERNEL = 'pointwise_kernel'
+DEPTH_MULTIPLIER = 'depth_multiplier'
+DATA_FORMAT = 'data_format'
+DILATION_RATE = 'dilation_rate'
+DEPTHWISE_INITIALIZER = 'depthwise_initializer'
+DEPTHWISE_REGULARIZER = 'depthwise_regularizer'
+DEPTHWISE_CONSTRAINT = 'depthwise_constraint'
+BIAS_INITIALIZER = 'bias_initializer'
+BIAS_REGULARIZER = 'bias_regularizer'
+BIAS_CONSTRAINT = 'bias_constraint'
+ACTIVITY_REGULARIZER = 'activity_regularizer'
+KERNEL_INITIALIZER = 'kernel_initializer'
+SEPARABLE_PW_KERNEL_INITIALIZER = 'pointwise_initializer'
+KERNEL_REGULARIZER = 'kernel_regularizer'
+SEPARABLE_PW_KERNEL_REGULARIZER = 'pointwise_regularizer'
+KERNEL_CONSTRAINT = 'kernel_constraint'
+SEPARABLE_PW_KERNEL_CONSTRAINT = 'pointwise_constraint'
+
+
+class MultiHeadAttentionDecomposition(common.BaseSubstitution):
+    """
+    Removes a MultiHeadAttention node from the graph,
+    and replaces it with a compatible graph that consists Dense, Dot, Softmax and Concatenate layers
+    (and tf.transpose)
+    """
+
+    def __init__(self):
+        """
+        Matches MultiHeadAttention node.
+        """
+        super().__init__(matcher_instance=NodeOperationMatcher(MultiHeadAttention))
+
+    def substitute(self,
+                   graph: Graph,
+                   mha_node: BaseNode) -> Graph:
+        """
+        Remove a SeparableConv2D node from the graph, and replace it with two equivalent nodes: DepthwiseConv2D
+        and Conv2D. The SeparableConv2D attributes are split to relevant attributes for each node.
+
+        Args:
+            graph: Graph we apply the substitution on.
+            separable_node: Separable node to replace with a depthwise and pointwise nodes.
+
+        Returns:
+            Graph after applying the substitution.
+        """
+
+        # multi_head_attention_1 / query / kernel: 0(8, 3, 4)
+        # multi_head_attention_1 / query / bias: 0(3, 4)
+        # multi_head_attention_1 / key / kernel: 0(8, 3, 4)
+        # multi_head_attention_1 / key / bias: 0(3, 4)
+        # multi_head_attention_1 / value / kernel: 0(8, 3, 6)
+        # multi_head_attention_1 / value / bias: 0(3, 6)
+        # multi_head_attention_1 / attention_output / kernel: 0(3, 6, 8)
+        # multi_head_attention_1 / attention_output / bias: 0(8, )
+
+        query_nodes, key_nodes, value_nodes, att_head_output_nodes = [], [], [], []
+
+        # MHA params:
+        num_heads = mha_node.framework_attr['num_heads']
+        use_bias = mha_node.framework_attr['use_bias']
+        key_dim = mha_node.framework_attr['key_dim']
+        value_dim = mha_node.framework_attr['value_dim']
+        query_shape = mha_node.framework_attr['query_shape']
+        key_shape = mha_node.framework_attr['key_shape']
+        value_shape = mha_node.framework_attr['value_shape']
+        d_model = value_shape[-1]
+        sequence_length = value_shape[1]
+        query_proj_shape = mha_node.framework_attr['query_shape'][:-1] + [key_dim]
+        key_proj_shape = mha_node.framework_attr['key_shape'][:-1] + [key_dim]
+        value_proj_shape = mha_node.framework_attr['value_shape'][:-1] + [value_dim]
+        concat_shape = mha_node.framework_attr['value_shape'][:-1] + [value_dim*num_heads]
+
+        reorder = lambda x, order: tuple([x[_i] for _i in order])
+
+        # matmul_output = layers.Dot(axes=(1, 2))([layers.Permute([2, 1])(q), k])
+        # attention_matrix = layers.Softmax()(layers.Multiply()([matmul_output, norm_factor]))
+        # return layers.Permute([2, 1])(layers.Dot(axes=(1, 2))([v, attention_matrix])), attention_matrix
+
+        # Generate nodes for attention heads:
+        # TODO: define constant
+        norm_factor = mha_node.weights[mha_node.name + '/query/kernel:0'].shape[-1] ** -0.5
+        for h in range(num_heads):
+            qk = mha_node.weights[mha_node.name + '/query/kernel:0'][:, h, :]
+            kk = mha_node.weights[mha_node.name + '/key/kernel:0'][:, h, :]
+            vk = mha_node.weights[mha_node.name + '/value/kernel:0'][:, h, :]
+            qb = mha_node.weights[mha_node.name + '/query/bias:0'][h, :]
+            kb = mha_node.weights[mha_node.name + '/key/bias:0'][h, :]
+            vb = mha_node.weights[mha_node.name + '/value/bias:0'][h, :]
+            # create new nodes:
+
+            # project quary, key & value inputs to key_dim, key_dim & value_dim respectively
+            q_node = BaseNode(f'{mha_node.name}_query_{h}', {'units': key_dim, 'use_bias': use_bias},
+                              query_shape, query_proj_shape, {KERNEL: qk, BIAS: qb}, Dense,
+                              reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            query_nodes.append(q_node)
+            graph.add_node(q_node)
+            k_node = BaseNode(f'{mha_node.name}_key_{h}', {'units': key_dim, 'use_bias': use_bias},
+                              key_shape, key_proj_shape, {KERNEL: kk, BIAS: kb}, Dense,
+                              reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            key_nodes.append(k_node)
+            graph.add_node(k_node)
+            v_node = BaseNode(f'{mha_node.name}_value_{h}', {'units': value_dim, 'use_bias': use_bias},
+                              value_shape, value_proj_shape, {KERNEL: vk, BIAS: vb}, Dense,
+                              reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            value_nodes.append(v_node)
+            graph.add_node(v_node)
+
+            # calculate attention matrix:
+            # apply tf.matmul(q, tf.transpose(k, perm=[0, 2, 1]) as layers.Dot(axes=(1, 2))([layers.Permute([2, 1])(q), k])
+            permute_node = BaseNode(f'{mha_node.name}_permute_{h}', {'dims': (2, 1)},
+                                    query_shape, reorder(query_shape, (0, 2, 1)), {}, Permute,
+                                    reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            graph.add_node_with_in_edges(permute_node, [q_node])
+            # graph.add_node(permute_node)
+            # graph.add_edge(q_node, permute_node, source_index=0, sink_index=0)
+
+            dot_node = BaseNode(f'{mha_node.name}_dot_{h}', {'axes': (1, 2)},
+                                key_shape, tuple([key_shape[0]] + [sequence_length, sequence_length]), {}, Dot,
+                                reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            graph.add_node_with_in_edges(dot_node, [permute_node, k_node])
+            # graph.add_node(dot_node)
+            # graph.add_edge(permute_node, dot_node, source_index=0, sink_index=0)
+            # graph.add_edge(k_node, dot_node, source_index=0, sink_index=1)
+
+            # apply softmax on attention matric
+            softmax_node = BaseNode(f'{mha_node.name}_softmax_{h}', {},
+                                    tuple([key_shape[0]] + [sequence_length, sequence_length]), tuple([key_shape[0]] + [sequence_length, sequence_length]),
+                                    {}, Softmax, reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            graph.add_node_with_in_edges(softmax_node, [dot_node])
+            # graph.add_node(softmax_node)
+            # graph.add_edge(dot_node, softmax_node, source_index=0, sink_index=0)
+
+            # calculate matmul(attention_matrix, projected_value) TODO: how to handle the input shape of a node with 2 inputs??
+            dot_node = BaseNode(f'{mha_node.name}_dotv_{h}', {'axes': (1, 2)},
+                                tuple([key_shape[0]] + [sequence_length, sequence_length]), reorder(value_proj_shape, (0, 2, 1)),
+                                {}, Dot, reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            graph.add_node_with_in_edges(dot_node, [v_node, softmax_node])
+            # graph.add_node(dot_node)
+            # graph.add_edge(v_node, dot_node, source_index=0, sink_index=0)
+            # graph.add_edge(softmax_node, dot_node, source_index=0, sink_index=1)
+
+            permute_node = BaseNode(f'{mha_node.name}_permute_out_{h}', {'dims': (2, 1)},
+                                    reorder(value_proj_shape, (0, 2, 1)), value_proj_shape, {}, Permute,
+                                    reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+            graph.add_node_with_in_edges(permute_node, [dot_node])
+            # graph.add_node(permute_node)
+            # graph.add_edge(dot_node, permute_node, source_index=0, sink_index=0)
+
+            att_head_output_nodes.append(permute_node)
+
+        # concatenate all attention heads
+        concat_node = BaseNode(f'{mha_node.name}_concat', {'dims': (2, 1)},
+                               value_proj_shape, concat_shape, {}, Concatenate,
+                               reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+        graph.add_node_with_in_edges(concat_node, att_head_output_nodes)
+        # graph.add_node(concat_node)
+        # for h in range(num_heads):
+        #     graph.add_edge(att_head_output_nodes[h], concat_node, source_index=0, sink_index=h)
+
+        w_out = mha_node.weights[mha_node.name + '/attention_output/kernel:0'].reshape((-1, d_model))
+        b_out = mha_node.weights[mha_node.name + '/attention_output/bias:0']
+        output_dense = BaseNode(f'{mha_node.name}_output_dense', {'units': d_model, 'use_bias': use_bias},
+                                query_shape, query_proj_shape, {KERNEL: w_out, BIAS: b_out}, Dense,
+                                reuse=mha_node.reuse, reuse_group=mha_node.reuse_group)
+        graph.add_node_with_in_edges(output_dense, [concat_node])
+        # graph.add_node(output_dense)
+        # graph.add_edge(concat_node, output_dense, source_index=0, sink_index=0)
+
+        # connect edges to new nodes
+        query_in_edge, key_value_in_edge = graph.in_edges(mha_node)
+        for h in range(num_heads):
+            graph.add_edge(query_in_edge[0], query_nodes[h], **graph.get_edge_data(*query_in_edge, 0))
+            graph.add_edge(key_value_in_edge[0], key_nodes[h], **graph.get_edge_data(*key_value_in_edge, 0))
+            graph.add_edge(key_value_in_edge[0], value_nodes[h], **graph.get_edge_data(*key_value_in_edge, 0))
+        graph.remove_edge(query_in_edge[0], mha_node)
+        graph.remove_edge(key_value_in_edge[0], mha_node)
+        graph.reconnect_out_edges(current_node=mha_node, new_node=output_dense)
+
+        graph.remove_node(mha_node, new_graph_outputs=[OutTensor(output_dense, 0)])
+
+        return graph

--- a/model_compression_toolkit/keras/keras_implementation.py
+++ b/model_compression_toolkit/keras/keras_implementation.py
@@ -26,6 +26,8 @@ from model_compression_toolkit.keras.graph_substitutions.substitutions.relu_boun
     ReLUBoundCorrection
 from model_compression_toolkit.keras.graph_substitutions.substitutions.remove_relu_upper_bound import \
     RemoveReLUUpperBound
+from model_compression_toolkit.keras.graph_substitutions.substitutions.multi_head_attention_decomposition import \
+    MultiHeadAttentionDecomposition
 from model_compression_toolkit.keras.graph_substitutions.substitutions.scale_equalization import \
     ScaleEqualization, ScaleEqualizationWithPad, ScaleEqualizationMidActivation, ScaleEqualizationMidActivationWithPad
 from model_compression_toolkit.keras.graph_substitutions.substitutions.separableconv_decomposition import \
@@ -184,6 +186,7 @@ class KerasImplementation(FrameworkImplementation):
 
         """
         return [SeparableConvDecomposition(),
+                MultiHeadAttentionDecomposition(),
                 ActivationDecomposition(),
                 keras_batchnorm_folding()]
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/decompose_separable_conv_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/decompose_separable_conv_test.py
@@ -33,9 +33,6 @@ class DecomposeSeparableConvTest(BaseKerasFeatureNetworkTest):
     def get_quantization_config(self):
         return mct.QuantizationConfig(weights_bias_correction=False)
 
-    # def create_inputs_shape(self):
-    #     return [[self.val_batch_size, 3, 4, 5]]
-
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
         outputs = layers.SeparableConv2D(1, 2, depth_multiplier=self.depth_multiplier)(inputs)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
+import model_compression_toolkit as mct
+from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
+from model_compression_toolkit.common.user_info import UserInformation
+import tensorflow as tf
+import numpy as np
+from tests.common_tests.helpers.tensors_compare import cosine_similarity
+
+keras = tf.keras
+layers = keras.layers
+
+
+class MultiHeadAttentionTest(BaseFeatureNetworkTest):
+    def __init__(self, unit_test, sequence_length, d_model_k, d_model_v, num_heads, key_dim, value_dim):
+        super().__init__(unit_test)
+        self.sequence_length = sequence_length
+        self.d_model_k = d_model_k
+        self.d_model_v = d_model_v
+        self.num_heads = num_heads
+        self.key_dim = key_dim
+        self.value_dim = value_dim
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, self.sequence_length, self.d_model_k + self.d_model_v]]
+
+    def create_feature_network(self, input_shape):
+        inputs = layers.Input(shape=input_shape[0][1:])
+        # TODO: check when key and value are separated inputs
+        outputs = layers.MultiHeadAttention(self.num_heads, self.key_dim, value_dim=self.value_dim,
+                                            kernel_initializer="glorot_uniform",
+                                            bias_initializer="glorot_uniform")(inputs[:, :, :self.d_model_k],
+                                                                               inputs[:, :, self.d_model_k:])
+        # outputs = layers.MultiHeadAttention(self.num_heads, self.key_dim, value_dim=self.value_dim)(outputs, outputs)
+        model = keras.Model(inputs=inputs, outputs=outputs)
+        return model
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        kernel_op_layer_index = 2
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[kernel_op_layer_index], self.kernel_op_layer))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[kernel_op_layer_index + 1], (layers.ReLU,
+                                                                                                 layers.Activation,
+                                                                                                 layers.PReLU)))

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -15,6 +15,8 @@
 
 
 from tests.keras_tests.feature_networks_tests.base_feature_test import BaseFeatureNetworkTest
+from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig,\
+    ThresholdSelectionMethod
 import model_compression_toolkit as mct
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.common.user_info import UserInformation
@@ -27,32 +29,46 @@ layers = keras.layers
 
 
 class MultiHeadAttentionTest(BaseFeatureNetworkTest):
-    def __init__(self, unit_test, sequence_length, d_model_k, d_model_v, num_heads, key_dim, value_dim):
+    def __init__(self, unit_test, q_sequence_length, kv_sequence_length, d_model_q, d_model_k, d_model_v,
+                 num_heads, query_key_dim, value_dim, separate_key_value=False):
         super().__init__(unit_test)
-        self.sequence_length = sequence_length
-        self.d_model_k = d_model_k
+        self.q_sequence_length = q_sequence_length
+        self.kv_sequence_length = kv_sequence_length
+        self.separate_key_value = separate_key_value
+        self.d_model_q = d_model_q
+        self.d_model_k = 0 if separate_key_value else d_model_k
         self.d_model_v = d_model_v
         self.num_heads = num_heads
-        self.key_dim = key_dim
+        self.query_key_dim = query_key_dim
         self.value_dim = value_dim
 
+    def get_quantization_config(self):
+        return QuantizationConfig(activation_threshold_method=ThresholdSelectionMethod.NOCLIPPING,
+                                  weights_threshold_method=ThresholdSelectionMethod.NOCLIPPING,
+                                  activation_n_bits=16, weights_n_bits=16,
+                                  )
+
     def create_inputs_shape(self):
-        return [[self.val_batch_size, self.sequence_length, self.d_model_k + self.d_model_v]]
+        return [[self.val_batch_size, self.q_sequence_length + self.kv_sequence_length,
+                 self.d_model_q + self.d_model_k + self.d_model_v]]
 
     def create_feature_network(self, input_shape):
         inputs = layers.Input(shape=input_shape[0][1:])
-        # TODO: check when key and value are separated inputs
-        outputs = layers.MultiHeadAttention(self.num_heads, self.key_dim, value_dim=self.value_dim,
-                                            kernel_initializer="glorot_uniform",
-                                            bias_initializer="glorot_uniform")(inputs[:, :, :self.d_model_k],
-                                                                               inputs[:, :, self.d_model_k:])
-        # outputs = layers.MultiHeadAttention(self.num_heads, self.key_dim, value_dim=self.value_dim)(outputs, outputs)
+        mha_layer = layers.MultiHeadAttention(self.num_heads, self.query_key_dim, value_dim=self.value_dim,
+                                              kernel_initializer="glorot_uniform",
+                                              bias_initializer="glorot_uniform")
+        if self.separate_key_value:
+            outputs = mha_layer(inputs[:, :self.q_sequence_length, :self.d_model_q],
+                                inputs[:, self.q_sequence_length:, self.d_model_q:self.d_model_q + self.d_model_v])
+        else:
+            outputs = mha_layer(inputs[:, :self.q_sequence_length, :self.d_model_q],
+                                inputs[:, self.q_sequence_length:, self.d_model_q:self.d_model_q+self.d_model_v],
+                                key=inputs[:, self.q_sequence_length:, self.d_model_q+self.d_model_v:])
         model = keras.Model(inputs=inputs, outputs=outputs)
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        kernel_op_layer_index = 2
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[kernel_op_layer_index], self.kernel_op_layer))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[kernel_op_layer_index + 1], (layers.ReLU,
-                                                                                                 layers.Activation,
-                                                                                                 layers.PReLU)))
+        out_quantized = quantized_model(input_x[0]).numpy().flatten()
+        out_float = float_model(input_x[0]).numpy().flatten()
+        nmse = np.mean(np.abs((out_quantized - out_float)) ** 2) / np.mean(np.abs(out_float) ** 2)
+        self.unit_test.assertTrue(np.isclose(nmse, 0))

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -16,7 +16,7 @@
 
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig,\
-    ThresholdSelectionMethod
+    QuantizationErrorMethod
 import model_compression_toolkit as mct
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.common.user_info import UserInformation
@@ -46,8 +46,8 @@ class MultiHeadAttentionTest(BaseKerasFeatureNetworkTest):
         self.output_dim = output_dim
 
     def get_quantization_config(self):
-        return QuantizationConfig(activation_threshold_method=ThresholdSelectionMethod.NOCLIPPING,
-                                  weights_threshold_method=ThresholdSelectionMethod.NOCLIPPING,
+        return QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,
+                                  weights_error_method=QuantizationErrorMethod.NOCLIPPING,
                                   activation_n_bits=16, weights_n_bits=16,
                                   )
 

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -361,6 +361,12 @@ class FeatureNetworkTest(unittest.TestCase):
     def test_multi_head_attention(self):
         MultiHeadAttentionTest(self, 5, 8, 12, 3, 4, 6).run_test()
 
+    def test_multi_head_attention_2_inputs(self):
+        MultiHeadAttentionTest(self, 5, 11, 8, 12, 7, 3, 4, 6, separate_key_value=True).run_test()
+
+    def test_multi_head_attention_3_inputs(self):
+        MultiHeadAttentionTest(self, 5, 11, 8, 12, 7, 3, 4, 6).run_test()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -378,7 +378,7 @@ class FeatureNetworkTest(unittest.TestCase):
                                    separate_key_value=separate_key_value, output_dim=14).run_test()
             MultiHeadAttentionTest(self, input_shapes,
                                    num_heads, qk_proj_dim, v_proj_dim, attention_axes,
-                                   separate_key_value=separate_key_value, output_dim=14).run_test()
+                                   separate_key_value=separate_key_value, output_dim=None).run_test()
             MultiHeadAttentionTest(self, input_shapes,
                                    num_heads, qk_proj_dim, v_proj_dim, None,
                                    separate_key_value=separate_key_value, output_dim=14).run_test()

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -65,6 +65,7 @@ from tests.keras_tests.feature_networks_tests.feature_networks.add_same_test imp
 from tests.keras_tests.feature_networks_tests.feature_networks.network_editor.node_filter_test import NameFilterTest, \
     ScopeFilterTest, TypeFilterTest
 from tests.keras_tests.feature_networks_tests.feature_networks.lut_quantizer import LUTQuantizerTest
+from tests.keras_tests.feature_networks_tests.feature_networks.multi_head_attention_test import MultiHeadAttentionTest
 import tensorflow as tf
 from tensorflow.keras.layers import ReLU, PReLU, ELU
 
@@ -356,6 +357,9 @@ class FeatureNetworkTest(unittest.TestCase):
         UniformRangeSelectionActivationTest(self, QuantizationErrorMethod.MAE).run_test()
         UniformRangeSelectionActivationTest(self, QuantizationErrorMethod.LP).run_test()
         UniformRangeSelectionActivationTest(self, QuantizationErrorMethod.KL).run_test()
+
+    def test_multi_head_attention(self):
+        MultiHeadAttentionTest(self, 5, 8, 12, 3, 4, 6).run_test()
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -359,13 +359,29 @@ class FeatureNetworkTest(unittest.TestCase):
         UniformRangeSelectionActivationTest(self, QuantizationErrorMethod.KL).run_test()
 
     def test_multi_head_attention(self):
-        MultiHeadAttentionTest(self, 5, 8, 12, 3, 4, 6).run_test()
-
-    def test_multi_head_attention_2_inputs(self):
-        MultiHeadAttentionTest(self, 5, 11, 8, 12, 7, 3, 4, 6, separate_key_value=True).run_test()
-
-    def test_multi_head_attention_3_inputs(self):
-        MultiHeadAttentionTest(self, 5, 11, 8, 12, 7, 3, 4, 6).run_test()
+        q_seq_len, kv_seq_len = 5, 6
+        q_dim, k_dim, v_dim = 11, 12, 13
+        num_heads, qk_proj_dim, v_proj_dim = 3, 4, 7
+        attention_axes = [1, 3]
+        num_iterations = 9
+        for separate_key_value in [False, True]:
+            MultiHeadAttentionTest(self, [(q_seq_len, q_dim),
+                                          (kv_seq_len, k_dim),
+                                          (kv_seq_len, v_dim)],
+                                   num_heads, qk_proj_dim, v_proj_dim, None,
+                                   separate_key_value=separate_key_value, output_dim=15).run_test()
+            input_shapes = [(2, num_iterations, q_seq_len, q_dim),
+                            (2, num_iterations, kv_seq_len, k_dim),
+                            (2, num_iterations, kv_seq_len, v_dim)]
+            MultiHeadAttentionTest(self, input_shapes,
+                                   num_heads, qk_proj_dim, v_proj_dim, attention_axes,
+                                   separate_key_value=separate_key_value, output_dim=14).run_test()
+            MultiHeadAttentionTest(self, input_shapes,
+                                   num_heads, qk_proj_dim, v_proj_dim, attention_axes,
+                                   separate_key_value=separate_key_value, output_dim=14).run_test()
+            MultiHeadAttentionTest(self, input_shapes,
+                                   num_heads, qk_proj_dim, v_proj_dim, None,
+                                   separate_key_value=separate_key_value, output_dim=14).run_test()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Support MultiHeadAttention layer in Tensorflow framework:

substitute the layer with an implementation of Dense, Reshape, Permute, Concat & Dot layers.

note: The keras layer allows running a loop on certain axes of the input tensor\s. In the current substitution axes that are looped on are folded to the bacth axis.