### PR TITLE
refactor default hw model

### DIFF
--- a/model_compression_toolkit/common/hardware_representation/op_quantization_config.py
+++ b/model_compression_toolkit/common/hardware_representation/op_quantization_config.py
@@ -54,10 +54,10 @@ class OpQuantizationConfig:
                  weights_per_channel_threshold: bool,
                  enable_weights_quantization: bool,
                  enable_activation_quantization: bool,
-                 quantization_preserving: bool = False,
-                 fixed_scale: float = None,
-                 fixed_zero_point: int = None,
-                 weights_multiplier_nbits: int = None  # If None - set 8 in hptq, o.w use it
+                 quantization_preserving: bool,
+                 fixed_scale: float,
+                 fixed_zero_point: int,
+                 weights_multiplier_nbits: int  # If None - set 8 in hptq, o.w use it
                  ):
         """
 

--- a/model_compression_toolkit/hardware_models/default_hwm.py
+++ b/model_compression_toolkit/hardware_models/default_hwm.py
@@ -18,17 +18,38 @@ hwm = mct.hardware_representation
 
 
 def get_default_hardware_model():
+    return generate_default_hardware_model()
+
+
+def generate_default_hardware_model(activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                    weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                    activation_n_bits=8,
+                                    weights_n_bits=8,
+                                    weights_per_channel_threshold=True,
+                                    enable_weights_quantization=True,
+                                    enable_activation_quantization=True,
+                                    quantization_preserving=False,
+                                    fixed_scale=None,
+                                    fixed_zero_point=None,
+                                    weights_multiplier_nbits=None,
+                                    mixed_precision_cfg=None
+                                    ):
+
     # Create a quantization config.
     # A quantization configuration defines how an operator
     # should be quantized on the modeled hardware:
     eight_bits = hwm.OpQuantizationConfig(
-        activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-        weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-        activation_n_bits=8,
-        weights_n_bits=8,
-        weights_per_channel_threshold=True,
-        enable_weights_quantization=True,
-        enable_activation_quantization=True
+        activation_quantization_method=activation_quantization_method,
+        weights_quantization_method=weights_quantization_method,
+        activation_n_bits=activation_n_bits,
+        weights_n_bits=weights_n_bits,
+        weights_per_channel_threshold=weights_per_channel_threshold,
+        enable_weights_quantization=enable_weights_quantization,
+        enable_activation_quantization=enable_activation_quantization,
+        quantization_preserving=quantization_preserving,
+        fixed_scale=fixed_scale,
+        fixed_zero_point=fixed_zero_point,
+        weights_multiplier_nbits=weights_multiplier_nbits
     )
 
     # Create a QuantizationConfigOptions, which defines a set
@@ -64,9 +85,9 @@ def get_default_hardware_model():
         # to quantize the operations' activations using LUT.
         four_bits = eight_bits.clone_and_edit(weights_n_bits=4)
         two_bits = eight_bits.clone_and_edit(weights_n_bits=2)
-        mixed_precision_configuration_options = hwm.QuantizationConfigOptions([eight_bits,
-                                                                               four_bits,
-                                                                               two_bits],
+        mixed_precision_cfg_list = [eight_bits, four_bits, two_bits] \
+            if mixed_precision_cfg is None else mixed_precision_cfg  # allowing to use mp config from input
+        mixed_precision_configuration_options = hwm.QuantizationConfigOptions(mixed_precision_cfg_list,
                                                                               base_config=eight_bits)
 
         # Define operator sets that use mixed_precision_configuration_options:
@@ -95,4 +116,3 @@ def get_default_hardware_model():
         hwm.Fusing([conv, any_relu, add])
 
     return default_hwm
-

--- a/model_compression_toolkit/hardware_models/default_hwm.py
+++ b/model_compression_toolkit/hardware_models/default_hwm.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List, Tuple
 
 import model_compression_toolkit as mct
+from model_compression_toolkit.common.hardware_representation import OpQuantizationConfig, HardwareModel
+
 hwm = mct.hardware_representation
 
 
-def get_default_hardware_model():
+def get_default_hardware_model() -> HardwareModel:
     """
     A method that generates a default hardware model, with base 8-bit quantization configuration and 8, 4, 2
     bits configuration list for mixed-precision quantization.
@@ -32,7 +35,7 @@ def get_default_hardware_model():
     return generate_hardware_model(base_config, mixed_precision_cfg_list, name='default_hwm')
 
 
-def get_op_quantization_configs():
+def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantizationConfig]]:
     """
     Creates a default configuration object for 8-bit quantization, to be used to set a default hardware model.
     In addition, creates a default configuration objects list (with 8, 4 and 2 bit quantization) to be used as
@@ -69,7 +72,9 @@ def get_op_quantization_configs():
     return eight_bits, mixed_precision_cfg_list
 
 
-def generate_hardware_model(base_config, mixed_precision_cfg_list, name):
+def generate_hardware_model(base_config: OpQuantizationConfig,
+                            mixed_precision_cfg_list: List[OpQuantizationConfig],
+                            name: str) -> HardwareModel:
     """
     Generates HardwareModel with default defined Operators Sets, based on the given base configuration and
     mixed-precision configurations options list.

--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py
@@ -71,7 +71,7 @@ def generate_fhw_model_keras(name: str, hardware_model: HardwareModel):
 
         hwm.OperationsSetToLayers("AnyReLU", [tf.nn.relu,
                                               tf.nn.relu6,
-                                              ReLU,
+                                              hwm.LayerFilterParams(ReLU, negative_slope=0.0),
                                               hwm.LayerFilterParams(Activation, activation="relu")])
 
         hwm.OperationsSetToLayers("Add", [tf.add,

--- a/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_default.py
+++ b/model_compression_toolkit/hardware_models/pytorch_hardware_model/pytorch_default.py
@@ -22,6 +22,7 @@ from torch.nn import Dropout, Flatten, Hardtanh
 from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh
 from torch.nn.functional import relu, relu6, prelu, silu, hardtanh
 
+from model_compression_toolkit.common.hardware_representation import HardwareModel
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
     FrameworkHardwareModel, LayerFilterParams
 from model_compression_toolkit.common.hardware_representation.hardware2framework import \
@@ -30,11 +31,24 @@ from model_compression_toolkit.hardware_models.default_hwm import get_default_ha
 
 
 def get_default_hwm_pytorch():
-    default_hm = get_default_hardware_model()
-    default_hwm_pytorch = FrameworkHardwareModel(default_hm,
-                                                 name='default_hwm_pytorch')
+    default_hwm = get_default_hardware_model()
+    return generate_fhw_model_pytorch(name='default_hwm_pytorch',
+                                      hardware_model=default_hwm)
 
-    with default_hwm_pytorch:
+
+def generate_fhw_model_pytorch(name: str, hardware_model: HardwareModel):
+    """
+    Generates a FrameworkHardwareModel object with default operation sets to layers mapping.
+    Args:
+        name: Name of the framework hardware model.
+        hardware_model: HardwareModel object.
+    Returns: a FrameworkHardwareModel object for the given HardwareModel.
+    """
+
+    fhwm_pytorch = FrameworkHardwareModel(hardware_model,
+                                          name=name)
+
+    with fhwm_pytorch:
         OperationsSetToLayers("NoQuantization", [Dropout,
                                                  Flatten,
                                                  dropout,
@@ -43,7 +57,8 @@ def get_default_hwm_pytorch():
                                                  operator.getitem,
                                                  reshape,
                                                  unsqueeze,
-                                                 BatchNorm2d])
+                                                 BatchNorm2d,
+                                                 torch.Tensor.size])
 
         OperationsSetToLayers("Conv", [Conv2d])
 
@@ -74,7 +89,4 @@ def get_default_hwm_pytorch():
         OperationsSetToLayers("Tanh", [Tanh,
                                        tanh])
 
-    return default_hwm_pytorch
-
-
-
+    return fhwm_pytorch

--- a/model_compression_toolkit/hardware_models/qnnpack.py
+++ b/model_compression_toolkit/hardware_models/qnnpack.py
@@ -29,7 +29,11 @@ def get_qnnpack_model():
         weights_n_bits=8,
         weights_per_channel_threshold=False,
         enable_weights_quantization=True,
-        enable_activation_quantization=True
+        enable_activation_quantization=True,
+        quantization_preserving=False,
+        fixed_scale=None,
+        fixed_zero_point=None,
+        weights_multiplier_nbits=None
     )
 
     # Create a QuantizationConfigOptions, which defines a set

--- a/model_compression_toolkit/hardware_models/tflite.py
+++ b/model_compression_toolkit/hardware_models/tflite.py
@@ -30,7 +30,11 @@ def get_tflite_hw_model():
         weights_n_bits=8,
         weights_per_channel_threshold=True,
         enable_weights_quantization=True,
-        enable_activation_quantization=True
+        enable_activation_quantization=True,
+        quantization_preserving=False,
+        fixed_scale=None,
+        fixed_zero_point=None,
+        weights_multiplier_nbits=None
     )
 
     # Create a QuantizationConfigOptions, which defines a set

--- a/tests/common_tests/test_hardware_model.py
+++ b/tests/common_tests/test_hardware_model.py
@@ -28,7 +28,12 @@ TEST_QC = hwm.OpQuantizationConfig(enable_activation_quantization=True,
                                    weights_n_bits=8,
                                    weights_per_channel_threshold=True,
                                    activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-                                   weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO)
+                                   weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                   quantization_preserving=False,
+                                   fixed_scale=None,
+                                   fixed_zero_point=None,
+                                   weights_multiplier_nbits=None
+                                   )
 TEST_QCO = hwm.QuantizationConfigOptions([TEST_QC])
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -51,13 +51,19 @@ class LUTQuantizerTest(BaseKerasFeatureNetworkTest):
 
 
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions([hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                                                      weights_quantization_method=hw_model.QuantizationMethod.LUT_QUANTIZER,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
+        qco = hw_model.QuantizationConfigOptions(
+            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
+                                           weights_quantization_method=hw_model.QuantizationMethod.LUT_QUANTIZER,
+                                           activation_n_bits=8,
+                                           weights_n_bits=8,
+                                           weights_per_channel_threshold=True,
+                                           enable_weights_quantization=True,
+                                           enable_activation_quantization=True,
+                                           quantization_preserving=False,
+                                           fixed_scale=None,
+                                           fixed_zero_point=None,
+                                           weights_multiplier_nbits=None
+                                           )])
         return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
 
     def get_quantization_config(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -38,13 +38,19 @@ class SymmetricThresholdSelectionActivationTest(BaseKerasFeatureNetworkTest):
                                       activation_n_bits=8)
 
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions([hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
-                                                                      weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
+        qco = hw_model.QuantizationConfigOptions(
+            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
+                                           weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
+                                           activation_n_bits=8,
+                                           weights_n_bits=8,
+                                           weights_per_channel_threshold=True,
+                                           enable_weights_quantization=True,
+                                           enable_activation_quantization=True,
+                                           quantization_preserving=False,
+                                           fixed_scale=None,
+                                           fixed_zero_point=None,
+                                           weights_multiplier_nbits=None
+                                           )])
         return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
 
     def create_networks(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -58,13 +58,19 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
 
     def get_fw_hw_model(self):
-        qco = hardware_representation.QuantizationConfigOptions([hardware_representation.OpQuantizationConfig(activation_quantization_method=hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                                                                      weights_quantization_method=self.quantization_method,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
+        qco = hardware_representation.QuantizationConfigOptions([hardware_representation.OpQuantizationConfig(
+            activation_quantization_method=hardware_representation.QuantizationMethod.POWER_OF_TWO,
+            weights_quantization_method=self.quantization_method,
+            activation_n_bits=8,
+            weights_n_bits=8,
+            weights_per_channel_threshold=True,
+            enable_weights_quantization=True,
+            enable_activation_quantization=True,
+            quantization_preserving=False,
+            fixed_scale=None,
+            fixed_zero_point=None,
+            weights_multiplier_nbits=None
+            )])
         return hardware_representation.FrameworkHardwareModel(hardware_representation.HardwareModel(qco))
 
     def get_quantization_config(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -38,13 +38,19 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
                                       activation_n_bits=8)
 
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions([hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
-                                                                      weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                                                      activation_n_bits=8,
-                                                                      weights_n_bits=8,
-                                                                      weights_per_channel_threshold=True,
-                                                                      enable_weights_quantization=True,
-                                                                      enable_activation_quantization=True)])
+        qco = hw_model.QuantizationConfigOptions(
+            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
+                                           weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
+                                           activation_n_bits=8,
+                                           weights_n_bits=8,
+                                           weights_per_channel_threshold=True,
+                                           enable_weights_quantization=True,
+                                           enable_activation_quantization=True,
+                                           quantization_preserving=False,
+                                           fixed_scale=None,
+                                           fixed_zero_point=None,
+                                           weights_multiplier_nbits=None
+                                           )])
         return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
 
     def create_networks(self):

--- a/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
@@ -52,13 +52,19 @@ class TestQuantizationConfigurations(unittest.TestCase):
 
         model = model_gen()
         for quantize_method, error_method, per_channel in weights_test_combinations:
-            default_op_cfg = hwm.OpQuantizationConfig(activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-                                                    weights_quantization_method=quantize_method,
-                                                    activation_n_bits=16,
-                                                    weights_n_bits=8,
-                                                    enable_weights_quantization=True,
-                                                    enable_activation_quantization=True,
-                                                    weights_per_channel_threshold=per_channel)
+            default_op_cfg = hwm.OpQuantizationConfig(
+                activation_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                weights_quantization_method=quantize_method,
+                activation_n_bits=16,
+                weights_n_bits=8,
+                enable_weights_quantization=True,
+                enable_activation_quantization=True,
+                weights_per_channel_threshold=per_channel,
+                quantization_preserving=False,
+                fixed_scale=None,
+                fixed_zero_point=None,
+                weights_multiplier_nbits=None
+                )
 
             hw_model = hwm.FrameworkHardwareModel(hwm.HardwareModel(hwm.QuantizationConfigOptions([default_op_cfg])))
 
@@ -81,12 +87,17 @@ class TestQuantizationConfigurations(unittest.TestCase):
         model = model_gen()
         for quantize_method, error_method, relu_bound_to_power_of_2 in activation_test_combinations:
             default_op_cfg = hwm.OpQuantizationConfig(activation_quantization_method=quantize_method,
-                                                weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
-                                                activation_n_bits=8,
-                                                weights_n_bits=8,
-                                                enable_weights_quantization=False,
-                                                enable_activation_quantization=True,
-                                                weights_per_channel_threshold=True)
+                                                      weights_quantization_method=hwm.QuantizationMethod.POWER_OF_TWO,
+                                                      activation_n_bits=8,
+                                                      weights_n_bits=8,
+                                                      enable_weights_quantization=False,
+                                                      enable_activation_quantization=True,
+                                                      weights_per_channel_threshold=True,
+                                                      quantization_preserving=False,
+                                                      fixed_scale=None,
+                                                      fixed_zero_point=None,
+                                                      weights_multiplier_nbits=None
+                                                      )
 
             hw_model = hwm.FrameworkHardwareModel(hwm.HardwareModel(hwm.QuantizationConfigOptions([default_op_cfg])))
 

--- a/tests/keras_tests/function_tests/test_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_quantization_configurations.py
@@ -71,7 +71,12 @@ class TestQuantizationConfigurations(unittest.TestCase):
                     weights_n_bits=8,
                     weights_per_channel_threshold=per_channel,
                     enable_weights_quantization=True,
-                    enable_activation_quantization=True)])
+                    enable_activation_quantization=True,
+                    quantization_preserving=False,
+                    fixed_scale=None,
+                    fixed_zero_point=None,
+                    weights_multiplier_nbits=None
+                )])
             fw_hw_model = mct.hardware_representation.FrameworkHardwareModel(
                 mct.hardware_representation.HardwareModel(qco))
             qc = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.NOCLIPPING,
@@ -99,7 +104,12 @@ class TestQuantizationConfigurations(unittest.TestCase):
                     weights_n_bits=8,
                     weights_per_channel_threshold=False,
                     enable_weights_quantization=True,
-                    enable_activation_quantization=True)])
+                    enable_activation_quantization=True,
+                    quantization_preserving=False,
+                    fixed_scale=None,
+                    fixed_zero_point=None,
+                    weights_multiplier_nbits=None
+                )])
 
             fw_hw_model = mct.hardware_representation.FrameworkHardwareModel(
                 mct.hardware_representation.HardwareModel(qco))

--- a/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
@@ -101,7 +101,12 @@ class TestSymmetricThresholdSelectionWeights(unittest.TestCase):
                 weights_n_bits=8,
                 weights_per_channel_threshold=True,
                 enable_weights_quantization=True,
-                enable_activation_quantization=True)])
+                enable_activation_quantization=True,
+                quantization_preserving=False,
+                fixed_scale=None,
+                fixed_zero_point=None,
+                weights_multiplier_nbits=None
+            )])
         hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
 
         fw_info = DEFAULT_KERAS_INFO

--- a/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
@@ -100,7 +100,12 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
                 weights_n_bits=8,
                 weights_per_channel_threshold=True,
                 enable_weights_quantization=True,
-                enable_activation_quantization=True)])
+                enable_activation_quantization=True,
+                quantization_preserving=False,
+                fixed_scale=None,
+                fixed_zero_point=None,
+                weights_multiplier_nbits=None
+            )])
         hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
 
         fw_info = DEFAULT_KERAS_INFO


### PR DESCRIPTION
Refactor default hardware model to allow generating new models for tests and experiments, while keeping the framework hardware modeling mapping