### PR TITLE
Remove BatchNormalization from Keras default model

### DIFF
--- a/model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py
+++ b/model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py
@@ -17,10 +17,10 @@ import tensorflow as tf
 
 if tf.__version__ < "2.6":
     from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, Dropout, \
-        MaxPooling2D, Activation, ReLU, Add, PReLU, Flatten, Cropping2D, BatchNormalization
+        MaxPooling2D, Activation, ReLU, Add, PReLU, Flatten, Cropping2D
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
-    Dropout, MaxPooling2D, Activation, ReLU, Add, PReLU, Flatten, Cropping2D, BatchNormalization
+    Dropout, MaxPooling2D, Activation, ReLU, Add, PReLU, Flatten, Cropping2D
 
 from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 
@@ -42,8 +42,7 @@ def get_default_hwm_keras():
                                                      Dropout,
                                                      MaxPooling2D,
                                                      tf.split,
-                                                     tf.quantization.fake_quant_with_min_max_vars,
-                                                     BatchNormalization])
+                                                     tf.quantization.fake_quant_with_min_max_vars])
 
         hwm.OperationsSetToLayers("Conv", [Conv2D,
                                            DepthwiseConv2D,


### PR DESCRIPTION
Remove BatchNormalization from NoQuantization op set
label, as its activations are quantized.