### PR TITLE
Get nbits config from hw model

### DIFF
--- a/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
+++ b/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
@@ -36,7 +36,7 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     graph = copy.deepcopy(graph_to_apply_bias_correction)
     for n in graph.nodes:
-        if fw_info.in_kernel_ops(n) and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.has_weights_to_quantize(fw_info) and n.final_weights_quantization_cfg.enable_weights_quantization:
             # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
             # a bias correction term was calculated during model preparation, and is used now in the node's bias term.
             if n.final_weights_quantization_cfg.weights_bias_correction:

--- a/model_compression_toolkit/common/bias_correction/compute_bias_correction_of_graph.py
+++ b/model_compression_toolkit/common/bias_correction/compute_bias_correction_of_graph.py
@@ -45,7 +45,7 @@ def compute_bias_correction_of_graph(graph_co_compute_bias: Graph,
 
     graph = copy.deepcopy(graph_co_compute_bias)
     for n in graph.nodes:
-        if fw_info.in_kernel_ops(n):
+        if n.is_weights_quantization_enabled() and n.has_weights_to_quantize(fw_info):
             _compute_bias_correction_per_candidate_qc(n,
                                                       fw_info,
                                                       graph.get_in_stats_collector(n),
@@ -69,26 +69,25 @@ def _compute_bias_correction_per_candidate_qc(node: BaseNode,
 
     """
 
-    if node.is_weights_quantization_enabled():
+    if node.is_weights_quantization_enabled() and node.has_weights_to_quantize(fw_info):
         for candidate_qc in node.candidates_quantization_cfg:
-            if fw_info.in_kernel_ops(node):
-                quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
-                                                                                        node,
-                                                                                        candidate_qc.weights_quantization_cfg,
-                                                                                        fw_impl=fw_impl)
+            quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
+                                                                                    node,
+                                                                                    candidate_qc.weights_quantization_cfg,
+                                                                                    fw_impl=fw_impl)
 
-                # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
-                # a bias correction term is being calculated and used in the node's bias term.
-                if candidate_qc.weights_quantization_cfg.weights_bias_correction:
-                    bias_correction_term = _get_bias_correction_term_of_node(io_channels_axes[0],
-                                                                             node,
-                                                                             node_in_stats_collector,
-                                                                             io_channels_axes[1],
-                                                                             quantized_kernel,
-                                                                             fw_impl=fw_impl)
+            # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
+            # a bias correction term is being calculated and used in the node's bias term.
+            if candidate_qc.weights_quantization_cfg.weights_bias_correction:
+                bias_correction_term = _get_bias_correction_term_of_node(io_channels_axes[0],
+                                                                         node,
+                                                                         node_in_stats_collector,
+                                                                         io_channels_axes[1],
+                                                                         quantized_kernel,
+                                                                         fw_impl=fw_impl)
 
-                    # Store the correction term to use it later,
-                    candidate_qc.weights_quantization_cfg.bias_corrected = bias_correction_term
+                # Store the correction term to use it later,
+                candidate_qc.weights_quantization_cfg.bias_corrected = bias_correction_term
 
 
 def _compute_bias_correction(kernel: np.ndarray,

--- a/model_compression_toolkit/common/collectors/statistics_collector_generator.py
+++ b/model_compression_toolkit/common/collectors/statistics_collector_generator.py
@@ -33,7 +33,7 @@ def create_stats_collector_for_node(node: common.BaseNode,
         Statistics collector for statistics collection for the node.
     """
 
-    if node.is_activation_quantization_enabled():
+    if node.has_activation and node.is_activation_quantization_enabled():
         stats_collector = common.StatsCollector(init_min_value=node.prior_info.min_output,
                                                 init_max_value=node.prior_info.max_output,
                                                 output_channel_index=output_channel_index)

--- a/model_compression_toolkit/common/framework_info.py
+++ b/model_compression_toolkit/common/framework_info.py
@@ -42,9 +42,6 @@ class ChannelAxis(Enum):
 class FrameworkInfo(object):
 
     def __init__(self,
-                 kernel_ops: list,
-                 activation_ops: list,
-                 no_quantization_ops: list,
                  activation_quantizer_mapping: Dict[QuantizationMethod, Callable],
                  weights_quantizer_mapping: Dict[QuantizationMethod, Callable],
                  kernel_channels_mapping: DefaultDict,
@@ -62,9 +59,6 @@ class FrameworkInfo(object):
         no_quantization_ops:Layers that should not get quantized (e.g., Reshape, Transpose, etc.)
 
         Args:
-            kernel_ops (list): A list of operators that are in the kernel_ops group.
-            activation_ops (list): A list of operators that are in the activation_ops group.
-            no_quantization_ops (list): A list of operators that are in the no_quantization_ops group.
             activation_quantizer_mapping (Dict[QuantizationMethod, Callable]): A dictionary mapping from QuantizationMethod to a quantization function.
             weights_quantizer_mapping (Dict[QuantizationMethod, Callable]): A dictionary mapping from QuantizationMethod to a quantization function.
             kernel_channels_mapping (DefaultDict): Dictionary from a layer to a tuple of its kernel in/out channels indices.
@@ -83,35 +77,20 @@ class FrameworkInfo(object):
 
             Then, we can create a FrameworkInfo object:
 
-            >>> FrameworkInfo(kernel_ops, [], [], kernel_channels_mapping, {}, {})
-
-            and pass it to :func:`~model_compression_toolkit.keras_post_training_quantization`.
-
-            To quantize the activations of ReLU, we can create a new FrameworkInfo instance:
-
-            >>> activation_ops = [tf.keras.layers.ReLU]
-            >>> FrameworkInfo(kernel_ops, activation_ops, [], kernel_channels_mapping, {}, {})
-
-            If we don't want to quantize a layer (e.g. Reshape), we can add it to the no_no_quantization_ops list:
-
-            >>> no_quantization_ops = [tf.keras.layers.Reshape]
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, {}, {})
+            >>> FrameworkInfo(kernel_channels_mapping, {}, {})
 
             If an activation layer (tf.keras.layers.Activation) should be quantized and we know it's min/max outputs range in advanced, we can add it to activation_min_max_mapping for saving the statistics collection time. For example:
 
             >>> activation_min_max_mapping = {'softmax': (0, 1)}
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, activation_min_max_mapping, {})
+            >>> FrameworkInfo(kernel_channels_mapping,activation_min_max_mapping, {})
 
             If a layer's activations should be quantized and we know it's min/max outputs range in advanced, we can add it to layer_min_max_mapping for saving the statistics collection time. For example:
 
             >>> layer_min_max_mapping = {tf.keras.layers.Softmax: (0, 1)}
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, activation_min_max_mapping, layer_min_max_mapping)
+            >>> FrameworkInfo(kernel_channels_mapping, activation_min_max_mapping, layer_min_max_mapping)
 
         """
 
-        self.kernel_ops = kernel_ops
-        self.activation_ops = activation_ops
-        self.no_quantization_ops = no_quantization_ops
         self.activation_quantizer_mapping = activation_quantizer_mapping
         self.weights_quantizer_mapping = weights_quantizer_mapping
         self.kernel_channels_mapping = kernel_channels_mapping
@@ -158,40 +137,3 @@ class FrameworkInfo(object):
         """
 
         return activation_name in self.activation_min_max_mapping
-
-    def in_kernel_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the kernel_ops group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the kernel_ops group or not.
-        """
-
-        return n.type in self.kernel_ops
-
-    def in_activation_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the activation group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the activation group or not.
-        """
-        return n.type in self.activation_ops
-
-    def in_no_quantization_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the no quantization group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the no quantization group or not.
-        """
-        return n.type in self.no_quantization_ops

--- a/model_compression_toolkit/common/graph/base_graph.py
+++ b/model_compression_toolkit/common/graph/base_graph.py
@@ -504,7 +504,7 @@ class Graph(nx.MultiDiGraph, GraphSearches):
         sorted_configurable_nodes = []
         sorted_nodes = list(topological_sort(self))
         for n in sorted_nodes:
-            if n.is_weights_quantization_enabled():
+            if n.is_weights_quantization_enabled() and n.has_weights_to_quantize(self.fw_info):
                 if not n.reuse or include_reused_nodes:
                     if len(n.candidates_quantization_cfg) >= 1:
                         sorted_configurable_nodes.append(n)

--- a/model_compression_toolkit/common/graph/base_node.py
+++ b/model_compression_toolkit/common/graph/base_node.py
@@ -36,7 +36,8 @@ class BaseNode:
                  layer_class: type,
                  reuse: bool = False,
                  reuse_group: str = None,
-                 quantization_attr: Dict[str, Any] = None):
+                 quantization_attr: Dict[str, Any] = None,
+                 has_activation: bool = True):
         """
         Init a Node object.
 
@@ -64,6 +65,7 @@ class BaseNode:
         self.final_activation_quantization_cfg = None
         self.candidates_quantization_cfg = None
         self.prior_info = None
+        self.has_activation = has_activation
 
     @property
     def type(self):

--- a/model_compression_toolkit/common/graph/base_node.py
+++ b/model_compression_toolkit/common/graph/base_node.py
@@ -51,6 +51,7 @@ class BaseNode:
             reuse: Whether this node was duplicated and represents a reused layer.
             reuse_group: Name of group of nodes from the same reused layer.
             quantization_attr: Attributes the node holds regarding how it should be quantized.
+            has_activation: Whether the node has activations that we might want to quantize.
         """
         self.name = name
         self.framework_attr = framework_attr
@@ -260,6 +261,14 @@ class BaseNode:
                    for candidate in self.candidates_quantization_cfg)
 
     def has_weights_to_quantize(self, fw_info):
+        """
+        Checks whether the node has weights that need to be quantized according to the framework info.
+        Args:
+            fw_info: FrameworkInfo object about the specific framework (e.g., attributes of different layers' weights to quantize).
+
+        Returns: Whether the node has weights that need to be quantized.
+
+        """
         attrs = fw_info.get_kernel_op_attributes(self.type)
         for attr in attrs:
             if attr and self.get_weights_by_keys(attr) is not None:

--- a/model_compression_toolkit/common/graph/base_node.py
+++ b/model_compression_toolkit/common/graph/base_node.py
@@ -257,3 +257,10 @@ class BaseNode:
                    self.candidates_quantization_cfg[0].weights_quantization_cfg
                    for candidate in self.candidates_quantization_cfg)
 
+    def has_weights_to_quantize(self, fw_info):
+        attrs = fw_info.get_kernel_op_attributes(self.type)
+        for attr in attrs:
+            if attr and self.get_weights_by_keys(attr) is not None:
+                return True
+        return False
+

--- a/model_compression_toolkit/common/graph/functional_node.py
+++ b/model_compression_toolkit/common/graph/functional_node.py
@@ -22,7 +22,8 @@ class FunctionalNode(BaseNode):
                  reuse_group: str = None,
                  quantization_attr: Dict[str, Any] = None,
                  functional_op: Any = None,
-                 inputs_as_list: bool = False):
+                 inputs_as_list: bool = False,
+                 has_activation: bool = True):
         """
         Init a FunctionalNode object.
 
@@ -51,7 +52,8 @@ class FunctionalNode(BaseNode):
                          layer_class,
                          reuse,
                          reuse_group,
-                         quantization_attr)
+                         quantization_attr,
+                         has_activation=has_activation)
 
         self.op_call_kwargs = op_call_kwargs
         self.op_call_args = op_call_args

--- a/model_compression_toolkit/common/graph/functional_node.py
+++ b/model_compression_toolkit/common/graph/functional_node.py
@@ -41,6 +41,7 @@ class FunctionalNode(BaseNode):
             quantization_attr: Attributes the node holds regarding how it should be quantized.
             functional_op: The op the node implements.
             inputs_as_list: Whether to pass the node its input tensors as a list or not when calling the layer.
+            has_activation: Whether the node has activations that we might want to quantize.
 
         """
 

--- a/model_compression_toolkit/common/hardware_representation/op_quantization_config.py
+++ b/model_compression_toolkit/common/hardware_representation/op_quantization_config.py
@@ -54,10 +54,10 @@ class OpQuantizationConfig:
                  weights_per_channel_threshold: bool,
                  enable_weights_quantization: bool,
                  enable_activation_quantization: bool,
-                 quantization_preserving: bool = False,
-                 fixed_scale: float = None,
-                 fixed_zero_point: int = None,
-                 weights_multiplier_nbits: int = None  # If None - set 8 in hptq, o.w use it
+                 quantization_preserving: bool,
+                 fixed_scale: float,
+                 fixed_zero_point: int,
+                 weights_multiplier_nbits: int  # If None - set 8 in hptq, o.w use it
                  ):
         """
 

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -93,7 +93,8 @@ def _get_node_qc_by_bit_widths(node: BaseNode,
     Returns:
         Node quantization configuration if it was found, or None otherwise.
     """
-
+    # if (node.is_weights_quantization_enabled() and node.has_weights_to_quantize(fw_info)) or \
+    #         (node.is_activation_quantization_enabled() and node.has_activation):
     if node.is_weights_quantization_enabled() or node.is_activation_quantization_enabled():
         bit_index_in_cfg = bit_width_cfg[node_index_in_graph]
         qc = node.candidates_quantization_cfg[bit_index_in_cfg]

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -45,48 +45,33 @@ def set_bit_widths(quant_config: QuantizationConfig,
     graph = copy.deepcopy(graph_to_set_bit_widths)
 
     if isinstance(quant_config, MixedPrecisionQuantizationConfig):
-        if len(quant_config.n_bits_candidates) == 0:
-            Logger.critical(
-                f'Quantization configuration nbits candidates list has to contain at least one bit width candidate. '
-                f'Length is: '
-                f'{len(quant_config.n_bits_candidates)}')
+        assert all([len(n.candidates_quantization_cfg) > 0 for n in graph.get_configurable_sorted_nodes()]), \
+            "All configurable nodes in graph should have at least one candidate configuration in mixed precision mode"
 
-        # When working in mixed-precision mode, and there's only one bitwidth, we simply set the
-        # only candidate of the node as its final weight and activation quantization configuration.
-        if len(quant_config.n_bits_candidates) == 1:
-            for n in graph.nodes:
-                if n.name in graph.get_configurable_sorted_nodes_names():
-                    assert len(n.candidates_quantization_cfg) == 1
-                    n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
-                    n.final_activation_quantization_cfg = n.candidates_quantization_cfg[0].activation_quantization_cfg
-
-        else:
-            Logger.info(f'Set bit widths from configuration: {bit_widths_config}')
-            # Get a list of nodes' names we need to finalize (that they have at least one weight qc candidate).
-            sorted_nodes_names = graph.get_configurable_sorted_nodes_names()
-            for node in graph.nodes:  # set a specific node qc for each node final weights qc
-                # If it's reused, take the configuration that the base node has
-                node_name = node.name if not node.reuse else '_'.join(node.name.split('_')[:-2])
-                if node_name in sorted_nodes_names:  # only configurable nodes are in this list
-                    node_index_in_graph = sorted_nodes_names.index(node_name)
-                    _set_node_final_qc(bit_widths_config,
-                                       fw_info,
-                                       node,
-                                       node_index_in_graph)
-                else:
-                    # TODO: refactor after adding activation mixed precision
-                    if node.is_activation_quantization_enabled():
-                        assert node.is_all_activation_candidates_equal, "Activation Mixed Precision is not supported"
-                        node.final_activation_quantization_cfg = node.candidates_quantization_cfg[0].activation_quantization_cfg
+        Logger.info(f'Set bit widths from configuration: {bit_widths_config}')
+        # Get a list of nodes' names we need to finalize (that they have at least one weight qc candidate).
+        sorted_nodes_names = graph.get_configurable_sorted_nodes_names()
+        for node in graph.nodes:  # set a specific node qc for each node final weights qc
+            # If it's reused, take the configuration that the base node has
+            node_name = node.name if not node.reuse else '_'.join(node.name.split('_')[:-2])
+            if node_name in sorted_nodes_names:  # only configurable nodes are in this list
+                node_index_in_graph = sorted_nodes_names.index(node_name)
+                _set_node_final_qc(bit_widths_config,
+                                   fw_info,
+                                   node,
+                                   node_index_in_graph)
+            else:
+                # TODO: refactor after adding activation mixed precision
+                if node.is_activation_quantization_enabled():
+                    assert node.is_all_activation_candidates_equal, "Activation Mixed Precision is not supported"
+                    node.final_activation_quantization_cfg = node.candidates_quantization_cfg[0].activation_quantization_cfg
 
     # When working in non-mixed-precision mode, there's only one bitwidth, and we simply set the
     # only candidate of the node as its final weight quantization configuration.
     else:
         for n in graph.nodes:
             assert len(n.candidates_quantization_cfg) == 1
-            if fw_info.in_kernel_ops(n):
-                n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
-            # TODO: do we need to set final config only to specific layer (fake quant?) or is setting to all layers is fine?
+            n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
             n.final_activation_quantization_cfg = n.candidates_quantization_cfg[0].activation_quantization_cfg
 
     return graph
@@ -139,7 +124,5 @@ def _set_node_final_qc(bit_width_cfg: List[int],
         Logger.critical(f'Node {node.name} quantization configuration from configuration file'
                         f' was not found in candidates configurations.')
     else:
-        if fw_info.in_kernel_ops(node):
-            node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
-        # TODO: do we need to set final config only to specific layer (fake quant?) or is setting to all layers is fine?
+        node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_activation_quantization_cfg = node_qc.activation_quantization_cfg

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -93,8 +93,6 @@ def _get_node_qc_by_bit_widths(node: BaseNode,
     Returns:
         Node quantization configuration if it was found, or None otherwise.
     """
-    # if (node.is_weights_quantization_enabled() and node.has_weights_to_quantize(fw_info)) or \
-    #         (node.is_activation_quantization_enabled() and node.has_activation):
     if node.is_weights_quantization_enabled() or node.is_activation_quantization_enabled():
         bit_index_in_cfg = bit_width_cfg[node_index_in_graph]
         qc = node.candidates_quantization_cfg[bit_index_in_cfg]

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -25,7 +25,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
     def __init__(self,
                  qc: QuantizationConfig = DEFAULTCONFIG,
-                 n_bits_candidates: List[Tuple[int, int]] = None,
                  compute_distance_fn: Callable = compute_mse,
                  distance_weighting_method: Callable = get_average_weights,
                  num_of_images: int = 32,
@@ -37,8 +36,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
         Args:
             qc (QuantizationConfig): QuantizationConfig object containing parameters of how the model should be quantized.
-            n_bits_candidates (List[Tuple[int, int]]): List of possible number of bits to quantize the coefficients and
-                activations (Tuple of (weights n_bits, activations n_bits)).
             compute_distance_fn (Callable): Function to compute a distance between two tensors.
             distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
             num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
@@ -47,8 +44,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
         """
 
         super().__init__(**qc.__dict__)
-        self.n_bits_candidates = n_bits_candidates if n_bits_candidates is not None else [(qc.weights_n_bits,
-                                                                                           qc.activation_n_bits)]
         self.compute_distance_fn = compute_distance_fn
         self.distance_weighting_method = distance_weighting_method
         self.num_of_images = num_of_images
@@ -57,6 +52,5 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
 # Default quantization configuration the library use.
 DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
-                                                                 [(2, 8), (4, 8), (8, 8)],  # mixed precision only for weights
                                                                  compute_mse,
                                                                  get_average_weights)

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_search_manager.py
@@ -112,7 +112,7 @@ class MixedPrecisionSearchManager(object):
                     node_idx = mp_nodes.index(n.name)
                     # TODO: modify to account for activations size when implementing activations mixed precision
                     node_nbits = n.candidates_quantization_cfg[mp_model_config[node_idx]].weights_quantization_cfg.weights_n_bits
-                elif n.is_weights_quantization_enabled():
+                elif n.is_weights_quantization_enabled() and n.has_weights_to_quantize(self.fw_info):
                     # The only valid way to get here is if the node is reused (which means that we're not looking
                     # for its configuration), and we ignore it when computing the KPI (as the base node will acount
                     # for it).

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -461,8 +461,7 @@ def _prepare_model_for_quantization(in_model: Any,
     ######################################
     # Shift Negative Activations
     ######################################
-    if quant_config.shift_negative_activation_correction and \
-            quant_config.enable_activation_quantization:
+    if quant_config.shift_negative_activation_correction:
         transformed_graph = fw_impl.shift_negative_correction(transformed_graph,
                                                               quant_config,
                                                               fw_info)

--- a/model_compression_toolkit/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/node_quantization_config.py
@@ -81,9 +81,9 @@ class NodeActivationQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.activation_quantization_params = {}
         self.activation_error_method = qc.activation_error_method
         self.activation_quantization_method = op_cfg.activation_quantization_method
-        self.activation_n_bits = qc.activation_n_bits
+        self.activation_n_bits = op_cfg.activation_n_bits
         self.relu_bound_to_power_of_2 = qc.relu_bound_to_power_of_2
-        self.enable_activation_quantization = qc.enable_activation_quantization
+        self.enable_activation_quantization = op_cfg.enable_activation_quantization
         self.activation_channel_equalization = qc.activation_channel_equalization
         self.input_scaling = qc.input_scaling
         self.min_threshold = qc.min_threshold
@@ -214,10 +214,10 @@ class NodeWeightsQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.weights_quantization_params = {}
         self.weights_error_method = qc.weights_error_method
         self.weights_quantization_method = op_cfg.weights_quantization_method
-        self.weights_n_bits = qc.weights_n_bits
+        self.weights_n_bits = op_cfg.weights_n_bits
         self.weights_bias_correction = qc.weights_bias_correction
         self.weights_per_channel_threshold = qc.weights_per_channel_threshold
-        self.enable_weights_quantization = qc.enable_weights_quantization
+        self.enable_weights_quantization = op_cfg.enable_weights_quantization
         self.min_threshold = qc.min_threshold
         self.l_p_value = qc.l_p_value
 

--- a/model_compression_toolkit/common/quantization/quantization_analyzer.py
+++ b/model_compression_toolkit/common/quantization/quantization_analyzer.py
@@ -60,7 +60,7 @@ def analyzer_graph(node_analyze_func: Callable,
         # If we use bias correction, and the node has coefficients to quantize, we need to make sure
         # its previous nodes' tensors are consistent with this node.
         # TODO: factor tensor marking in case of bias correction.
-        if qc.weights_bias_correction and n.is_weights_quantization_enabled() and n.has_weights_to_quantize(fw_info):
+        if qc.weights_bias_correction and n.has_weights_to_quantize(fw_info) and n.is_weights_quantization_enabled():
             for ie in graph.incoming_edges(n):
                 input_node = ie.source_node
                 create_tensor2node(graph,

--- a/model_compression_toolkit/common/quantization/quantization_analyzer.py
+++ b/model_compression_toolkit/common/quantization/quantization_analyzer.py
@@ -60,7 +60,7 @@ def analyzer_graph(node_analyze_func: Callable,
         # If we use bias correction, and the node has coefficients to quantize, we need to make sure
         # its previous nodes' tensors are consistent with this node.
         # TODO: factor tensor marking in case of bias correction.
-        if qc.weights_bias_correction and fw_info.in_kernel_ops(n):
+        if qc.weights_bias_correction and n.is_weights_quantization_enabled() and n.has_weights_to_quantize(fw_info):
             for ie in graph.incoming_edges(n):
                 input_node = ie.source_node
                 create_tensor2node(graph,

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -49,14 +49,10 @@ class QuantizationConfig(object):
     def __init__(self,
                  activation_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
                  weights_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
-                 activation_n_bits: int = 8,
-                 weights_n_bits: int = 8,
                  relu_bound_to_power_of_2: bool = False,
                  weights_bias_correction: bool = True,
                  weights_per_channel_threshold: bool = True,
                  input_scaling: bool = False,
-                 enable_weights_quantization: bool = True,
-                 enable_activation_quantization: bool = True,
                  shift_negative_activation_correction: bool = False,
                  activation_channel_equalization: bool = False,
                  z_threshold: float = math.inf,
@@ -70,14 +66,10 @@ class QuantizationConfig(object):
         Args:
             activation_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
             weights_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
-            activation_n_bits (int): Number of bits to quantize the activations.
-            weights_n_bits (int): Number of bits to quantize the coefficients.
             relu_bound_to_power_of_2 (bool): Whether to use relu to power of 2 scaling correction or not.
             weights_bias_correction (bool): Whether to use weights bias correction or not.
             weights_per_channel_threshold (bool): Whether to quantize the weights per-channel or not (per-tensor).
             input_scaling (bool): Whether to use input scaling or not.
-            enable_weights_quantization (bool): Whether to quantize the model weights or not.
-            enable_activation_quantization (bool): Whether to quantize the model activations or not.
             shift_negative_activation_correction (bool): Whether to use shifting negative activation correction or not.
             activation_channel_equalization (bool): Whether to use activation channel equalization correction or not.
             z_threshold (float): Value of z score for outliers removal.
@@ -94,7 +86,7 @@ class QuantizationConfig(object):
             enabling relu_bound_to_power_of_2, weights_bias_correction, and quantizing the weights per-channel,
             one can instantiate a quantization configuration:
 
-            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,activation_n_bits=6,weights_n_bits=7,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
+            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
 
 
             The QuantizationConfig instanse can then be passed to
@@ -103,19 +95,15 @@ class QuantizationConfig(object):
             In order to use a different quantization method (than power-of-two that is used by default),
             one may pass a desired QuantizationMethod when instantiating a QuantizationConfig. For example:
 
-            >>> qc = QuantizationConfig(activation_quantization_method=QuantizationMethod.LUT_QUANTIZER)
+            >>> qc = QuantizationConfig()
 
         """
 
         self.activation_error_method = activation_error_method
         self.weights_error_method = weights_error_method
-        self.activation_n_bits = activation_n_bits
-        self.weights_n_bits = weights_n_bits
         self.relu_bound_to_power_of_2 = relu_bound_to_power_of_2
         self.weights_bias_correction = weights_bias_correction
         self.weights_per_channel_threshold = weights_per_channel_threshold
-        self.enable_weights_quantization = enable_weights_quantization
-        self.enable_activation_quantization = enable_activation_quantization
         self.activation_channel_equalization = activation_channel_equalization
         self.input_scaling = input_scaling
         self.min_threshold = min_threshold
@@ -132,8 +120,6 @@ class QuantizationConfig(object):
 # Default quantization configuration the library use.
 DEFAULTCONFIG = QuantizationConfig(QuantizationErrorMethod.MSE,
                                    QuantizationErrorMethod.MSE,
-                                   activation_n_bits=8,
-                                   weights_n_bits=8,
                                    relu_bound_to_power_of_2=False,
                                    weights_bias_correction=True,
                                    weights_per_channel_threshold=True,

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
@@ -51,40 +51,21 @@ def calculate_quantization_params(graph: Graph,
     nodes_list: List[BaseNode] = nodes if specific_nodes else graph.nodes()
 
     for n in nodes_list:  # iterate only nodes that we should compute their thresholds
-
-        weights_params, activation_params, activation_is_signed, output_channels_axis, \
-        input_channels_axis, activation_threshold_float = {}, {}, None, None, None, None
-
         for candidate_qc in n.candidates_quantization_cfg:
-            if fw_info.in_kernel_ops(n):  # If the node has a kernel to quantize
-                if n.is_weights_quantization_enabled():
-                    output_channels_axis, _ = get_channels_axis(candidate_qc.weights_quantization_cfg, fw_info, n.type)
-                    weights_params = get_weights_qparams(n.get_weights_by_keys(fw_impl.constants.KERNEL),
-                                                         candidate_qc.weights_quantization_cfg,
-                                                         output_channels_axis)
+            if n.is_weights_quantization_enabled() and n.has_weights_to_quantize(fw_info):
+                # If node's weights should be quantized, we compute its weights' quantization parameters
+                output_channels_axis, _ = get_channels_axis(candidate_qc.weights_quantization_cfg, fw_info, n.type)
+                weights_params = get_weights_qparams(n.get_weights_by_keys(fw_impl.constants.KERNEL),
+                                                     candidate_qc.weights_quantization_cfg,
+                                                     output_channels_axis)
 
-                    candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
-                    candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
+                candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
+                candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
 
-                if n.is_activation_quantization_enabled():
-                    # If node's activations should be quantized as well, we compute its activation threshold
-                    activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
-                                                                nodes_prior_info=n.prior_info,
-                                                                out_stats_container=graph.get_out_stats_collector(n))
-
-            elif fw_info.in_activation_ops(n):  # If node has no kernel, but its activations should be quantized
-                if n.is_activation_quantization_enabled():
-                    activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
-                                                                nodes_prior_info=n.prior_info,
-                                                                out_stats_container=graph.get_out_stats_collector(n))
-            # If node should not be quantized at all
-            elif fw_info.in_no_quantization_ops(n):
-                pass  # pragma: no cover
-
-            # Create a NodeQuantizationConfig containing all quantization params and attach it to the node
             if n.is_activation_quantization_enabled():
+                # If node's activations should be quantized as well, we compute its activation quantization parameters
+                activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
+                                                            nodes_prior_info=n.prior_info,
+                                                            out_stats_container=graph.get_out_stats_collector(n))
+                # Create a NodeQuantizationConfig containing all quantization params and attach it to the node
                 candidate_qc.activation_quantization_cfg.set_activation_quantization_param(activation_params)
-
-        # If layer type is not in framework info, log a warning.
-        if not fw_info.in_no_quantization_ops(n) and not fw_info.in_activation_ops(n) and not fw_info.in_kernel_ops(n):
-            Logger.warning(f"Warning: unknown layer: {n.type.__name__}")

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
@@ -62,7 +62,7 @@ def calculate_quantization_params(graph: Graph,
                 candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
                 candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
 
-            if n.is_activation_quantization_enabled():
+            if n.has_activation and n.is_activation_quantization_enabled():
                 # If node's activations should be quantized as well, we compute its activation quantization parameters
                 activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
                                                             nodes_prior_info=n.prior_info,

--- a/model_compression_toolkit/common/quantization/quantize_graph_weights.py
+++ b/model_compression_toolkit/common/quantization/quantize_graph_weights.py
@@ -41,8 +41,7 @@ def quantize_graph_weights(graph_to_quantize: Graph,
     # Iterate over nodes in the graph and quantize each node's weights and activations
     # (according to operators groups in framework info).
     for n in graph.nodes():
-
-        if fw_info.in_kernel_ops(n) and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.has_weights_to_quantize(fw_info) and n.final_weights_quantization_cfg.enable_weights_quantization:
             quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
                                                                                     n,
                                                                                     n.final_weights_quantization_cfg,

--- a/model_compression_toolkit/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/set_node_quantization_config.py
@@ -29,7 +29,8 @@ from model_compression_toolkit.common.quantization.quantization_config import Qu
 from model_compression_toolkit.common.quantization.quantization_params_fn_selection import \
     get_activation_quantization_params_fn, get_weights_quantization_params_fn
 from model_compression_toolkit.common.hardware_representation.hardware2framework import FrameworkHardwareModel
-from model_compression_toolkit.common.hardware_representation.op_quantization_config import OpQuantizationConfig
+from model_compression_toolkit.common.hardware_representation.op_quantization_config import OpQuantizationConfig, \
+    QuantizationConfigOptions
 
 
 def set_quantization_configuration_to_graph(graph: Graph,
@@ -68,20 +69,14 @@ def set_quantization_configs_to_node(node: BaseNode,
         fw_hw_model: FrameworkHardwareModel to get default OpQuantizationConfig.
 
     """
-    op_cfg = fw_hw_model.get_default_op_qc()
+    node_qc_options = fw_hw_model.get_qco_by_node(node)
 
     # Create QC candidates for weights and activation combined
     weight_channel_axis = fw_info.kernel_channels_mapping.get(node.type)[0]
     node.candidates_quantization_cfg = _create_node_candidates_qc(quant_config,
                                                                   fw_info,
                                                                   weight_channel_axis,
-                                                                  op_cfg)
-
-    enable_activation_quantization = quant_config.enable_activation_quantization and (fw_info.in_activation_ops(node) or fw_info.in_kernel_ops(node))
-    enable_weights_quantization = quant_config.enable_weights_quantization and fw_info.in_kernel_ops(node)
-    for candidate_qc in node.candidates_quantization_cfg:
-        candidate_qc.weights_quantization_cfg.enable_weights_quantization = enable_weights_quantization
-        candidate_qc.activation_quantization_cfg.enable_activation_quantization = enable_activation_quantization
+                                                                  node_qc_options)
 
 
 def create_node_activation_qc(qc: QuantizationConfig,
@@ -162,7 +157,7 @@ def create_node_qc_candidate(qc: QuantizationConfig,
 def _create_node_candidates_qc(qc: QuantizationConfig,
                                fw_info: FrameworkInfo,
                                weight_channel_axis: int,
-                               op_cfg: OpQuantizationConfig) -> List[CandidateNodeQuantizationConfig]:
+                               node_qc_options: QuantizationConfigOptions) -> List[CandidateNodeQuantizationConfig]:
     """
     Create a list of candidates of weights and activation quantization configurations for a node.
 
@@ -170,7 +165,7 @@ def _create_node_candidates_qc(qc: QuantizationConfig,
         qc: Quantization configuration the quantization process should follow.
         fw_info: Framework information (e.g., which layers should have their kernels' quantized).
         weight_channel_axis: Output channel index of the node's kernel.
-        op_cfg: OpQuantizationConfig for the node with quantizers types.
+        node_qc_options: QuantizationConfigOptions for the node with quantization candidates information.
 
     Returns:
         List of candidates of weights quantization configurations to set for a node.
@@ -178,16 +173,23 @@ def _create_node_candidates_qc(qc: QuantizationConfig,
 
     candidates = []
     if isinstance(qc, MixedPrecisionQuantizationConfig):
-        qc.n_bits_candidates.sort(reverse=True)
-        for weights_n_bits, activation_n_bits in qc.n_bits_candidates:
+        for op_cfg in node_qc_options.quantization_config_list:
             candidate_nbits_qc = copy.deepcopy(qc)
-            candidate_nbits_qc.weights_n_bits = weights_n_bits
-            candidate_nbits_qc.activation_n_bits = activation_n_bits
             candidates.append(create_node_qc_candidate(candidate_nbits_qc,
                                                        fw_info,
                                                        weight_channel_axis,
                                                        op_cfg))
+        # sorting the candidates by weights number of bits first and then by activation number of bits
+        # (in reversed order)
+        candidates.sort(key=lambda c: (c.weights_quantization_cfg.weights_n_bits,
+                                       c.activation_quantization_cfg.activation_n_bits), reverse=True)
+
     else:
+        op_cfg = node_qc_options.quantization_config_list[0]
+        if len(node_qc_options.quantization_config_list) > 1:
+            op_cfg = node_qc_options.base_config
+            Logger.warning(f"Given multiple candidates configurations for non mixed-precision quantization,"
+                           f"using base_config as the node's configuration")
         candidates.append(create_node_qc_candidate(qc,
                                                    fw_info,
                                                    weight_channel_axis,

--- a/model_compression_toolkit/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/common/substitutions/shift_negative_activation.py
@@ -328,12 +328,13 @@ def shift_negative_function(graph: Graph,
                     bypass_candidate_qc.activation_quantization_cfg.activation_quantization_params[SIGNED] = False
                     graph.shift_stats_collector(bypass_node, np.array(shift_value))
 
-    for candidate_qc in add_node.candidates_quantization_cfg:
+    add_node_qco = graph.fw_hw_model.get_qco_by_node(add_node).quantization_config_list
+    for op_qc_idx, candidate_qc in enumerate(add_node.candidates_quantization_cfg):
         candidate_qc.weights_quantization_cfg.enable_weights_quantization = False
 
         candidate_qc.activation_quantization_cfg = create_node_activation_qc(qc,
                                                                              fw_info,
-                                                                             graph.fw_hw_model.get_default_op_qc())
+                                                                             add_node_qco[op_qc_idx])
 
         candidate_qc.activation_quantization_cfg.set_activation_quantization_param({THRESHOLD: activation_threshold,
                                                                                     SIGNED: False})
@@ -461,13 +462,14 @@ def apply_shift_negative_correction(graph: Graph,
     Returns:
         Graph after applying shift negative on selected activations.
     """
-    # Skip substitution if QuantizationMethod is uniform.
-    op_qc = graph.fw_hw_model.get_default_op_qc()
-    if op_qc.activation_quantization_method is QuantizationMethod.UNIFORM:
-        return graph
-
     nodes = list(graph.nodes())
     for n in nodes:
+        # Skip substitution if QuantizationMethod is uniform.
+        node_qco = graph.fw_hw_model.get_qco_by_node(n)
+        if any([op_qc.activation_quantization_method is QuantizationMethod.UNIFORM
+                for op_qc in node_qco.quantization_config_list]):
+            continue
+
         if snc_node_types.apply(n):
             linear_node, pad_node, bypass_nodes = get_next_nodes_to_correct(n,
                                                                             graph,
@@ -476,7 +478,7 @@ def apply_shift_negative_correction(graph: Graph,
                                                                             pad_node_types,
                                                                             is_padding_node_and_node_has_padding
                                                                             )
-            if linear_node is not None:
+            if linear_node is not None and n.is_activation_quantization_enabled():
                 graph = shift_negative_function(graph,
                                                 quant_config,
                                                 n,

--- a/model_compression_toolkit/hardware_models/default_hwm.py
+++ b/model_compression_toolkit/hardware_models/default_hwm.py
@@ -18,17 +18,38 @@ hwm = mct.hardware_representation
 
 
 def get_default_hardware_model():
+    return generate_default_hardware_model()
+
+
+def generate_default_hardware_model(activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                    weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                    activation_n_bits=8,
+                                    weights_n_bits=8,
+                                    weights_per_channel_threshold=True,
+                                    enable_weights_quantization=True,
+                                    enable_activation_quantization=True,
+                                    quantization_preserving=False,
+                                    fixed_scale=None,
+                                    fixed_zero_point=None,
+                                    weights_multiplier_nbits=None,
+                                    mixed_precision_cfg=None
+                                    ):
+
     # Create a quantization config.
     # A quantization configuration defines how an operator
     # should be quantized on the modeled hardware:
     eight_bits = hwm.OpQuantizationConfig(
-        activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-        weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-        activation_n_bits=8,
-        weights_n_bits=8,
-        weights_per_channel_threshold=True,
-        enable_weights_quantization=True,
-        enable_activation_quantization=True
+        activation_quantization_method=activation_quantization_method,
+        weights_quantization_method=weights_quantization_method,
+        activation_n_bits=activation_n_bits,
+        weights_n_bits=weights_n_bits,
+        weights_per_channel_threshold=weights_per_channel_threshold,
+        enable_weights_quantization=enable_weights_quantization,
+        enable_activation_quantization=enable_activation_quantization,
+        quantization_preserving=quantization_preserving,
+        fixed_scale=fixed_scale,
+        fixed_zero_point=fixed_zero_point,
+        weights_multiplier_nbits=weights_multiplier_nbits
     )
 
     # Create a QuantizationConfigOptions, which defines a set
@@ -64,9 +85,9 @@ def get_default_hardware_model():
         # to quantize the operations' activations using LUT.
         four_bits = eight_bits.clone_and_edit(weights_n_bits=4)
         two_bits = eight_bits.clone_and_edit(weights_n_bits=2)
-        mixed_precision_configuration_options = hwm.QuantizationConfigOptions([eight_bits,
-                                                                               four_bits,
-                                                                               two_bits],
+        mixed_precision_cfg_list = [eight_bits, four_bits, two_bits] \
+            if mixed_precision_cfg is None else mixed_precision_cfg  # allowing to use mp config from input
+        mixed_precision_configuration_options = hwm.QuantizationConfigOptions(mixed_precision_cfg_list,
                                                                               base_config=eight_bits)
 
         # Define operator sets that use mixed_precision_configuration_options:
@@ -95,4 +116,3 @@ def get_default_hardware_model():
         hwm.Fusing([conv, any_relu, add])
 
     return default_hwm
-

--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py
@@ -15,6 +15,8 @@
 
 import tensorflow as tf
 
+from model_compression_toolkit.common.hardware_representation import HardwareModel
+
 if tf.__version__ < "2.6":
     from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, PReLU, Flatten, Cropping2D, BatchNormalization
@@ -30,10 +32,23 @@ hwm = mct.hardware_representation
 
 def get_default_hwm_keras():
     default_hwm = get_default_hardware_model()
-    default_hwm_keras = hwm.FrameworkHardwareModel(default_hwm,
-                                                   name='default_hwm_keras')
+    return generate_fhw_model_keras(name='default_hwm_keras',
+                                    hardware_model=default_hwm)
 
-    with default_hwm_keras:
+
+def generate_fhw_model_keras(name: str, hardware_model: HardwareModel):
+    """
+    Generates a FrameworkHardwareModel object with default operation sets to layers mapping.
+    Args:
+        name: Name of the framework hardware model.
+        hardware_model: HardwareModel object.
+
+    Returns: a FrameworkHardwareModel object for the given HardwareModel.
+    """
+
+    fhwm_keras = hwm.FrameworkHardwareModel(hardware_model,
+                                            name=name)
+    with fhwm_keras:
         hwm.OperationsSetToLayers("NoQuantization", [Reshape,
                                                      tf.reshape,
                                                      Flatten,
@@ -57,7 +72,7 @@ def get_default_hwm_keras():
 
         hwm.OperationsSetToLayers("AnyReLU", [tf.nn.relu,
                                               tf.nn.relu6,
-                                              hwm.LayerFilterParams(ReLU, negative_slope=0.0),
+                                              ReLU,
                                               hwm.LayerFilterParams(Activation, activation="relu")])
 
         hwm.OperationsSetToLayers("Add", [tf.add,
@@ -73,7 +88,4 @@ def get_default_hwm_keras():
 
         hwm.OperationsSetToLayers("Tanh", [tf.nn.tanh,
                                            hwm.LayerFilterParams(Activation, activation="tanh")])
-
-    return default_hwm_keras
-
-
+    return fhwm_keras

--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_qnnpack.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_qnnpack.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
+from model_compression_toolkit.common.hardware_representation import HardwareModel
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
     FrameworkHardwareModel, LayerFilterParams
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
@@ -28,8 +28,12 @@ else:
 
 def get_qnnpack_tensorflow():
     qnnpackhm = get_qnnpack_model()
-    qnnpack_tf = FrameworkHardwareModel(qnnpackhm,
-                                        name='qnnpack_tensorflow')
+    return generate_fhw_model_qnnpack(name='qnnpack_tensorflow',
+                                      qnnpack_hm=qnnpackhm)
+
+
+def generate_fhw_model_qnnpack(name: str, qnnpack_hm: HardwareModel):
+    qnnpack_tf = FrameworkHardwareModel(qnnpack_hm, name=name)
 
     with qnnpack_tf:
         OperationsSetToLayers("Conv", [Conv2D,

--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_qnnpack.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_qnnpack.py
@@ -28,11 +28,11 @@ else:
 
 def get_qnnpack_tensorflow():
     qnnpackhm = get_qnnpack_model()
-    return generate_fhw_model_qnnpack(name='qnnpack_tensorflow',
-                                      qnnpack_hm=qnnpackhm)
+    return generate_fhw_model_qnnpack_keras(name='qnnpack_tensorflow',
+                                            qnnpack_hm=qnnpackhm)
 
 
-def generate_fhw_model_qnnpack(name: str, qnnpack_hm: HardwareModel):
+def generate_fhw_model_qnnpack_keras(name: str, qnnpack_hm: HardwareModel):
     qnnpack_tf = FrameworkHardwareModel(qnnpack_hm, name=name)
 
     with qnnpack_tf:

--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_tflite.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_tflite.py
@@ -23,7 +23,7 @@ else:
 from tensorflow.python.keras.layers.core import SlicingOpLambda
 from tensorflow.python.ops.image_ops_impl import ResizeMethod
 
-from model_compression_toolkit.common.hardware_representation import FrameworkHardwareModel
+from model_compression_toolkit.common.hardware_representation import FrameworkHardwareModel, HardwareModel
 from model_compression_toolkit.common.hardware_representation.hardware2framework import OperationsSetToLayers, \
     LayerFilterParams
 from model_compression_toolkit.common.hardware_representation.hardware2framework.attribute_filter import Eq
@@ -32,7 +32,12 @@ from model_compression_toolkit.hardware_models.tflite import get_tflite_hw_model
 
 def get_keras_hardware_model_tflite():
     tflite_hm = get_tflite_hw_model()
-    tflite_keras = FrameworkHardwareModel(tflite_hm, name='tflite_keras')
+    return generate_fhw_model_tflite(name='tflite_keras',
+                                     tflite_hm=tflite_hm)
+
+
+def generate_fhw_model_tflite(name: str, tflite_hm: HardwareModel):
+    tflite_keras = FrameworkHardwareModel(tflite_hm, name=name)
 
     with tflite_keras:
         OperationsSetToLayers("PreserveQuantizationParams", [AveragePooling2D,
@@ -93,4 +98,3 @@ def get_keras_hardware_model_tflite():
                                       Add])
 
     return tflite_keras
-

--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_tflite.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_tflite.py
@@ -32,11 +32,11 @@ from model_compression_toolkit.hardware_models.tflite import get_tflite_hw_model
 
 def get_keras_hardware_model_tflite():
     tflite_hm = get_tflite_hw_model()
-    return generate_fhw_model_tflite(name='tflite_keras',
-                                     tflite_hm=tflite_hm)
+    return generate_fhw_model_tflite_keras(name='tflite_keras',
+                                           tflite_hm=tflite_hm)
 
 
-def generate_fhw_model_tflite(name: str, tflite_hm: HardwareModel):
+def generate_fhw_model_tflite_keras(name: str, tflite_hm: HardwareModel):
     tflite_keras = FrameworkHardwareModel(tflite_hm, name=name)
 
     with tflite_keras:

--- a/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_default.py
+++ b/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_default.py
@@ -22,6 +22,7 @@ from torch.nn import Dropout, Flatten, Hardtanh
 from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh
 from torch.nn.functional import relu, relu6, prelu, silu, hardtanh
 
+from model_compression_toolkit.common.hardware_representation import HardwareModel
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
     FrameworkHardwareModel, LayerFilterParams
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
@@ -30,11 +31,25 @@ from model_compression_toolkit.hardware_models.default_hwm import get_default_ha
 
 
 def get_default_hwm_pytorch():
-    default_hm = get_default_hardware_model()
-    default_hwm_pytorch = FrameworkHardwareModel(default_hm,
-                                                 name='default_hwm_pytorch')
+    default_hwm = get_default_hardware_model()
+    return generate_fhw_model_pytorch(name='default_hwm_pytorch',
+                                      hardware_model=default_hwm)
 
-    with default_hwm_pytorch:
+
+def generate_fhw_model_pytorch(name: str, hardware_model: HardwareModel):
+    """
+    Generates a FrameworkHardwareModel object with default operation sets to layers mapping.
+    Args:
+        name: Name of the framework hardware model.
+        hardware_model: HardwareModel object.
+
+    Returns: a FrameworkHardwareModel object for the given HardwareModel.
+    """
+
+    fhwm_pytorch = FrameworkHardwareModel(hardware_model,
+                                          name=name)
+
+    with fhwm_pytorch:
         OperationsSetToLayers("NoQuantization", [Dropout,
                                                  Flatten,
                                                  dropout,
@@ -74,7 +89,4 @@ def get_default_hwm_pytorch():
         OperationsSetToLayers("Tanh", [Tanh,
                                        tanh])
 
-    return default_hwm_pytorch
-
-
-
+    return fhwm_pytorch

--- a/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_default.py
+++ b/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_default.py
@@ -28,6 +28,7 @@ from model_compression_toolkit.common.hardware_representation.hardware2framework
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
     OperationsSetToLayers
 from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from model_compression_toolkit.pytorch.reader.graph_builders import ConstantHolder, DummyPlaceHolder
 
 
 def get_default_hwm_pytorch():
@@ -58,7 +59,8 @@ def generate_fhw_model_pytorch(name: str, hardware_model: HardwareModel):
                                                  operator.getitem,
                                                  reshape,
                                                  unsqueeze,
-                                                 BatchNorm2d])
+                                                 BatchNorm2d,
+                                                 torch.Tensor.size])
 
         OperationsSetToLayers("Conv", [Conv2d])
 

--- a/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_qnnpack.py
+++ b/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_qnnpack.py
@@ -18,6 +18,7 @@ import torch
 from torch.nn import Conv2d, Linear, BatchNorm2d, ConvTranspose2d, Hardtanh, ReLU, ReLU6
 from torch.nn.functional import relu, relu6, hardtanh
 
+from model_compression_toolkit.common.hardware_representation import HardwareModel
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
     FrameworkHardwareModel, LayerFilterParams
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
@@ -27,8 +28,13 @@ from model_compression_toolkit.hardware_models.qnnpack import get_qnnpack_model
 
 def get_qnnpack_pytorch():
     qnnpackhm = get_qnnpack_model()
-    qnnpack_pytorch = FrameworkHardwareModel(qnnpackhm,
-                                             name='qnnpack_pytorch')
+    return generate_fhw_model_qnnpack_pytorch(name='qnnpack_tensorflow',
+                                              qnnpack_hm=qnnpackhm)
+
+
+def generate_fhw_model_qnnpack_pytorch(name: str, qnnpack_hm: HardwareModel):
+    qnnpack_pytorch = FrameworkHardwareModel(qnnpack_hm,
+                                             name=name)
 
     with qnnpack_pytorch:
         OperationsSetToLayers("Conv", [Conv2d,

--- a/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_tflite.py
+++ b/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_tflite.py
@@ -16,7 +16,7 @@ import torch
 from torch.nn import AvgPool2d, MaxPool2d
 from torch.nn.functional import avg_pool2d, max_pool2d, interpolate
 
-from model_compression_toolkit.common.hardware_representation import FrameworkHardwareModel
+from model_compression_toolkit.common.hardware_representation import FrameworkHardwareModel, HardwareModel
 from model_compression_toolkit.common.hardware_representation.hardware2framework import OperationsSetToLayers, \
     LayerFilterParams
 from model_compression_toolkit.common.hardware_representation.hardware2framework.attribute_filter import Eq
@@ -26,7 +26,12 @@ import operator
 
 def get_pytorch_tflite_model():
     tflite_hm = get_tflite_hw_model()
-    tflite_torch = FrameworkHardwareModel(tflite_hm, name='tflite_torch')
+    return generate_fhw_model_tflite_pytorch(name='tflite_torch',
+                                     tflite_hm=tflite_hm)
+
+
+def generate_fhw_model_tflite_pytorch(name: str, tflite_hm: HardwareModel):
+    tflite_torch = FrameworkHardwareModel(tflite_hm, name=name)
 
     with tflite_torch:
         OperationsSetToLayers("PreserveQuantizationParams", [AvgPool2d,

--- a/model_compression_toolkit/hardware_models/qnnpack.py
+++ b/model_compression_toolkit/hardware_models/qnnpack.py
@@ -17,19 +17,37 @@ from model_compression_toolkit import hardware_representation as hw_model
 
 
 def get_qnnpack_model():
+    return generate_qnnpack_hw_model()
+
+
+def generate_qnnpack_hw_model(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
+                              weights_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
+                              activation_n_bits=8,
+                              weights_n_bits=8,
+                              weights_per_channel_threshold=False,
+                              enable_weights_quantization=True,
+                              enable_activation_quantization=True,
+                              quantization_preserving=False,
+                              fixed_scale=None,
+                              fixed_zero_point=None,
+                              weights_multiplier_nbits=None):
     # Create a quantization config. A quantization configuration defines how an operator
     # should be quantized on the modeled hardware.
     # For qnnpack backend, Pytorch uses a QConfig with torch.per_tensor_affine for
     # activations quantization and a torch.per_tensor_symmetric quantization scheme
     # for weights quantization (https://pytorch.org/docs/stable/quantization.html#natively-supported-backends):
     eight_bits = hw_model.OpQuantizationConfig(
-        activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
-        weights_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
-        activation_n_bits=8,
-        weights_n_bits=8,
-        weights_per_channel_threshold=False,
-        enable_weights_quantization=True,
-        enable_activation_quantization=True
+        activation_quantization_method=activation_quantization_method,
+        weights_quantization_method=weights_quantization_method,
+        activation_n_bits=activation_n_bits,
+        weights_n_bits=weights_n_bits,
+        weights_per_channel_threshold=weights_per_channel_threshold,
+        enable_weights_quantization=enable_weights_quantization,
+        enable_activation_quantization=enable_activation_quantization,
+        quantization_preserving=quantization_preserving,
+        fixed_scale=fixed_scale,
+        fixed_zero_point=fixed_zero_point,
+        weights_multiplier_nbits=weights_multiplier_nbits
     )
 
     # Create a QuantizationConfigOptions, which defines a set
@@ -61,4 +79,3 @@ def get_qnnpack_model():
         hw_model.Fusing([linear, relu])
 
     return qnnpack_model
-

--- a/model_compression_toolkit/hardware_models/tflite.py
+++ b/model_compression_toolkit/hardware_models/tflite.py
@@ -14,23 +14,39 @@
 # ==============================================================================
 
 from model_compression_toolkit import hardware_representation as hw_model
-from model_compression_toolkit.common.hardware_representation.op_quantization_config import QuantizationMethod
 
 
 def get_tflite_hw_model():
+    return generate_tflite_hw_model()
 
+
+def generate_tflite_hw_model(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
+                             weights_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
+                             activation_n_bits=8,
+                             weights_n_bits=8,
+                             weights_per_channel_threshold=True,
+                             enable_weights_quantization=True,
+                             enable_activation_quantization=True,
+                             quantization_preserving=False,
+                             fixed_scale=None,
+                             fixed_zero_point=None,
+                             weights_multiplier_nbits=None):
     # Create a quantization config. A quantization configuration defines how an operator
     # should be quantized on the modeled hardware. In TFLite
     # activations quantization is asymmetric, and weights quantization is symmetric:
     # https://www.tensorflow.org/lite/performance/quantization_spec#symmetric_vs_asymmetric
     eight_bits = hw_model.OpQuantizationConfig(
-        activation_quantization_method=QuantizationMethod.UNIFORM,
-        weights_quantization_method=QuantizationMethod.SYMMETRIC,
-        activation_n_bits=8,
-        weights_n_bits=8,
-        weights_per_channel_threshold=True,
-        enable_weights_quantization=True,
-        enable_activation_quantization=True
+        activation_quantization_method=activation_quantization_method,
+        weights_quantization_method=weights_quantization_method,
+        activation_n_bits=activation_n_bits,
+        weights_n_bits=weights_n_bits,
+        weights_per_channel_threshold=weights_per_channel_threshold,
+        enable_weights_quantization=enable_weights_quantization,
+        enable_activation_quantization=enable_activation_quantization,
+        quantization_preserving=quantization_preserving,
+        fixed_scale=fixed_scale,
+        fixed_zero_point=fixed_zero_point,
+        weights_multiplier_nbits=weights_multiplier_nbits
     )
 
     # Create a QuantizationConfigOptions, which defines a set
@@ -98,4 +114,3 @@ def get_tflite_hw_model():
         hw_model.Fusing([batch_norm, add, activations_to_fuse])
 
     return tflite_model
-

--- a/model_compression_toolkit/keras/back2framework/model_builder.py
+++ b/model_compression_toolkit/keras/back2framework/model_builder.py
@@ -299,7 +299,7 @@ def model_builder(graph: common.Graph,
             if len(nodes) == 1:
                 node = nodes[0]
                 # Wrap only if its weights should be quantized
-                if node.is_weights_quantization_enabled():
+                if node.is_weights_quantization_enabled() and node.has_weights_to_quantize(fw_info):
                     return QuantizeWrapper(layer, quantization_config_builder_mixed_precision(node, fw_info))
                 return layer
 

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -17,13 +17,9 @@
 import tensorflow as tf
 
 if tf.__version__ < "2.6":
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, Dropout, \
-        MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, InputLayer, \
-        Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute, LayerNormalization
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 else:
-    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
-    Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, \
-    InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute, LayerNormalization
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -35,75 +31,6 @@ from model_compression_toolkit.common.quantization.quantizers.uniform_quantizers
 from model_compression_toolkit.keras.constants import SOFTMAX, LINEAR, RELU, SWISH, SIGMOID, IDENTITY, TANH, SELU, \
     KERNEL, DEPTHWISE_KERNEL
 from model_compression_toolkit.keras.quantizer.fake_quant_builder import power_of_two_quantization, symmetric_quantization, uniform_quantization
-
-"""
-Division of Keras layers by how they should be quantized.
-KERNEL_OPS: Layers that their coefficients should be quantized.
-ACTIVATION: Layers that their activation should be quantized.
-NO_QUANTIZATION: Layers that should not be quantized.
-"""
-# TODO: remove these three lists and refactor kernel_ops, activation_ops, no_quantization_ops
-KERNEL_OPS = [Conv2D,
-              DepthwiseConv2D,
-              Dense,
-              Conv2DTranspose]
-
-NO_QUANTIZATION = [Reshape,
-                   tf.reshape,
-                   Flatten,
-                   Permute,
-                   Cropping2D,
-                   ZeroPadding2D,
-                   Dropout,
-                   MaxPooling2D,
-                   tf.reshape,
-                   tf.split,
-                   tf.quantization.fake_quant_with_min_max_vars]  # TODO:  replace with marking
-
-ACTIVATION = [Activation,
-              ReLU,
-              tf.nn.relu,
-              tf.nn.relu6,
-              tf.nn.leaky_relu,
-              Softmax,
-              GlobalAveragePooling2D,
-              Add,
-              Multiply,
-              AveragePooling2D,
-              UpSampling2D,
-              InputLayer,
-              Concatenate,
-              PReLU,
-              ELU,
-              tf.nn.silu,
-              tf.nn.swish,
-              tf.nn.sigmoid,
-              tf.nn.tanh,
-              tf.nn.relu,
-              tf.nn.relu6,
-              tf.nn.leaky_relu,
-              LeakyReLU,
-              tf.nn.softsign,
-              tf.nn.gelu,
-              tf.nn.elu,
-              tf.nn.selu,
-              tf.nn.softplus,
-              tf.nn.softmax,
-              Dot,
-              LayerNormalization,
-              tf.add,
-              tf.multiply,
-              tf.reduce_mean,
-              tf.reduce_min,
-              tf.reduce_sum,
-              tf.reduce_max,
-              tf.image.resize,
-              tf.image.crop_and_resize,
-              tf.concat,
-              ]
-
-
-
 
 """
 Map each layer to a list of its' weights attributes that should get quantized.
@@ -178,10 +105,7 @@ Output channel index of the model's layers
 """
 OUTPUT_CHANNEL_INDEX = ChannelAxis.NHWC
 
-DEFAULT_KERAS_INFO = FrameworkInfo(KERNEL_OPS,
-                                   ACTIVATION,
-                                   NO_QUANTIZATION,
-                                   ACTIVATION_QUANTIZER_MAPPING,
+DEFAULT_KERAS_INFO = FrameworkInfo(ACTIVATION_QUANTIZER_MAPPING,
                                    WEIGHTS_QUANTIZER_MAPPING,
                                    DEFAULT_CHANNEL_AXIS_DICT,
                                    ACTIVATION2MINMAX,

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -42,7 +42,7 @@ KERNEL_OPS: Layers that their coefficients should be quantized.
 ACTIVATION: Layers that their activation should be quantized.
 NO_QUANTIZATION: Layers that should not be quantized.
 """
-
+# TODO: remove these three lists and refactor kernel_ops, activation_ops, no_quantization_ops
 KERNEL_OPS = [Conv2D,
               DepthwiseConv2D,
               Dense,

--- a/model_compression_toolkit/keras/gradient_ptq/graph_info.py
+++ b/model_compression_toolkit/keras/gradient_ptq/graph_info.py
@@ -68,7 +68,9 @@ def get_trainable_parameters(fxp_model: Model,
             # collect trainable weights per layer
             layer_trainable_weights = layer.quantize_config.get_trainable_quantizer_parameters()
             if add_bias:
-                use_bias = isinstance(layer.layer, tuple(fw_info.kernel_ops)) and layer.layer.get_config().get(USE_BIAS)
+                kernel_ops_attrs = fw_info.kernel_ops_attributes_mapping.get(type(layer.layer))
+                use_bias = kernel_ops_attrs is not None and kernel_ops_attrs[0] is not None \
+                           and layer.layer.get_config().get(USE_BIAS)
                 if use_bias is not None and use_bias:
                     layer_trainable_weights.append(layer.layer.bias)
             trainable_weights.append(layer_trainable_weights)

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -215,7 +215,7 @@ if importlib.util.find_spec("tensorflow") is not None\
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
              Here, each layer can be quantized by 2, 4 or 8 bits:
 
-             >>> config = mct.MixedPrecisionQuantizationConfig(weights_n_bits=[4, 2, 8])
+             >>> config = mct.MixedPrecisionQuantizationConfig()
 
              Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias will not):
 
@@ -232,16 +232,9 @@ if importlib.util.find_spec("tensorflow") is not None\
                              fw_info=fw_info).validate()
 
         if target_kpi is None:
-            # Before starting non-mixed-precision process, we need to set only single bit width, so we take the best
-            # option which is the maximal number of bits.
-            single_bitwidth_candidate = quant_config.n_bits_candidates[0]
-            quant_config.weights_n_bits = [single_bitwidth_candidate[0]]
-            quant_config.activation_n_bits = [single_bitwidth_candidate[1]]
-            quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
-                f"weights_n_bits={quant_config.weights_n_bits} "
-                f"and activation_n_bits={quant_config.activation_n_bits}...")
+                f"base_config defined in the given hardware model...")
             return keras_post_training_quantization(in_model,
                                                     representative_data_gen,
                                                     n_iter,

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -232,6 +232,8 @@ if importlib.util.find_spec("tensorflow") is not None\
                              fw_info=fw_info).validate()
 
         if target_kpi is None:
+            # TODO: throw exception or fix such that the actual config would be base_config (requires fix
+            #   in set_node_quantization_config and in bit_width_setter)
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
                 f"base_config defined in the given hardware model...")

--- a/model_compression_toolkit/keras/quantizer/gradient_ptq/config_factory.py
+++ b/model_compression_toolkit/keras/quantizer/gradient_ptq/config_factory.py
@@ -43,7 +43,8 @@ def quantization_config_builder_gptq(n: common.BaseNode,
         quantization configuration).
     """
 
-    if n.is_weights_quantization_enabled() and n.is_activation_quantization_enabled():
+    quantize_weights = n.is_weights_quantization_enabled() and n.has_weights_to_quantize(fw_info)
+    if quantize_weights and n.is_activation_quantization_enabled():
         qc = keras.quantizer.gradient_ptq.WeightQuantizeConfig(fw_info.get_kernel_op_attributes(n.type),
                                                                n.final_weights_quantization_cfg.weights_quantization_params.get(
                                                                    THRESHOLD),
@@ -51,9 +52,9 @@ def quantization_config_builder_gptq(n: common.BaseNode,
                                                                n.final_weights_quantization_cfg.weights_n_bits,
                                                                max_lsbs_change_map=gptq_config.lsb_change_per_bit_width)
         # Quantization is Preformed using fake quantization node
-    elif n.is_activation_quantization_enabled() and not n.is_weights_quantization_enabled():
+    elif n.is_activation_quantization_enabled() and not quantize_weights:
         qc = NoOpQuantizeConfig()  # Quantization is Preformed using fake quantization node
-    elif n.is_weights_quantization_enabled() and not n.is_activation_quantization_enabled():
+    elif quantize_weights and not n.is_activation_quantization_enabled():
         qc = keras.quantizer.gradient_ptq.WeightQuantizeConfig(fw_info.get_kernel_op_attributes(n.type),
                                                                n.final_weights_quantization_cfg.weights_quantization_params.get(
                                                                    THRESHOLD),
@@ -61,7 +62,7 @@ def quantization_config_builder_gptq(n: common.BaseNode,
                                                                n.final_weights_quantization_cfg.weights_n_bits,
                                                                max_lsbs_change_map=gptq_config.lsb_change_per_bit_width)
 
-    elif not n.is_weights_quantization_enabled() and not n.is_activation_quantization_enabled():
+    elif not quantize_weights and not n.is_activation_quantization_enabled():
         qc = NoOpQuantizeConfig()
 
     else:

--- a/model_compression_toolkit/pytorch/back2framework/model_builder.py
+++ b/model_compression_toolkit/pytorch/back2framework/model_builder.py
@@ -84,7 +84,7 @@ def run_operation(n: BaseNode,
         out_tensors_of_n = op_func(*input_tensors + op_call_args, **functional_kwargs)
 
     # Add a fake quant node if the node has an activation threshold.
-    if mode == ModelBuilderMode.QUANTIZED and n.is_activation_quantization_enabled() \
+    if mode == ModelBuilderMode.QUANTIZED and n.is_activation_quantization_enabled() and n.has_activation \
             and n.final_activation_quantization_cfg:
         out_tensors_of_n = n.final_activation_quantization_cfg.quantize_node_output(out_tensors_of_n)
 

--- a/model_compression_toolkit/pytorch/default_framework_info.py
+++ b/model_compression_toolkit/pytorch/default_framework_info.py
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import torch
-from torch.nn import Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, \
-    Sigmoid, Softplus, Softsign, Tanh
-from torch.nn.functional import hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, \
-    softplus, softsign
-from torch.nn import UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d
-from torch.nn.functional import upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d
-from torch.nn import Conv2d, ConvTranspose2d, Linear, BatchNorm2d
-from torch.nn import Dropout, Flatten
-from torch import add, multiply, mul, sub, flatten, reshape, split, unsqueeze, concat, cat,\
-    mean, dropout, sigmoid, tanh
-import operator
+from torch.nn import Hardsigmoid, ReLU, ReLU6, Softmax, Sigmoid
+from torch.nn.functional import hardsigmoid, relu, relu6, softmax
+from torch.nn import Conv2d, ConvTranspose2d, Linear
+from torch import sigmoid
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -35,30 +27,6 @@ from model_compression_toolkit.common.quantization.quantizers.uniform_quantizers
 from model_compression_toolkit.pytorch.constants import KERNEL
 from model_compression_toolkit.pytorch.quantizer.fake_quant_builder import power_of_two_quantization, \
     symmetric_quantization, uniform_quantization
-from model_compression_toolkit.pytorch.quantizer.fake_quant_builder import power_of_two_quantization
-from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder, ConstantHolder
-
-"""
-Division of Pytorch modules by how they should be quantized.
-KERNEL_OPS: Layers that their coefficients should be quantized.
-ACTIVATION: Layers that their activation should be quantized.
-NO_QUANTIZATION: Layers that should not be quantized.
-"""
-
-KERNEL_OPS = [Conv2d, Linear, ConvTranspose2d]
-
-NO_QUANTIZATION = [Dropout, Flatten, ConstantHolder] + \
-                  [dropout, flatten, split, operator.getitem, reshape, unsqueeze]
-
-ACTIVATION = [DummyPlaceHolder] + \
-    [Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, Sigmoid, Softplus, Softsign, Tanh] + \
-    [hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, sigmoid, softplus, softsign, tanh] + \
-    [torch.relu] + \
-    [UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d] + \
-    [upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d] + \
-    [add, sub, mul, multiply] + \
-    [operator.add, operator.sub, operator.mul] + \
-    [BatchNorm2d, concat, cat, mean]
 
 """
 Map each layer to a list of its' weights attributes that should get quantized.
@@ -121,10 +89,7 @@ Output channel index of the model's layers
 """
 OUTPUT_CHANNEL_INDEX = ChannelAxis.NCHW
 
-DEFAULT_PYTORCH_INFO = FrameworkInfo(KERNEL_OPS,
-                                     ACTIVATION,
-                                     NO_QUANTIZATION,
-                                     ACTIVATION_QUANTIZER_MAPPING,
+DEFAULT_PYTORCH_INFO = FrameworkInfo(ACTIVATION_QUANTIZER_MAPPING,
                                      WEIGHTS_QUANTIZER_MAPPING,
                                      DEFAULT_CHANNEL_AXIS_DICT,
                                      ACTIVATION2MINMAX,

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -180,6 +180,8 @@ if importlib.util.find_spec("torch") is not None:
 
          """
         if target_kpi is None:
+            # TODO: throw exception or fix such that the actual config would be base_config (requires fix
+            #   in set_node_quantization_config and in bit_width_setter)
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
                 f"base_config defined in the given hardware model...")

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -166,7 +166,7 @@ if importlib.util.find_spec("torch") is not None:
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
              Here, each layer can be quantized by 2, 4 or 8 bits:
 
-             >>> config = mct.MixedPrecisionQuantizationConfig(weights_n_bits=[4, 2, 8])
+             >>> config = mct.MixedPrecisionQuantizationConfig()
 
              Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias will not):
 
@@ -188,8 +188,7 @@ if importlib.util.find_spec("torch") is not None:
             quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
-                f"weights_n_bits={quant_config.weights_n_bits} "
-                f"and activation_n_bits={quant_config.activation_n_bits}...")
+                f"base_config defined in the given hardware model...")
             return pytorch_post_training_quantization(in_model,
                                                       representative_data_gen,
                                                       n_iter,

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -180,12 +180,6 @@ if importlib.util.find_spec("torch") is not None:
 
          """
         if target_kpi is None:
-            # Before starting non-mixed-precision process, we need to set only single bit width, so we take the best
-            # option which is the maximal number of bits.
-            single_bitwidth_candidate = quant_config.n_bits_candidates[0]
-            quant_config.weights_n_bits = [single_bitwidth_candidate[0]]
-            quant_config.activation_n_bits = [single_bitwidth_candidate[1]]
-            quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
                 f"base_config defined in the given hardware model...")

--- a/model_compression_toolkit/pytorch/reader/graph_builders.py
+++ b/model_compression_toolkit/pytorch/reader/graph_builders.py
@@ -75,6 +75,7 @@ def nodes_builder(model: GraphModule,
     for node in model.graph.nodes:
         # extract node type and framework attributes
         framework_attr = dict(node.kwargs)
+        node_has_activation = True
         if node.target in module_dict.keys():
             node_module = module_dict[node.target]
             node_type = type(node_module)
@@ -99,6 +100,7 @@ def nodes_builder(model: GraphModule,
                 raise Exception(f'Call method of type \'{node.target}\' is currently not supported.')
         elif node.op == GET_ATTR:
             node_type = ConstantHolder
+            node_has_activation = False
             common.Logger.warning(
                 'Pytorch model has a parameter or constant Tensor value. This can cause unexpected behaviour when '
                 'converting the model.')
@@ -176,6 +178,7 @@ def nodes_builder(model: GraphModule,
                                      output_shape=output_shape,
                                      weights=weights,
                                      layer_class=node_type,
+                                     has_activation=node_has_activation,
                                      **kwargs)
 
         # generate graph inputs list

--- a/tests/common_tests/base_layer_test.py
+++ b/tests/common_tests/base_layer_test.py
@@ -50,15 +50,7 @@ class BaseLayerTest(BaseTest):
         return self.layers
 
     def get_fw_hw_model(self):
-        if self.current_mode == LayerTestMode.FLOAT:
-            # Disable all features that are enabled by default:
-            hwm = generate_default_hardware_model(enable_weights_quantization=False,
-                                                  enable_activation_quantization=False)
-            return generate_fhw_model_keras(name="base_layer_test", hardware_model=hwm)
-        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
-            return get_default_hwm_keras()
-        else:
-            raise NotImplemented
+        raise NotImplemented
 
     def get_quantization_config(self):
         qc = copy.deepcopy(DEFAULTCONFIG)

--- a/tests/common_tests/base_layer_test.py
+++ b/tests/common_tests/base_layer_test.py
@@ -54,7 +54,7 @@ class BaseLayerTest(BaseTest):
             # Disable all features that are enabled by default:
             hwm = generate_default_hardware_model(enable_weights_quantization=False,
                                                   enable_activation_quantization=False)
-            return generate_fhw_model_keras(name="bn_folding_test", hardware_model=hwm)
+            return generate_fhw_model_keras(name="base_layer_test", hardware_model=hwm)
         elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
             return get_default_hwm_keras()
         else:

--- a/tests/common_tests/test_hardware_model.py
+++ b/tests/common_tests/test_hardware_model.py
@@ -28,7 +28,12 @@ TEST_QC = hwm.OpQuantizationConfig(enable_activation_quantization=True,
                                    weights_n_bits=8,
                                    weights_per_channel_threshold=True,
                                    activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-                                   weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO)
+                                   weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                   quantization_preserving=False,
+                                   fixed_scale=None,
+                                   fixed_zero_point=None,
+                                   weights_multiplier_nbits=None
+                                   )
 TEST_QCO = hwm.QuantizationConfigOptions([TEST_QC])
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -17,6 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.constants import ACTIVATION, LINEAR
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
@@ -24,6 +26,7 @@ import model_compression_toolkit as mct
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
 
 class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
@@ -31,8 +34,13 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
         self.activation_function = activation_function
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(enable_activation_quantization=False,
+                                              enable_weights_quantization=False)
+        return generate_fhw_model_keras(name="activation_decomposition_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -16,6 +16,8 @@
 
 from abc import ABC
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
@@ -27,17 +29,23 @@ from tests.common_tests.helpers.tensors_compare import cosine_similarity
 
 keras = tf.keras
 layers = keras.layers
-
+hw_model = mct.hardware_representation
 
 class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
 
     def __init__(self, unit_test):
         super(BaseBatchNormalizationFolding, self).__init__(unit_test=unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16,
+                                              enable_weights_quantization=False,
+                                              enable_activation_quantization=False)
+        return generate_fhw_model_keras(name="bn_folding_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,16, 16,
-                                      False, False, True, enable_weights_quantization=False,
-                                      enable_activation_quantization=False)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
+                                      False, False, True)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         y = float_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
@@ -18,6 +18,8 @@ import tensorflow as tf
 import model_compression_toolkit as mct
 import model_compression_toolkit.common.gptq.gptq_config
 from model_compression_toolkit.common.user_info import UserInformation
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.gradient_ptq.gptq_loss import multiple_tensors_mse_loss
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -25,6 +27,7 @@ from tests.keras_tests.feature_networks_tests.base_keras_feature_test import Bas
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
 
 class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
@@ -32,10 +35,14 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(1,16,16,3))
 
-    def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,16, 16,
-                                      True, False, True)
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(activation_n_bits=16,
+                                              weights_n_bits=16)
+        return generate_fhw_model_keras(name="gptq_test", hardware_model=hwm)
 
+    def get_quantization_config(self):
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
+                                      True, False, True)
 
     def get_gptq_config(self):
         return model_compression_toolkit.common.gptq.gptq_config.GradientPTQConfig(5,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
@@ -73,17 +73,20 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
         model_float = self.create_networks()
 
         qc = self.get_quantization_config()
+        fw_hw_model = self.get_fw_hw_model()
         ptq_model, quantization_info = mct.keras_post_training_quantization(model_float, representative_data_gen,
                                                                             n_iter=self.num_calibration_iter,
                                                                             quant_config=qc,
                                                                             fw_info=DEFAULT_KERAS_INFO,
-                                                                            network_editor=self.get_network_editor())
+                                                                            network_editor=self.get_network_editor(),
+                                                                            fw_hw_model=fw_hw_model)
         ptq_gptq_model, quantization_info = mct.keras_post_training_quantization(model_float, representative_data_gen,
                                                                                  n_iter=self.num_calibration_iter,
                                                                                  quant_config=qc,
                                                                                  fw_info=DEFAULT_KERAS_INFO,
                                                                                  network_editor=self.get_network_editor(),
-                                                                                 gptq_config=self.get_gptq_config())
+                                                                                 gptq_config=self.get_gptq_config(),
+                                                                                 fw_hw_model=fw_hw_model)
 
         self.compare(ptq_model, ptq_gptq_model, input_x=x, quantization_info=quantization_info)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
@@ -14,22 +14,31 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import \
+    generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import get_default_hwm_keras, \
+    generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.keras.back2framework.model_builder import is_layer_fake_quant
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
 
 class BaseInputScalingTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(activation_n_bits=16,
+                                              weights_n_bits=16)
+        return generate_fhw_model_keras(name="input_scaling_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
-                                      mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
                                       input_scaling=True)
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -23,6 +23,8 @@ import model_compression_toolkit as cmo
 import tensorflow as tf
 import numpy as np
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
 keras = tf.keras
@@ -49,22 +51,21 @@ class LUTQuantizerTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
 
-
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions([hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                                                      weights_quantization_method=hw_model.QuantizationMethod.LUT_QUANTIZER,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_default_hardware_model(
+            activation_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
+            weights_quantization_method=hw_model.QuantizationMethod.LUT_QUANTIZER,
+            weights_n_bits=2,
+            activation_n_bits=4,
+            weights_per_channel_threshold=True,
+            enable_weights_quantization=True,
+            enable_activation_quantization=True
+        )
+        return generate_fhw_model_keras(name="lut_quantizer_test", hardware_model=hwm)
 
     def get_quantization_config(self):
         return cmo.QuantizationConfig(cmo.QuantizationErrorMethod.MSE,
                                       cmo.QuantizationErrorMethod.MSE,
-                                      4,
-                                      2,
                                       False,
                                       False,
                                       True)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
 import model_compression_toolkit as mct
@@ -44,9 +44,13 @@ class MultiHeadAttentionTest(BaseKerasFeatureNetworkTest):
         self.separate_key_value = separate_key_value
         self.output_dim = output_dim
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(enable_weights_quantization=False,
+                                              enable_activation_quantization=False)
+        return generate_fhw_model_keras(name="mha_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return QuantizationConfig(enable_weights_quantization=False,
-                                  enable_activation_quantization=False)
+        return QuantizationConfig()
 
     def get_input_shapes(self):
         if self.separate_key_value:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -26,9 +29,14 @@ class MultiInputsToNodeTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="multi_input_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
-                                      True, True, True, input_scaling=True)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, True, True,
+                                      True, input_scaling=True)
 
     def get_input_shapes(self):
         return [[self.val_batch_size, 224, 224, 3]]

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
@@ -27,9 +29,13 @@ class MultipleInputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="multiple_input_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       True, False, True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
@@ -29,9 +29,13 @@ class MultipleOutputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(enable_weights_quantization=False,
+                                              enable_activation_quantization=False)
+        return generate_fhw_model_keras(name="multiple_output_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_activation_quantization=False,
-                                      enable_weights_quantization=False)
+        return mct.QuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -16,6 +16,9 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -35,9 +38,15 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="nested_multiple_input_test", hardware_model=hwm)
+
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
-                                      True, True, True)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, True, True,
+                                      True)
 
     def get_input_shapes(self):
         return [[self.val_batch_size, 236, 236, 3]]

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -17,6 +17,9 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -35,13 +38,13 @@ class NestedModelMultipleOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, val_batch_size=10)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="nested_multiple_output_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
-                                      mct.QuantizationErrorMethod.MSE,
-                                      16,
-                                      16,
-                                      True,
-                                      True,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, True, True,
                                       True)
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -15,6 +15,10 @@
 
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -36,8 +40,13 @@ class NestedModelUnusedInputsOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(enable_weights_quantization=False,
+                                              enable_activation_quantization=False)
+        return generate_fhw_model_keras(name="nested_unused_input_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     def inner_functional_model(self, input_shape):
         inputs = layers.Input(shape=input_shape[1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -37,8 +41,13 @@ class NestedTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(enable_weights_quantization=False,
+                                              enable_activation_quantization=False)
+        return generate_fhw_model_keras(name="nested_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     # Dummy model to test reader's recursively model parsing
     def dummy_model(self, input_shape):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
@@ -18,6 +18,9 @@ from model_compression_toolkit.common.quantization.quantization_params_fn_select
 
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.common.network_editors.node_filters import NodeNameFilter, NodeNameScopeFilter, \
@@ -52,9 +55,14 @@ class ScopeFilterTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="scope_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
-                                      False, False, True)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, False, False,
+                                      True)
 
     def get_network_editor(self):
         # first rule is to check that the scope filter catches the 2 convs with
@@ -123,9 +131,14 @@ class NameFilterTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="name_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
-                                      False, False, True)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, False, False,
+                                      True)
 
     def get_network_editor(self):
         return [EditRule(filter=NodeNameFilter(self.node_to_change_name),
@@ -183,9 +196,14 @@ class TypeFilterTest(BaseKerasFeatureNetworkTest):
             hw_model.QuantizationMethod.POWER_OF_TWO,
             mct.QuantizationErrorMethod.NOCLIPPING)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="type_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
-                                      False, False, False)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, False, False,
+                                      False)
 
     def get_network_editor(self):
         return [EditRule(filter=NodeTypeFilter(self.type_to_change),
@@ -250,10 +268,7 @@ class FilterLogicTest(BaseKerasFeatureNetworkTest):
             cmo.QuantizationErrorMethod.NOCLIPPING)
 
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                      model_compression_toolkit.hardware_model.op_quantization_config
-                                      .QuantizationMethod.POWER_OF_TWO, model_compression_toolkit.hardware_model.op_quantization_config.QuantizationMethod.POWER_OF_TWO, 16, 16,
-                                      False, False, False)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, False, False)
 
     def get_network_editor(self):
         return [(NodeTypeFilter(self.type_to_change),

--- a/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -26,9 +29,13 @@ class RemoveUpperBoundTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, num_calibration_iter=1, val_batch_size=32)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="remove_upper_bound_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       False, False, False)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
@@ -32,11 +32,11 @@ class ReusedLayerMixedPrecisionTest(BaseKerasFeatureNetworkTest):
 
     def get_quantization_config(self):
         qc = mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                    activation_n_bits=16, relu_bound_to_power_of_2=True, weights_bias_correction=True,
+                                    relu_bound_to_power_of_2=True, weights_bias_correction=True,
                                     weights_per_channel_threshold=True, input_scaling=True,
                                     activation_channel_equalization=True)
 
-        return MixedPrecisionQuantizationConfig(qc, n_bits_candidates=[(2, 16), (16, 16), (4, 16)])
+        return MixedPrecisionQuantizationConfig(qc)
 
     def create_networks(self):
         layer = layers.Conv2D(3, 4)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
@@ -17,6 +17,8 @@
 import numpy as np
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
 import model_compression_toolkit as mct
@@ -34,9 +36,13 @@ class ScaleEqualizationTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="scale_equalization_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                      16, 16,
                                       relu_bound_to_power_of_2=False, weights_bias_correction=False,
                                       weights_per_channel_threshold=True, activation_channel_equalization=True)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
 else:
@@ -36,10 +40,14 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
         self.bypass_op_list = bypass_op_list
         super().__init__(unit_test, input_shape=input_shape, num_calibration_iter=100)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="shift_neg_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
-                                      False, False, True, shift_negative_activation_correction=True,
-                                      shift_negative_ratio=np.inf)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, False, False,
+                                      True, shift_negative_activation_correction=True, shift_negative_ratio=np.inf)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/slicing_op_lambda_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/slicing_op_lambda_test.py
@@ -15,6 +15,9 @@
 import tensorflow as tf
 
 import model_compression_toolkit.hardware_representation.op_quantization_config
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
 if tf.__version__ < "2.6":
@@ -36,10 +39,14 @@ class SlicingOpLambdaTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, val_batch_size=1)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="slicing_op_lambda_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                      model_compression_toolkit.hardware_model.op_quantization_config.QuantizationMethod.POWER_OF_TWO, model_compression_toolkit.hardware_model.op_quantization_config.QuantizationMethod.POWER_OF_TWO, 16, 16,
-                                      False, False, True)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, False,
+                                      False)
 
 
     def create_networks(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
@@ -27,11 +29,14 @@ class SplitConvBugTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="split_conv_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
-                                      mct.QuantizationErrorMethod.MSE,
-                                      16, 16,
-                                      True, True, True, input_scaling=True)
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, True, True,
+                                      True, input_scaling=True)
 
     def get_input_shapes(self):
         return [[self.val_batch_size, 224, 224, 3]]

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -17,6 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as cmo
 
@@ -33,19 +35,13 @@ class SymmetricThresholdSelectionActivationTest(BaseKerasFeatureNetworkTest):
     def generate_inputs(self):
         return [np.random.uniform(low=-7, high=7, size=in_shape) for in_shape in self.get_input_shapes()]
 
-    def get_quantization_config(self):
-        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method,
-                                      activation_n_bits=8)
-
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions([hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
-                                                                      weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_default_hardware_model(activation_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
+                                              activation_n_bits=8)
+        return generate_fhw_model_keras(name="symmetric_threshold_test", hardware_model=hwm)
+
+    def get_quantization_config(self):
+        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/tanh_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/tanh_activation_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import model_compression_toolkit.hardware_representation.op_quantization_config
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
@@ -28,12 +30,14 @@ class TanhActivationTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
-    def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                      model_compression_toolkit.hardware_model.op_quantization_config
-                                      .QuantizationMethod.POWER_OF_TWO, model_compression_toolkit.hardware_model.op_quantization_config.QuantizationMethod.POWER_OF_TWO, 16, 16,
-                                      True, True, True)
+    def get_fw_hw_model(self):
+        hwm = generate_default_hardware_model(weights_n_bits=16,
+                                              activation_n_bits=16)
+        return generate_fhw_model_keras(name="tanh_activation_test", hardware_model=hwm)
 
+    def get_quantization_config(self):
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE, True,
+                                      True)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -20,6 +20,9 @@ from model_compression_toolkit.common.network_editors.node_filters import NodeNa
 from model_compression_toolkit.common.network_editors.actions import EditRule, ChangeCandidatesWeightsQuantConfigAttr
 import model_compression_toolkit as cmo
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 
@@ -58,22 +61,15 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
 
     def get_fw_hw_model(self):
-        qco = hardware_representation.QuantizationConfigOptions([hardware_representation.OpQuantizationConfig(activation_quantization_method=hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                                                                      weights_quantization_method=self.quantization_method,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
-        return hardware_representation.FrameworkHardwareModel(hardware_representation.HardwareModel(qco))
+        hwm = generate_default_hardware_model(
+            activation_quantization_method=hardware_representation.QuantizationMethod.POWER_OF_TWO,
+            weights_quantization_method=self.quantization_method,
+            weights_n_bits=self.weights_n_bits,
+            activation_n_bits=4)
+        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
 
     def get_quantization_config(self):
-        return cmo.QuantizationConfig(cmo.QuantizationErrorMethod.MSE,
-                                      cmo.QuantizationErrorMethod.MSE,
-                                      4,
-                                      self.weights_n_bits,
-                                      False,
-                                      False,
+        return cmo.QuantizationConfig(cmo.QuantizationErrorMethod.MSE, cmo.QuantizationErrorMethod.MSE, False, False,
                                       True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -17,7 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
-
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as cmo
 
@@ -33,19 +34,13 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
     def generate_inputs(self):
         return [np.random.uniform(low=-7, high=7, size=in_shape) for in_shape in self.get_input_shapes()]
 
-    def get_quantization_config(self):
-        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method,
-                                      activation_n_bits=8)
-
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions([hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
-                                                                      weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_default_hardware_model(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
+                                              activation_n_bits=8)
+        return generate_fhw_model_keras(name="uniform_range_test", hardware_model=hwm)
+
+    def get_quantization_config(self):
+        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/test_networks_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_networks_runner.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 import model_compression_toolkit.common.gptq.gptq_config
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 import tensorflow as tf
 import numpy as np
@@ -25,21 +27,24 @@ import random
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
-TWO_BIT_QUANTIZATION = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
-                                              weights_error_method=mct.QuantizationErrorMethod.MSE,
-                                              activation_n_bits=2, weights_n_bits=2, relu_bound_to_power_of_2=False,
-                                              weights_bias_correction=False, weights_per_channel_threshold=True)
+QUANTIZATION_CONFIG = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
+                                             weights_error_method=mct.QuantizationErrorMethod.MSE,
+                                             relu_bound_to_power_of_2=False, weights_bias_correction=False,
+                                             weights_per_channel_threshold=True)
 
-EIGHT_BIT_QUANTIZATION = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
-                                                weights_error_method=mct.QuantizationErrorMethod.MSE,
-                                                activation_n_bits=8, weights_n_bits=8, relu_bound_to_power_of_2=False,
-                                                weights_bias_correction=False, weights_per_channel_threshold=True)
+TWO_BIT_QUANTIZATION = generate_fhw_model_keras(name="two_bit_network_test",
+                                                hardware_model=generate_default_hardware_model(weights_n_bits=2,
+                                                                                               activation_n_bits=2))
 
-FLOAT_QUANTIZATION = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
-                                            weights_error_method=mct.QuantizationErrorMethod.MSE,
-                                            activation_n_bits=16, weights_n_bits=16, relu_bound_to_power_of_2=False,
-                                            weights_bias_correction=False, weights_per_channel_threshold=True)
+EIGHT_BIT_QUANTIZATION = generate_fhw_model_keras(name="eight_bit_network_test",
+                                                  hardware_model=generate_default_hardware_model(weights_n_bits=8,
+                                                                                                 activation_n_bits=8))
+
+FLOAT_QUANTIZATION = generate_fhw_model_keras(name="float_network_test",
+                                              hardware_model=generate_default_hardware_model(weights_n_bits=16,
+                                                                                             activation_n_bits=16))
 
 
 class RunMode(Enum):
@@ -48,10 +53,10 @@ class RunMode(Enum):
     FLOAT = 2
 
 
-def run_mode(qc):
-    if qc is FLOAT_QUANTIZATION:
+def run_mode(fwhm):
+    if fwhm is FLOAT_QUANTIZATION:
         return RunMode.FLOAT
-    elif qc is EIGHT_BIT_QUANTIZATION:
+    elif fwhm is EIGHT_BIT_QUANTIZATION:
         return RunMode.EIGHT
     else:
         return RunMode.TWO
@@ -65,21 +70,21 @@ class NetworkTest(object):
         self.num_calibration_iter = num_calibration_iter
         self.gptq = gptq
 
-    def compare(self, inputs_list, quantized_model, qc):
+    def compare(self, inputs_list, quantized_model, qc, fwhm):
         output_q = quantized_model.predict(inputs_list)
         output_f = self.model_float.predict(inputs_list)
         if isinstance(output_f, list):
             cs = np.mean([cosine_similarity(oq, of) for oq, of, in zip(output_q, output_f)])
         else:
             cs = cosine_similarity(output_f, output_q)
-        if run_mode(qc) == RunMode.FLOAT:
+        if run_mode(fwhm) == RunMode.FLOAT:
             self.unit_test.assertTrue(np.isclose(cs, 1, 0.001), msg=f'fail cosine similarity check: {cs}')
-        elif run_mode(qc) == RunMode.EIGHT:
+        elif run_mode(fwhm) == RunMode.EIGHT:
             pass  # remove the cs check for 8 bit quantizaiton at this stage
             # self.unit_test.assertTrue(np.isclose(cs, 1, atol=0.6), msg=f'fail cosine similarity check:{cs}')
-        elif run_mode(qc) == RunMode.TWO:
+        elif run_mode(fwhm) == RunMode.TWO:
             self.unit_test.assertTrue(np.isclose(cs, 0, atol=0.5), msg=f'fail cosine similarity check:{cs}')
-        if run_mode(qc) == RunMode.EIGHT:
+        if run_mode(fwhm) == RunMode.EIGHT:
             # TFLite Converter only support eight bit quantization
             try:
                 converter = tf.lite.TFLiteConverter.from_keras_model(quantized_model)
@@ -88,7 +93,7 @@ class NetworkTest(object):
                 error_msg = e.message if hasattr(e, 'message') else str(e)
                 self.unit_test.assertTrue(False, f'fail TFLite convertion with the following error: {error_msg}')
 
-    def run_network(self, inputs_list, qc):
+    def run_network(self, inputs_list, qc, fwhm):
         def representative_data_gen():
             return inputs_list
 
@@ -102,14 +107,16 @@ class NetworkTest(object):
                                                                                 quant_config=qc,
                                                                                 fw_info=DEFAULT_KERAS_INFO,
                                                                                 n_iter=self.num_calibration_iter,
-                                                                                gptq_config=arc)
+                                                                                gptq_config=arc,
+                                                                                fw_hw_model=fwhm)
         else:
             ptq_model, quantization_info = mct.keras_post_training_quantization(self.model_float,
                                                                                 representative_data_gen,
                                                                                 quant_config=qc,
                                                                                 fw_info=DEFAULT_KERAS_INFO,
-                                                                                n_iter=self.num_calibration_iter)
-        self.compare(inputs_list, ptq_model, qc)
+                                                                                n_iter=self.num_calibration_iter,
+                                                                                fw_hw_model=fwhm)
+        self.compare(inputs_list, ptq_model, qc, fwhm)
 
 
 def set_seed():
@@ -133,11 +140,15 @@ class FeatureNetworkTest(unittest.TestCase):
         inputs_list = FeatureNetworkTest.create_inputs(input_shapes)
 
         NetworkTest(self, model_float, input_shapes, num_calibration_iter, gptq=gptq).run_network(inputs_list,
+                                                                                                  QUANTIZATION_CONFIG,
                                                                                                   EIGHT_BIT_QUANTIZATION)
         if not gptq:
             NetworkTest(self, model_float, input_shapes, num_calibration_iter, gptq=gptq).run_network(inputs_list,
+                                                                                                      QUANTIZATION_CONFIG,
                                                                                                       TWO_BIT_QUANTIZATION)
+
             NetworkTest(self, model_float, input_shapes, num_calibration_iter, gptq=gptq).run_network(inputs_list,
+                                                                                                      QUANTIZATION_CONFIG,
                                                                                                       FLOAT_QUANTIZATION)
 
     def test_mobilenet_v1(self):

--- a/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 import unittest
 import numpy as np
@@ -19,7 +21,6 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 from tensorflow.keras import layers
 import itertools
-from model_compression_toolkit import hardware_representation as hwm
 
 def model_gen():
     inputs = layers.Input(shape=[4, 4, 3])
@@ -36,9 +37,9 @@ class TestQuantizationConfigurations(unittest.TestCase):
         def representative_data_gen():
             return [x]
 
-        quantizer_methods = [hwm.QuantizationMethod.POWER_OF_TWO,
-                             hwm.QuantizationMethod.SYMMETRIC,
-                             hwm.QuantizationMethod.UNIFORM]
+        quantizer_methods = [mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
+                             mct.hardware_representation.QuantizationMethod.SYMMETRIC,
+                             mct.hardware_representation.QuantizationMethod.UNIFORM]
 
         quantization_error_methods = [mct.QuantizationErrorMethod.KL]
         relu_bound_to_power_of_2 = [True, False]
@@ -52,23 +53,16 @@ class TestQuantizationConfigurations(unittest.TestCase):
 
         model = model_gen()
         for quantize_method, error_method, per_channel in weights_test_combinations:
-            default_op_cfg = hwm.OpQuantizationConfig(activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-                                                    weights_quantization_method=quantize_method,
-                                                    activation_n_bits=16,
-                                                    weights_n_bits=8,
-                                                    enable_weights_quantization=True,
-                                                    enable_activation_quantization=True,
-                                                    weights_per_channel_threshold=per_channel)
-
-            hw_model = hwm.FrameworkHardwareModel(hwm.HardwareModel(hwm.QuantizationConfigOptions([default_op_cfg])))
+            hwm = generate_default_hardware_model(weights_quantization_method=quantize_method,
+                                                  activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
+                                                  weights_n_bits=8,
+                                                  activation_n_bits=16,
+                                                  weights_per_channel_threshold=per_channel)
+            fw_hw_model = generate_fhw_model_keras(name="kl_quant_config_weights_test", hardware_model=hwm)
 
             qc = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.NOCLIPPING,
-                                        weights_error_method=error_method,
-                                        activation_n_bits=16,
-                                        weights_n_bits=8,
-                                        relu_bound_to_power_of_2=False,
-                                        weights_bias_correction=True,
-                                        weights_per_channel_threshold=per_channel,
+                                        weights_error_method=error_method, relu_bound_to_power_of_2=False,
+                                        weights_bias_correction=True, weights_per_channel_threshold=per_channel,
                                         input_scaling=False)
 
             q_model, quantization_info = mct.keras_post_training_quantization(model,
@@ -76,32 +70,28 @@ class TestQuantizationConfigurations(unittest.TestCase):
                                                                               n_iter=1,
                                                                               quant_config=qc,
                                                                               fw_info=DEFAULT_KERAS_INFO,
-                                                                              fw_hw_model=hw_model)
+                                                                              fw_hw_model=fw_hw_model)
 
         model = model_gen()
         for quantize_method, error_method, relu_bound_to_power_of_2 in activation_test_combinations:
-            default_op_cfg = hwm.OpQuantizationConfig(activation_quantization_method=quantize_method,
-                                                weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-                                                activation_n_bits=8,
-                                                weights_n_bits=8,
-                                                enable_weights_quantization=False,
-                                                enable_activation_quantization=True,
-                                                weights_per_channel_threshold=True)
-
-            hw_model = hwm.FrameworkHardwareModel(hwm.HardwareModel(hwm.QuantizationConfigOptions([default_op_cfg])))
+            hwm = generate_default_hardware_model(weights_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
+                                                  activation_quantization_method=quantize_method,
+                                                  weights_n_bits=8,
+                                                  activation_n_bits=8,
+                                                  enable_weights_quantization=False,
+                                                  enable_activation_quantization=True)
+            fw_hw_model = generate_fhw_model_keras(name="kl_quant_config_activation_test", hardware_model=hwm)
 
             qc = mct.QuantizationConfig(activation_error_method=error_method,
-                                        activation_n_bits=8,
                                         relu_bound_to_power_of_2=relu_bound_to_power_of_2,
-                                        shift_negative_activation_correction=False,
-                                        enable_weights_quantization=False)
+                                        shift_negative_activation_correction=False)
 
             q_model, quantization_info = mct.keras_post_training_quantization(model,
                                                                               representative_data_gen,
                                                                               n_iter=1,
                                                                               quant_config=qc,
                                                                               fw_info=DEFAULT_KERAS_INFO,
-                                                                              fw_hw_model=hw_model)
+                                                                              fw_hw_model=fw_hw_model)
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
@@ -31,6 +31,8 @@ from model_compression_toolkit.common.quantization.quantization_params_generatio
 from model_compression_toolkit.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
 from model_compression_toolkit.common.model_collector import ModelCollector
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
 
@@ -88,26 +90,20 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
         self.run_test_for_threshold_method(QuantizationErrorMethod.KL, per_channel=False)
 
     def run_test_for_threshold_method(self, threshold_method, per_channel=True):
-        qc = QuantizationConfig(weights_error_method=threshold_method,
-                                weights_n_bits=8,
-                                weights_per_channel_threshold=per_channel)
+        qc = QuantizationConfig(weights_error_method=threshold_method, weights_per_channel_threshold=per_channel)
 
-        qco = mct.hardware_representation.QuantizationConfigOptions(
-            [mct.hardware_representation.OpQuantizationConfig(
-                activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                weights_quantization_method=mct.hardware_representation.QuantizationMethod.UNIFORM,
-                activation_n_bits=8,
-                weights_n_bits=8,
-                weights_per_channel_threshold=True,
-                enable_weights_quantization=True,
-                enable_activation_quantization=True)])
-        hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
+        hwm = generate_default_hardware_model(
+            weights_quantization_method=mct.hardware_representation.QuantizationMethod.UNIFORM,
+            activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
+            weights_n_bits=8,
+            activation_n_bits=8)
+        fw_hw_model = generate_fhw_model_keras(name="uniform_range_selection_test", hardware_model=hwm)
 
         fw_info = DEFAULT_KERAS_INFO
         in_model = create_network()
         keras_impl = KerasImplementation()
         graph = keras_impl.model_reader(in_model, None)  # model reading
-        graph.set_fw_hw_model(hw_model)
+        graph.set_fw_hw_model(fw_hw_model)
         graph.set_fw_info(fw_info)
         graph = set_quantization_configuration_to_graph(graph=graph,
                                                         quant_config=qc)

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -145,6 +145,7 @@ class BasePytorchLayerTest(BaseLayerTest):
                 continue
             if hasattr(quantized_model, str(node.target)):
                 if type(op) in fw_info.kernel_ops:
+                # if node.is_weights_quantization_enabled():
                     quantized_weights = get_layer_weights(getattr(quantized_model, node.target))
                     float_weights = get_layer_weights(getattr(float_model, node.target))
                     for k, v in quantized_weights.items():
@@ -158,6 +159,7 @@ class BasePytorchLayerTest(BaseLayerTest):
                     self.unit_test.assertTrue(is_node_fake_quant(node_next))
 
             elif op in fw_info.activation_ops:
+            # elif node.is_activation_quantization_enabled():
                 node_next = node.next
                 while get_node_operation(node_next, quantized_model) == operator.getitem:
                     node_next = node_next.next

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -16,17 +16,49 @@ import operator
 from typing import List, Any, Tuple
 import numpy as np
 import torch
+from torch.nn import Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, \
+    Sigmoid, Softplus, Softsign, Tanh
+from torch.nn.functional import hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, \
+    softplus, softsign
+from torch.nn import UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d
+from torch.nn.functional import upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d
+from torch.nn import Conv2d, ConvTranspose2d, Linear, BatchNorm2d
+from torch.nn import Dropout, Flatten
+from torch import add, multiply, mul, sub, flatten, reshape, split, unsqueeze, concat, cat,\
+    mean, dropout, sigmoid, tanh
 from torch.fx import symbolic_trace
 from torch.nn import Module
 
 from model_compression_toolkit import FrameworkInfo, pytorch_post_training_quantization
 from model_compression_toolkit.common.framework_implementation import FrameworkImplementation
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import get_default_hwm_pytorch
 from model_compression_toolkit.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
-from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder
 from model_compression_toolkit.pytorch.utils import torch_tensor_to_numpy, to_torch_tensor
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode
 from model_compression_toolkit.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.pytorch.pytorch_implementation import PytorchImplementation
+from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder, ConstantHolder
+
+PYTORCH_LAYER_TEST_OPS = {
+    "kernel_ops": [Conv2d, Linear, ConvTranspose2d],
+
+    "no_quantization": [Dropout, Flatten, ConstantHolder, dropout, flatten, split, operator.getitem, reshape,
+                        unsqueeze],
+
+    "activation": [DummyPlaceHolder,
+                   Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax,
+                   Sigmoid, Softplus, Softsign, Tanh, hardswish, hardsigmoid, relu, hardtanh,
+                   relu6, leaky_relu, prelu,
+                   silu, softmax, sigmoid, softplus, softsign, tanh, torch.relu,
+                   UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d,
+                   upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d,
+                   add, sub, mul, multiply,
+                   operator.add, operator.sub, operator.mul,
+                   BatchNorm2d, concat, cat, mean]
+}
+
 
 class LayerTestModel(torch.nn.Module):
     def __init__(self, layer):
@@ -100,6 +132,17 @@ class BasePytorchLayerTest(BaseLayerTest):
                          is_inputs_a_list=is_inputs_a_list,
                          use_cpu=use_cpu)
 
+    def get_fw_hw_model(self):
+        if self.current_mode == LayerTestMode.FLOAT:
+            # Disable all features that are enabled by default:
+            hwm = generate_default_hardware_model(enable_weights_quantization=False,
+                                                  enable_activation_quantization=False)
+            return generate_fhw_model_keras(name="base_torch_layer_test", hardware_model=hwm)
+        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
+            return get_default_hwm_pytorch()
+        else:
+            raise NotImplemented
+
     def get_fw_info(self) -> FrameworkInfo:
         return DEFAULT_PYTORCH_INFO
 
@@ -144,8 +187,7 @@ class BasePytorchLayerTest(BaseLayerTest):
             if op == OUTPUT or op == operator.getitem or is_node_fake_quant(node):
                 continue
             if hasattr(quantized_model, str(node.target)):
-                if type(op) in fw_info.kernel_ops:
-                # if node.is_weights_quantization_enabled():
+                if type(op) in PYTORCH_LAYER_TEST_OPS['kernel_ops']:
                     quantized_weights = get_layer_weights(getattr(quantized_model, node.target))
                     float_weights = get_layer_weights(getattr(float_model, node.target))
                     for k, v in quantized_weights.items():
@@ -158,14 +200,13 @@ class BasePytorchLayerTest(BaseLayerTest):
                         node_next = node_next.next
                     self.unit_test.assertTrue(is_node_fake_quant(node_next))
 
-            elif op in fw_info.activation_ops:
-            # elif node.is_activation_quantization_enabled():
+            elif op in PYTORCH_LAYER_TEST_OPS['activation']:
                 node_next = node.next
                 while get_node_operation(node_next, quantized_model) == operator.getitem:
                     node_next = node_next.next
                 self.unit_test.assertTrue(is_node_fake_quant(node_next))
 
-            elif op in fw_info.no_quantization_ops:
+            elif op in PYTORCH_LAYER_TEST_OPS['no_quantization']:
                 node_next = node.next
                 while get_node_operation(node_next, quantized_model) == operator.getitem:
                     node_next = node_next.next

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -44,13 +44,13 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                                                               activation_n_bits=32,
                                                               enable_weights_quantization=False,
                                                               enable_activation_quantization=False)),
-            'all_32bit': generate_fhw_model_pytorch(name="no_quant_pytorch_test",
+            'all_32bit': generate_fhw_model_pytorch(name="32_quant_pytorch_test",
                                                     hardware_model=generate_default_hardware_model(
                                                         weights_n_bits=32,
                                                         activation_n_bits=32,
                                                         enable_weights_quantization=True,
                                                         enable_activation_quantization=True)),
-            'all_4bit': generate_fhw_model_pytorch(name="no_quant_pytorch_test",
+            'all_4bit': generate_fhw_model_pytorch(name="4_quant_pytorch_test",
                                                    hardware_model=generate_default_hardware_model(
                                                        weights_n_bits=4,
                                                        activation_n_bits=4,

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -37,20 +37,11 @@ class BasePytorchTest(BaseFeatureNetworkTest):
     def get_quantization_configs(self):
         return {
             'no_quantization': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
-                                                      mct.QuantizationErrorMethod.NOCLIPPING,
-                                                      32, 32, False, True, True,
-                                                      enable_weights_quantization=False,
-                                                      enable_activation_quantization=False),
+                                                      mct.QuantizationErrorMethod.NOCLIPPING, False, True, True),
             'all_32bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
-                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                                32, 32, False, True, True,
-                                                enable_weights_quantization=True,
-                                                enable_activation_quantization=True),
+                                                mct.QuantizationErrorMethod.NOCLIPPING, False, True, True),
             'all_4bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
-                                               mct.QuantizationErrorMethod.NOCLIPPING,
-                                               4, 4, False, False, True,
-                                               enable_weights_quantization=True,
-                                               enable_activation_quantization=True),
+                                               mct.QuantizationErrorMethod.NOCLIPPING, False, False, True),
         }
 
     def create_inputs_shape(self):

--- a/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
@@ -77,9 +77,7 @@ class LUTQuantizerTest(BasePytorchTest):
 
     def get_quantization_configs(self):
         return {'lut_quantizer_test': mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
-                                                             mct.QuantizationErrorMethod.MSE,
-                                                             8,
-                                                             self.weights_n_bits)}
+                                                             mct.QuantizationErrorMethod.MSE)}
 
     def get_network_editor(self):
         return [EditRule(filter=NodeNameFilter(self.node_to_change_name),

--- a/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
@@ -18,6 +18,8 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.common.network_editors.node_filters import NodeNameFilter
 from model_compression_toolkit.common.network_editors.actions import EditRule, \
     ChangeCandidatesWeightsQuantizationMethod
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 
@@ -74,6 +76,14 @@ class LUTQuantizerTest(BasePytorchTest):
         self.node_to_change_name = 'conv1'
         self.num_conv_channels = 3
         self.kernel = 3
+
+    def get_fw_hw_model(self):
+        return {
+            'lut_quantizer_test': generate_fhw_model_pytorch(name="lut_quantizer_pytorch_test",
+                                                             hardware_model=generate_default_hardware_model(
+                                                                 activation_n_bits=8,
+                                                                 weights_n_bits=self.weights_n_bits)),
+        }
 
     def get_quantization_configs(self):
         return {'lut_quantizer_test': mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
@@ -18,6 +18,8 @@ from torch.nn import Conv2d
 
 from model_compression_toolkit import MixedPrecisionQuantizationConfig, KPI
 from model_compression_toolkit.common.user_info import UserInformation
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit as mct
 
@@ -29,6 +31,12 @@ This test checks the Mixed Precision feature.
 class MixedPercisionBaseTest(BasePytorchTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
+
+    def get_fw_hw_model(self):
+        return {
+            'mixed_precision_model': generate_fhw_model_pytorch(name="mixed_precision_pytorch_test",
+                                                                hardware_model=generate_default_hardware_model()),
+        }
 
     def get_quantization_configs(self):
         qc = mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
@@ -31,17 +31,12 @@ class MixedPercisionBaseTest(BasePytorchTest):
         super().__init__(unit_test)
 
     def get_quantization_configs(self):
-        qc = mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
-                                    mct.QuantizationErrorMethod.MSE,
-                                    weights_bias_correction=True,
-                                    weights_per_channel_threshold=True,
-                                    activation_channel_equalization=False,
-                                    relu_bound_to_power_of_2=False,
-                                    input_scaling=False)
+        qc = mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
+                                    relu_bound_to_power_of_2=False, weights_bias_correction=True,
+                                    weights_per_channel_threshold=True, input_scaling=False,
+                                    activation_channel_equalization=False)
 
-        return {"mixed_precision_model": MixedPrecisionQuantizationConfig(qc,
-                                                                          n_bits_candidates=[(2, 8), (8, 8), (4, 8)],
-                                                                          num_of_images=1)}
+        return {"mixed_precision_model": MixedPrecisionQuantizationConfig(qc, num_of_images=1)}
 
     def create_feature_network(self, input_shape):
         return MixedPrecisionNet(input_shape)

--- a/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 import torch
+
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 from torch.nn import Conv2d, ReLU, ReLU6, Hardtanh
 from torch.nn.functional import relu, relu6, hardtanh
@@ -92,6 +95,12 @@ class ReLUBoundToPOTNetTest(BasePytorchTest):
     def create_inputs_shape(self):
         return [[self.val_batch_size, 3, 32, 32]]
 
+    def get_fw_hw_model(self):
+        return {
+            '8bit_relu_bound': generate_fhw_model_pytorch(name="relu_bound_pytorch_test",
+                                                          hardware_model=generate_default_hardware_model()),
+        }
+
     def get_quantization_configs(self):
         quant_config = mct.DEFAULTCONFIG
         quant_config.relu_bound_to_power_of_2 = True
@@ -127,6 +136,12 @@ class HardtanhBoundToPOTNetTest(BasePytorchTest):
 
     def create_inputs_shape(self):
         return [[self.val_batch_size, 3, 32, 32]]
+
+    def get_fw_hw_model(self):
+        return {
+            '8bit_relu_bound': generate_fhw_model_pytorch(name="tanh_pytorch_test",
+                                                          hardware_model=generate_default_hardware_model()),
+        }
 
     def get_quantization_configs(self):
         quant_config = mct.DEFAULTCONFIG

--- a/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
@@ -55,12 +55,7 @@ class ShiftNegaviteActivationNetTest(BasePytorchTest):
         return {
             'all_8bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               8,
-                                               8,
-                                               enable_weights_quantization=True,
-                                               enable_activation_quantization=True,
-                                               shift_negative_activation_correction=True,
-                                               shift_negative_ratio=np.inf),
+                                               shift_negative_activation_correction=True, shift_negative_ratio=np.inf),
         }
 
     def create_inputs_shape(self):

--- a/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 import torch
 
+from model_compression_toolkit.hardware_models.default_hwm import generate_default_hardware_model
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.utils import to_torch_tensor
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit as mct
@@ -50,6 +52,12 @@ class ShiftNegaviteActivationNetTest(BasePytorchTest):
         i[0][0, 0, 0, 0] = 10
         i[0][0, 0, 0, 1] = -10
         return i
+
+    def get_fw_hw_model(self):
+        return {
+            'all_8bit': generate_fhw_model_pytorch(name="sn_pytorch_test",
+                                                   hardware_model=generate_default_hardware_model()),
+        }
 
     def get_quantization_configs(self):
         return {

--- a/tests/pytorch_tests/test_pytorch_hardware_model.py
+++ b/tests/pytorch_tests/test_pytorch_hardware_model.py
@@ -239,7 +239,8 @@ class TestGetPytorchHardwareModelAPI(unittest.TestCase):
                                                                                         rep_data,
                                                                                         n_iter=1,
                                                                                         fw_hw_model=fw_hw_model,
-                                                                                        quant_config=mp_qc)
+                                                                                        quant_config=mp_qc,
+                                                                                        target_kpi=mct.KPI(np.inf))
 
     def test_get_pytorch_not_supported_model(self):
         with self.assertRaises(Exception) as e:

--- a/tutorials/example_keras_mobilenet_mixed_precision.py
+++ b/tutorials/example_keras_mobilenet_mixed_precision.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     # will search a mixed-precision configuration (namely, bit width for each layer)
     # and quantize the model according to this configuration.
     # Here, each layer can be quantized by 2, 4 or 8 bits.
-    configuration = MixedPrecisionQuantizationConfig(weights_n_bits=[2, 8, 4])
+    configuration = MixedPrecisionQuantizationConfig()
 
     # Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that
     # should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias


### PR DESCRIPTION
Refactor to allow getting quantization configuration candidates from hardware model instead of given list in quantization config.
Main changes include:

- Remove n_bits and enable_quantization for both weights and activation from `QuantizationConfig` and remove n_bits_candidates from `MixedPrecisionQuantizationConfig`.
- Set node's config with info from hardware modeling.
- Removed operations lists from framework info.
- Minor adjustments in default hardware model and framework hardware model.
- Large refactor in tests - to adjust setting test configuration with hw model.