### PR TITLE
support adding model's weights to GPTQ loss

### DIFF
--- a/docs/api/api_docs/classes/GradientPTQConfig.html
+++ b/docs/api/api_docs/classes/GradientPTQConfig.html
@@ -53,7 +53,7 @@
 <dd class="field-odd"><ul class="simple">
 <li><p><strong>n_iter</strong> (<em>int</em>) – Number of iterations to train.</p></li>
 <li><p><strong>optimizer</strong> (<em>Any</em>) – Optimizer to use.</p></li>
-<li><p><strong>loss</strong> (<em>Callable</em>) – the loss to use. should accept 2 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors.</p></li>
+<li><p><strong>loss</strong> (<em>Callable</em>) – The loss to use. Should accept 4 lists of tensors. 1st list of quantized tensors, the 2nd list are the float tensors, the 3rd list are the quantized weights and the 4th lsit are the float weights.</p></li>
 <li><p><strong>log_function</strong> (<em>Callable</em>) – Function to log information about the GPTQ process.</p></li>
 <li><p><strong>train_bias</strong> (<em>bool</em>) – Whether to update the bias during the training or not.</p></li>
 </ul>

--- a/docs/api/api_docs/classes/GradientPTQConfig.html
+++ b/docs/api/api_docs/classes/GradientPTQConfig.html
@@ -53,7 +53,7 @@
 <dd class="field-odd"><ul class="simple">
 <li><p><strong>n_iter</strong> (<em>int</em>) – Number of iterations to train.</p></li>
 <li><p><strong>optimizer</strong> (<em>Any</em>) – Optimizer to use.</p></li>
-<li><p><strong>loss</strong> (<em>Callable</em>) – The loss to use. Should accept 4 lists of tensors. 1st list of quantized tensors, the 2nd list are the float tensors, the 3rd list are the quantized weights and the 4th lsit are the float weights.</p></li>
+<li><p><strong>loss</strong> (<em>Callable</em>) – the loss to use. should accept 2 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors.</p></li>
 <li><p><strong>log_function</strong> (<em>Callable</em>) – Function to log information about the GPTQ process.</p></li>
 <li><p><strong>train_bias</strong> (<em>bool</em>) – Whether to update the bias during the training or not.</p></li>
 </ul>

--- a/model_compression_toolkit/common/gptq/gptq_config.py
+++ b/model_compression_toolkit/common/gptq/gptq_config.py
@@ -39,7 +39,8 @@ class GradientPTQConfig:
         Args:
             n_iter (int): Number of iterations to train.
             optimizer (Any): Optimizer to use.
-            loss (Callable): the loss to use. should accept 2 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors.
+            loss (Callable): The loss to use. should accept 4 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors,
+             the 3rd is a list of quantized weights and the 4th is a list of float weights.
             log_function (Callable): Function to log information about the GPTQ process.
             train_bias (bool): Whether to update the bias during the training or not.
             lsb_change_per_bit_width (dict): Whether to update the bias during the training or not.

--- a/model_compression_toolkit/keras/gradient_ptq/gptq_loss.py
+++ b/model_compression_toolkit/keras/gradient_ptq/gptq_loss.py
@@ -34,13 +34,17 @@ def mse_loss(y: tf.Tensor, x: tf.Tensor, normalized: bool = True) -> tf.Tensor:
 
 
 def multiple_tensors_mse_loss(y_list: List[tf.Tensor],
-                              x_list: List[tf.Tensor]) -> tf.Tensor:
+                              x_list: List[tf.Tensor],
+                              fxp_w_list: List[List[tf.Tensor]],
+                              flp_w_list: List[List[tf.Tensor]]) -> tf.Tensor:
     """
     Compute MSE similarity between two lists of tensors
 
     Args:
         y_list: First list of tensors.
         x_list: Second list of tensors.
+        fxp_w_list: list of lists each containing a quantized model layer's trainable weights - quantized
+        flp_w_list: list of lists each containing a float model layer's weights - not quantized
 
     Returns:
         A single loss value which is the average of all MSE loss of all tensor pairs

--- a/model_compression_toolkit/keras/gradient_ptq/graph_info.py
+++ b/model_compression_toolkit/keras/gradient_ptq/graph_info.py
@@ -48,9 +48,10 @@ def get_compare_points(input_graph: Graph) -> Tuple[List[BaseNode], List[str]]:
 
 def get_trainable_parameters(fxp_model: Model,
                              fw_info: FrameworkInfo,
-                             add_bias: bool = False) -> List[tf.Variable]:
+                             add_bias: bool = False) -> Tuple[List[List[tf.Variable]], List[list], List[list]]:
     """
-    Get trainable parameters from all layers in a model.
+    Get trainable parameters from all layers in a model, and all float and quantized kernels
+    for the GPTQ loss
 
     Args:
         fxp_model: Model to get its trainable parameters.
@@ -58,16 +59,32 @@ def get_trainable_parameters(fxp_model: Model,
         add_bias: Whether to include biases of the model (if there are) or not.
 
     Returns:
-        A list of trainable variables in a model.
+        A list of trainable variables in a model. Each item is a list of a layers weights.
+        A list of float kernels, each item is the float kernel of the layer
+        A list of quantized kernels, each item is the quantized kernel of the layer
     """
 
     trainable_weights = []
+    flp_weights_list = []
+    fxp_weights_list = []
     for layer in fxp_model.layers:
         if isinstance(layer, QuantizeWrapper) and isinstance(
                 layer.quantize_config, WeightQuantizeConfig):
-            trainable_weights.extend(layer.quantize_config.get_trainable_quantizer_parameters())
+
+            # collect pairs of float and quantized weights per layer
+            _layer_flp_weights, _layer_fxp_weights = [], []
+            for weight, quantizer, quantizer_vars in layer._weight_vars:
+                _layer_flp_weights.append(weight)
+                _layer_fxp_weights.append(quantizer(weight, training=False, weights=quantizer_vars))
+            flp_weights_list.append(_layer_flp_weights)
+            fxp_weights_list.append(_layer_fxp_weights)
+
+            # collect trainable weights per layer
+            layer_trainable_weights = layer.quantize_config.get_trainable_quantizer_parameters()
             if add_bias:
                 use_bias = isinstance(layer.layer, tuple(fw_info.kernel_ops)) and layer.layer.get_config().get(USE_BIAS)
                 if use_bias is not None and use_bias:
-                    trainable_weights.append(layer.layer.bias)
-    return trainable_weights
+                    layer_trainable_weights.append(layer.layer.bias)
+            trainable_weights.append(layer_trainable_weights)
+
+    return trainable_weights, flp_weights_list, fxp_weights_list

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -50,7 +50,8 @@ if importlib.util.find_spec("tensorflow") is not None\
         args:
             n_iter (int): Number of iterations to fine-tune.
             optimizer (OptimizerV2): Keras optimizer to use for fine-tuning.
-            loss (Callable): loss to use during fine-tuning. Should accept 2 lists of Tensorflow tensors. 1st list of quantized tensors, the 2nd list is the float tensors.
+            loss (Callable): loss to use during fine-tuning. should accept 4 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors,
+             the 3rd is a list of quantized weights and the 4th is a list of float weights.
             log_function (Callable): Function to log information about the gptq process.
             train_bias (bool): Whether to update the bias during the the fine-tuning or not.
 


### PR DESCRIPTION
Add float and quantized kernels to GPTQ loss function API.
Changed get_trainble_parameters to return the trainable parameters as a list of lists, each containing a layer's weights for trainin, and 2 mote lists containing the quantized and float kernels of the layers to be passed to the GPTQ loss function.