### PR TITLE
Vectorized per-channel for power-of-two threshold

### DIFF
--- a/model_compression_toolkit/common/quantization/quantization_params_generation/kl_selection.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/kl_selection.py
@@ -190,8 +190,7 @@ def _kl_error_function(x: np.ndarray,
     q_bins = uniform_quantize_tensor(bv,
                                      range_min,
                                      range_max,
-                                     n_bits,
-                                     (bv < 0).any())
+                                     n_bits)
 
     # Sum all quantized values to a single bin of that value. Other bins of the same value
     # are zero.

--- a/model_compression_toolkit/common/quantization/quantizers/uniform_quantizers.py
+++ b/model_compression_toolkit/common/quantization/quantizers/uniform_quantizers.py
@@ -58,9 +58,7 @@ def power_of_two_quantizer(tensor_data: np.ndarray,
     return quantize_tensor(tensor_data,
                            threshold,
                            n_bits,
-                           signed,
-                           per_channel,
-                           output_channels_axis)
+                           signed)
 
 
 def symmetric_quantizer(tensor_data: np.ndarray,
@@ -91,9 +89,7 @@ def symmetric_quantizer(tensor_data: np.ndarray,
     return quantize_tensor(tensor_data,
                            threshold,
                            n_bits,
-                           signed,
-                           per_channel,
-                           output_channels_axis)
+                           signed)
 
 
 def uniform_quantizer(tensor_data: np.ndarray,
@@ -121,4 +117,4 @@ def uniform_quantizer(tensor_data: np.ndarray,
     if range_min is None or range_max is None:
         raise Exception("'quantization range' parameters must be defined in 'quantization_params'")
 
-    return uniform_quantize_tensor(tensor_data, range_min, range_max, n_bits, per_channel, output_channels_axis)
+    return uniform_quantize_tensor(tensor_data, range_min, range_max, n_bits)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
@@ -119,7 +119,9 @@ class GradientPTQLearnRateZeroTest(GradientPTQBaseTest):
         self.unit_test.assertTrue(len(quantized_model.weights) == len(quantized_gptq_model.weights),
                                   msg='float model number of weights different from quantized model: ' +
                                       f'{len(quantized_gptq_model.weights)} != {len(quantized_model.weights)}')
-        # check all weights didn't change
-        weights_diff = [np.all(w_q.numpy() == w_f.numpy()) for w_q, w_f in
+        # check all weights didn't change (small noise is possible due to quantization with numpy
+        # vs quantization with tf)
+        weights_diff = [np.isclose(np.max(np.abs(w_q - w_f)), 0, atol=1e-5) for w_q, w_f in
                         zip(quantized_model.weights, quantized_gptq_model.weights)]
-        self.unit_test.assertTrue(all(weights_diff), msg="Some weights were updated")
+        for weights_close in weights_diff:
+            self.unit_test.assertTrue(np.all(weights_close))

--- a/tests/keras_tests/function_tests/test_fix_range_to_zero.py
+++ b/tests/keras_tests/function_tests/test_fix_range_to_zero.py
@@ -60,8 +60,7 @@ class TestFixRangeToZero(unittest.TestCase):
                                            num=tensor_data.shape[channel_axis]), get_output_shape(shape, channel_axis))
         max_range = np.reshape(np.linspace(start=max_range_bounds[0], stop=max_range_bounds[1],
                                            num=tensor_data.shape[channel_axis]), get_output_shape(shape, channel_axis))
-        q = uniform_quantize_tensor(tensor_data, range_min=min_range, range_max=max_range, n_bits=n_bits,
-                                    per_channel=True, channel_axis=channel_axis)
+        q = uniform_quantize_tensor(tensor_data, range_min=min_range, range_max=max_range, n_bits=n_bits)
         self.assertTrue((q == 0).any())
 
 

--- a/tests/keras_tests/function_tests/test_uniform_quantize_tensor.py
+++ b/tests/keras_tests/function_tests/test_uniform_quantize_tensor.py
@@ -60,8 +60,7 @@ class TestUniformQuantizeTensor(unittest.TestCase):
         gt_quantized_tensor = \
             ground_truth_quantize_tensor(tensor_data, threshold=threshold, n_bits=n_bits, signed=signed)
         quantized_tensor = \
-            quantize_tensor(tensor_data, threshold=threshold, n_bits=n_bits, signed=signed,
-                            per_channel=per_channel, channel_axis=channel_axis)
+            quantize_tensor(tensor_data, threshold=threshold, n_bits=n_bits, signed=signed)
         self.assertTrue(gt_quantized_tensor.shape == quantized_tensor.shape)
         self.assertTrue((gt_quantized_tensor == quantized_tensor).all())
 


### PR DESCRIPTION
* Vectorized search per-channel for power-of-two threshold.
* Modified fix range to include zero to work vectorized per-channel as well.