### PR TITLE
Get n_bits candidates from hw model

### DIFF
--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -45,48 +45,34 @@ def set_bit_widths(quant_config: QuantizationConfig,
     graph = copy.deepcopy(graph_to_set_bit_widths)
 
     if isinstance(quant_config, MixedPrecisionQuantizationConfig):
-        if len(quant_config.n_bits_candidates) == 0:
-            Logger.critical(
-                f'Quantization configuration nbits candidates list has to contain at least one bit width candidate. '
-                f'Length is: '
-                f'{len(quant_config.n_bits_candidates)}')
+        assert all([len(n.candidates_quantization_cfg) > 0 for n in graph.get_configurable_sorted_nodes()]), \
+            "All configurable nodes in graph should have at least one candidate configuration in mixed precision mode"
 
-        # When working in mixed-precision mode, and there's only one bitwidth, we simply set the
-        # only candidate of the node as its final weight and activation quantization configuration.
-        if len(quant_config.n_bits_candidates) == 1:
-            for n in graph.nodes:
-                if n.name in graph.get_configurable_sorted_nodes_names():
-                    assert len(n.candidates_quantization_cfg) == 1
-                    n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
-                    n.final_activation_quantization_cfg = n.candidates_quantization_cfg[0].activation_quantization_cfg
-
-        else:
-            Logger.info(f'Set bit widths from configuration: {bit_widths_config}')
-            # Get a list of nodes' names we need to finalize (that they have at least one weight qc candidate).
-            sorted_nodes_names = graph.get_configurable_sorted_nodes_names()
-            for node in graph.nodes:  # set a specific node qc for each node final weights qc
-                # If it's reused, take the configuration that the base node has
-                node_name = node.name if not node.reuse else '_'.join(node.name.split('_')[:-2])
-                if node_name in sorted_nodes_names:  # only configurable nodes are in this list
-                    node_index_in_graph = sorted_nodes_names.index(node_name)
-                    _set_node_final_qc(bit_widths_config,
-                                       fw_info,
-                                       node,
-                                       node_index_in_graph)
-                else:
-                    # TODO: refactor after adding activation mixed precision
-                    if node.is_activation_quantization_enabled():
-                        assert node.is_all_activation_candidates_equal, "Activation Mixed Precision is not supported"
-                        node.final_activation_quantization_cfg = node.candidates_quantization_cfg[0].activation_quantization_cfg
+        Logger.info(f'Set bit widths from configuration: {bit_widths_config}')
+        # Get a list of nodes' names we need to finalize (that they have at least one weight qc candidate).
+        sorted_nodes_names = graph.get_configurable_sorted_nodes_names()
+        for node in graph.nodes:  # set a specific node qc for each node final weights qc
+            # If it's reused, take the configuration that the base node has
+            node_name = node.name if not node.reuse else '_'.join(node.name.split('_')[:-2])
+            if node_name in sorted_nodes_names:  # only configurable nodes are in this list
+                node_index_in_graph = sorted_nodes_names.index(node_name)
+                _set_node_final_qc(bit_widths_config,
+                                   fw_info,
+                                   node,
+                                   node_index_in_graph)
+            else:
+                # TODO: refactor after adding activation mixed precision
+                if node.is_activation_quantization_enabled():
+                    assert node.is_all_activation_candidates_equal, "Activation Mixed Precision is not supported"
+                    node.final_activation_quantization_cfg = node.candidates_quantization_cfg[
+                        0].activation_quantization_cfg
 
     # When working in non-mixed-precision mode, there's only one bitwidth, and we simply set the
-    # only candidate of the node as its final weight quantization configuration.
+    # only candidate of the node as its final weight and activation quantization configuration.
     else:
         for n in graph.nodes:
             assert len(n.candidates_quantization_cfg) == 1
-            if fw_info.in_kernel_ops(n):
-                n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
-            # TODO: do we need to set final config only to specific layer (fake quant?) or is setting to all layers is fine?
+            n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
             n.final_activation_quantization_cfg = n.candidates_quantization_cfg[0].activation_quantization_cfg
 
     return graph
@@ -141,5 +127,5 @@ def _set_node_final_qc(bit_width_cfg: List[int],
     else:
         if fw_info.in_kernel_ops(node):
             node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
-        # TODO: do we need to set final config only to specific layer (fake quant?) or is setting to all layers is fine?
+        node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_activation_quantization_cfg = node_qc.activation_quantization_cfg

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -125,7 +125,5 @@ def _set_node_final_qc(bit_width_cfg: List[int],
         Logger.critical(f'Node {node.name} quantization configuration from configuration file'
                         f' was not found in candidates configurations.')
     else:
-        if fw_info.in_kernel_ops(node):
-            node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_activation_quantization_cfg = node_qc.activation_quantization_cfg

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -25,7 +25,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
     def __init__(self,
                  qc: QuantizationConfig = DEFAULTCONFIG,
-                 n_bits_candidates: List[Tuple[int, int]] = None,
                  compute_distance_fn: Callable = compute_mse,
                  distance_weighting_method: Callable = get_average_weights,
                  num_of_images: int = 32,
@@ -37,8 +36,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
         Args:
             qc (QuantizationConfig): QuantizationConfig object containing parameters of how the model should be quantized.
-            n_bits_candidates (List[Tuple[int, int]]): List of possible number of bits to quantize the coefficients and
-                activations (Tuple of (weights n_bits, activations n_bits)).
             compute_distance_fn (Callable): Function to compute a distance between two tensors.
             distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
             num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
@@ -47,8 +44,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
         """
 
         super().__init__(**qc.__dict__)
-        self.n_bits_candidates = n_bits_candidates if n_bits_candidates is not None else [(qc.weights_n_bits,
-                                                                                           qc.activation_n_bits)]
         self.compute_distance_fn = compute_distance_fn
         self.distance_weighting_method = distance_weighting_method
         self.num_of_images = num_of_images
@@ -57,6 +52,5 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
 # Default quantization configuration the library use.
 DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
-                                                                 [(2, 8), (4, 8), (8, 8)],  # mixed precision only for weights
                                                                  compute_mse,
                                                                  get_average_weights)

--- a/model_compression_toolkit/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/node_quantization_config.py
@@ -81,7 +81,7 @@ class NodeActivationQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.activation_quantization_params = {}
         self.activation_error_method = qc.activation_error_method
         self.activation_quantization_method = op_cfg.activation_quantization_method
-        self.activation_n_bits = qc.activation_n_bits
+        self.activation_n_bits = op_cfg.activation_n_bits
         self.relu_bound_to_power_of_2 = qc.relu_bound_to_power_of_2
         self.enable_activation_quantization = qc.enable_activation_quantization
         self.activation_channel_equalization = qc.activation_channel_equalization
@@ -214,7 +214,7 @@ class NodeWeightsQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.weights_quantization_params = {}
         self.weights_error_method = qc.weights_error_method
         self.weights_quantization_method = op_cfg.weights_quantization_method
-        self.weights_n_bits = qc.weights_n_bits
+        self.weights_n_bits = op_cfg.weights_n_bits
         self.weights_bias_correction = qc.weights_bias_correction
         self.weights_per_channel_threshold = qc.weights_per_channel_threshold
         self.enable_weights_quantization = qc.enable_weights_quantization

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -84,8 +84,7 @@ class QuantizationConfig(object):
 
         Examples:
             One may create a quantization configuration to quantize a model according to.
-            For example, to quantize a model using 6 bits for activation, 7 bits for weights,
-            weights and activation quantization method is symetric uniform,
+            For example, to quantize a model's weights and activation using symetric uniform quantization method,
             weights threshold selection using MSE, activation threshold selection using NOCLIPPING,
             enabling relu_bound_to_power_of_2, weights_bias_correction, and quantizing the weights per-channel,
             one can instantiate a quantization configuration:

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -49,8 +49,6 @@ class QuantizationConfig(object):
     def __init__(self,
                  activation_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
                  weights_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
-                 activation_n_bits: int = 8,
-                 weights_n_bits: int = 8,
                  relu_bound_to_power_of_2: bool = False,
                  weights_bias_correction: bool = True,
                  weights_per_channel_threshold: bool = True,
@@ -70,8 +68,6 @@ class QuantizationConfig(object):
         Args:
             activation_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
             weights_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
-            activation_n_bits (int): Number of bits to quantize the activations.
-            weights_n_bits (int): Number of bits to quantize the coefficients.
             relu_bound_to_power_of_2 (bool): Whether to use relu to power of 2 scaling correction or not.
             weights_bias_correction (bool): Whether to use weights bias correction or not.
             weights_per_channel_threshold (bool): Whether to quantize the weights per-channel or not (per-tensor).
@@ -94,23 +90,16 @@ class QuantizationConfig(object):
             enabling relu_bound_to_power_of_2, weights_bias_correction, and quantizing the weights per-channel,
             one can instantiate a quantization configuration:
 
-            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,activation_n_bits=6,weights_n_bits=7,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
+            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
 
 
             The QuantizationConfig instanse can then be passed to
             :func:`~model_compression_toolkit.keras_post_training_quantization`
 
-            In order to use a different quantization method (than power-of-two that is used by default),
-            one may pass a desired QuantizationMethod when instantiating a QuantizationConfig. For example:
-
-            >>> qc = QuantizationConfig(activation_quantization_method=QuantizationMethod.LUT_QUANTIZER)
-
         """
 
         self.activation_error_method = activation_error_method
         self.weights_error_method = weights_error_method
-        self.activation_n_bits = activation_n_bits
-        self.weights_n_bits = weights_n_bits
         self.relu_bound_to_power_of_2 = relu_bound_to_power_of_2
         self.weights_bias_correction = weights_bias_correction
         self.weights_per_channel_threshold = weights_per_channel_threshold
@@ -132,8 +121,6 @@ class QuantizationConfig(object):
 # Default quantization configuration the library use.
 DEFAULTCONFIG = QuantizationConfig(QuantizationErrorMethod.MSE,
                                    QuantizationErrorMethod.MSE,
-                                   activation_n_bits=8,
-                                   weights_n_bits=8,
                                    relu_bound_to_power_of_2=False,
                                    weights_bias_correction=True,
                                    weights_per_channel_threshold=True,

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -212,7 +212,7 @@ if importlib.util.find_spec("tensorflow") is not None\
              >>> def repr_datagen(): return [np.random.random((1,224,224,3))]
 
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
-             Here, each layer can be quantized by 2, 4 or 8 bits:
+             The candidates bitwidth for quantization should be defined in the hardware model:
 
              >>> config = mct.MixedPrecisionQuantizationConfig()
 

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -215,7 +215,7 @@ if importlib.util.find_spec("tensorflow") is not None\
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
              Here, each layer can be quantized by 2, 4 or 8 bits:
 
-             >>> config = mct.MixedPrecisionQuantizationConfig(weights_n_bits=[4, 2, 8])
+             >>> config = mct.MixedPrecisionQuantizationConfig()
 
              Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias will not):
 
@@ -232,16 +232,9 @@ if importlib.util.find_spec("tensorflow") is not None\
                              fw_info=fw_info).validate()
 
         if target_kpi is None:
-            # Before starting non-mixed-precision process, we need to set only single bit width, so we take the best
-            # option which is the maximal number of bits.
-            single_bitwidth_candidate = quant_config.n_bits_candidates[0]
-            quant_config.weights_n_bits = [single_bitwidth_candidate[0]]
-            quant_config.activation_n_bits = [single_bitwidth_candidate[1]]
-            quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
-                f"weights_n_bits={quant_config.weights_n_bits} "
-                f"and activation_n_bits={quant_config.activation_n_bits}...")
+                f"base_config defined in the given hardware model...")
             return keras_post_training_quantization(in_model,
                                                     representative_data_gen,
                                                     n_iter,

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -166,7 +166,7 @@ if importlib.util.find_spec("torch") is not None:
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
              Here, each layer can be quantized by 2, 4 or 8 bits:
 
-             >>> config = mct.MixedPrecisionQuantizationConfig(weights_n_bits=[4, 2, 8])
+             >>> config = mct.MixedPrecisionQuantizationConfig()
 
              Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias will not):
 
@@ -180,16 +180,9 @@ if importlib.util.find_spec("torch") is not None:
 
          """
         if target_kpi is None:
-            # Before starting non-mixed-precision process, we need to set only single bit width, so we take the best
-            # option which is the maximal number of bits.
-            single_bitwidth_candidate = quant_config.n_bits_candidates[0]
-            quant_config.weights_n_bits = [single_bitwidth_candidate[0]]
-            quant_config.activation_n_bits = [single_bitwidth_candidate[1]]
-            quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
-                f"weights_n_bits={quant_config.weights_n_bits} "
-                f"and activation_n_bits={quant_config.activation_n_bits}...")
+                f"base_config defined in the given hardware model...")
             return pytorch_post_training_quantization(in_model,
                                                       representative_data_gen,
                                                       n_iter,

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -164,7 +164,7 @@ if importlib.util.find_spec("torch") is not None:
              >>> def repr_datagen(): return [np.random.random((1,224,224,3))]
 
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
-             Here, each layer can be quantized by 2, 4 or 8 bits:
+             The candidates bitwidth for quantization should be defined in the hardware model:
 
              >>> config = mct.MixedPrecisionQuantizationConfig()
 

--- a/tests/common_tests/base_layer_test.py
+++ b/tests/common_tests/base_layer_test.py
@@ -44,6 +44,9 @@ class BaseLayerTest(BaseTest):
     def get_layers(self):
         return self.layers
 
+    def get_fw_hw_model(self):
+        raise NotImplemented
+
     def get_quantization_config(self):
         qc = copy.deepcopy(DEFAULTCONFIG)
         qc.weights_bias_correction = False
@@ -51,11 +54,6 @@ class BaseLayerTest(BaseTest):
             # Disable all features that are enabled by default:
             qc.enable_activation_quantization = False
             qc.enable_weights_quantization = False
-        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
-            qc.weights_n_bits = 8
-            qc.activation_n_bits = 8
-        else:
-            raise NotImplemented
         return qc
 
     def run_test(self):
@@ -70,13 +68,15 @@ class BaseLayerTest(BaseTest):
                                                                                          self.representative_data_gen,
                                                                                          n_iter=self.num_calibration_iter,
                                                                                          quant_config=qc,
-                                                                                         fw_info=self.get_fw_info())
+                                                                                         fw_info=self.get_fw_info(),
+                                                                                         fw_hw_model=self.get_fw_hw_model())
                 else:
                     ptq_model, quantization_info = self.get_ptq_facade()(model_float,
                                                                          self.representative_data_gen,
                                                                          n_iter=self.num_calibration_iter,
                                                                          quant_config=qc,
-                                                                         fw_info=self.get_fw_info())
+                                                                         fw_info=self.get_fw_info(),
+                                                                         fw_hw_model=self.get_fw_hw_model())
 
                 self.compare(ptq_model, model_float, input_x=self.representative_data_gen(),
                              quantization_info=quantization_info)

--- a/tests/common_tests/helpers/generate_test_hw_model.py
+++ b/tests/common_tests/helpers/generate_test_hw_model.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from model_compression_toolkit.hardware_models.default_hwm import get_op_quantization_configs, generate_hardware_model
+import model_compression_toolkit as mct
+
+hwm = mct.hardware_representation
+
+
+def generate_test_hw_model(edit_params_dict, name=""):
+    base_config, mixed_precision_cfg_list = get_op_quantization_configs()
+    updated_config = base_config.clone_and_edit(**edit_params_dict)
+
+    return generate_hardware_model(updated_config, mixed_precision_cfg_list, name=name)
+
+
+def generate_mixed_precision_test_hw_model(base_cfg, mp_bitwidth_candidates_list, name=""):
+    mp_op_cfg_list = []
+    for weights_n_bits, activation_n_bits in mp_bitwidth_candidates_list:
+        candidate_cfg = base_cfg.clone_and_edit(weights_n_bits=weights_n_bits,
+                                                activation_n_bits=activation_n_bits)
+        mp_op_cfg_list.append(candidate_cfg)
+
+    return generate_hardware_model(base_cfg, mp_op_cfg_list, name=name)

--- a/tests/common_tests/helpers/generate_test_hw_model.py
+++ b/tests/common_tests/helpers/generate_test_hw_model.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Sony Semiconductors Israel, Inc. All rights reserved.
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # ==============================================================================
 from model_compression_toolkit.hardware_models.default_hwm import get_op_quantization_configs, generate_hardware_model
 import model_compression_toolkit as mct
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 
 hwm = mct.hardware_representation
 
@@ -33,3 +34,9 @@ def generate_mixed_precision_test_hw_model(base_cfg, mp_bitwidth_candidates_list
         mp_op_cfg_list.append(candidate_cfg)
 
     return generate_hardware_model(base_cfg, mp_op_cfg_list, name=name)
+
+
+def get_16bit_fw_hw_model(name):
+    hw_model = generate_test_hw_model({'weights_n_bits': 16,
+                                       'activation_n_bits': 16})
+    return generate_fhw_model_keras(name=name, hardware_model=hw_model)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -22,7 +22,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from tests.common_tests.base_layer_test import LayerTestMode
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -38,9 +38,7 @@ class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
         super(BaseBatchNormalizationFolding, self).__init__(unit_test=unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("kmean_quantizer_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -16,17 +16,20 @@
 
 from abc import ABC
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
 
 from tests.common_tests.base_layer_test import LayerTestMode
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
 
 class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
@@ -34,8 +37,13 @@ class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
     def __init__(self, unit_test):
         super(BaseBatchNormalizationFolding, self).__init__(unit_test=unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
                                       False, False, True, enable_weights_quantization=False,
                                       enable_activation_quantization=False)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq_test.py
@@ -21,7 +21,7 @@ from model_compression_toolkit.common.user_info import UserInformation
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.gradient_ptq.gptq_loss import multiple_tensors_mse_loss
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
@@ -36,9 +36,7 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
                          input_shape=(1,16,16,3))
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("gptq_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
@@ -16,7 +16,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.keras.back2framework.model_builder import is_layer_fake_quant
@@ -30,9 +30,7 @@ class BaseInputScalingTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="input_scaling_range_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("input_scaling_range_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.keras.back2framework.model_builder import is_layer_fake_quant
@@ -26,10 +29,14 @@ class BaseInputScalingTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="input_scaling_range_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                       mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       input_scaling=True)
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
@@ -16,7 +16,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -30,9 +30,7 @@ class MultiInputsToNodeTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="multi_input_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("multi_input_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -26,8 +29,13 @@ class MultiInputsToNodeTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="multi_input_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       True, True, True, input_scaling=True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
@@ -17,7 +17,7 @@ from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
 
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -31,9 +31,7 @@ class MultipleInputsNodeTests(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="multiple_inputs_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("multiple_inputs_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -27,9 +30,13 @@ class MultipleInputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="multiple_inputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       True, False, True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -16,6 +16,9 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -35,8 +38,13 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="nested_multi_inputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       True, True, True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -17,7 +17,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
@@ -39,9 +39,7 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="nested_multi_inputs_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("nested_multi_inputs_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -17,6 +17,9 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -35,11 +38,14 @@ class NestedModelMultipleOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, val_batch_size=10)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="nested_multi_outputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
                                       mct.QuantizationErrorMethod.MSE,
-                                      16,
-                                      16,
                                       True,
                                       True,
                                       True)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -18,7 +18,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
@@ -39,9 +39,7 @@ class NestedModelMultipleOutputsTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, val_batch_size=10)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="nested_multi_outputs_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("nested_multi_outputs_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
@@ -20,7 +20,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.common.network_editors.node_filters import NodeNameFilter, NodeNameScopeFilter, \
@@ -56,9 +56,7 @@ class ScopeFilterTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="scope_filter_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("scope_filter_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
@@ -132,9 +130,7 @@ class NameFilterTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="name_filter_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("name_filter_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
@@ -197,9 +193,7 @@ class TypeFilterTest(BaseKerasFeatureNetworkTest):
             mct.QuantizationErrorMethod.NOCLIPPING)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="type_filter_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("type_filter_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
@@ -18,6 +18,9 @@ from model_compression_toolkit.common.quantization.quantization_params_fn_select
 
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.common.network_editors.node_filters import NodeNameFilter, NodeNameScopeFilter, \
@@ -52,8 +55,13 @@ class ScopeFilterTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="scope_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, True)
 
     def get_network_editor(self):
@@ -123,8 +131,13 @@ class NameFilterTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="name_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, True)
 
     def get_network_editor(self):
@@ -183,8 +196,13 @@ class TypeFilterTest(BaseKerasFeatureNetworkTest):
             hw_model.QuantizationMethod.POWER_OF_TWO,
             mct.QuantizationErrorMethod.NOCLIPPING)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="type_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, False)
 
     def get_network_editor(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -26,9 +29,13 @@ class RemoveUpperBoundTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, num_calibration_iter=1, val_batch_size=32)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="remove_upper_bound_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       False, False, False)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
@@ -16,7 +16,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -30,9 +30,7 @@ class RemoveUpperBoundTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, num_calibration_iter=1, val_batch_size=32)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="remove_upper_bound_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("remove_upper_bound_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
@@ -17,6 +17,8 @@
 import numpy as np
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
 import model_compression_toolkit as mct
@@ -34,9 +36,13 @@ class ScaleEqualizationTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="scale_equalization_bound_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                      16, 16,
                                       relu_bound_to_power_of_2=False, weights_bias_correction=False,
                                       weights_per_channel_threshold=True, activation_channel_equalization=True)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
@@ -18,7 +18,7 @@ import numpy as np
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
 import model_compression_toolkit as mct
@@ -37,9 +37,7 @@ class ScaleEqualizationTest(BaseKerasFeatureNetworkTest):
                          input_shape=(16,16,3))
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="scale_equalization_bound_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("scale_equalization_bound_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -16,7 +16,7 @@ import model_compression_toolkit as mct
 import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
@@ -41,9 +41,7 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, input_shape=input_shape, num_calibration_iter=100)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="shift_negative_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("shift_negative_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
 else:
@@ -36,8 +40,13 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
         self.bypass_op_list = bypass_op_list
         super().__init__(unit_test, input_shape=input_shape, num_calibration_iter=100)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="shift_negative_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, True, shift_negative_activation_correction=True,
                                       shift_negative_ratio=np.inf)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
@@ -17,7 +17,7 @@ from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
 
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -31,9 +31,7 @@ class SplitConvBugTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test)
 
     def get_fw_hw_model(self):
-        hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="split_conv_bug_test", hardware_model=hwm)
+        return get_16bit_fw_hw_model("split_conv_bug_test")
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -27,10 +30,14 @@ class SplitConvBugTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="split_conv_bug_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
                                       mct.QuantizationErrorMethod.MSE,
-                                      16, 16,
                                       True, True, True, input_scaling=True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -17,6 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as cmo
 
@@ -33,25 +35,14 @@ class SymmetricThresholdSelectionActivationTest(BaseKerasFeatureNetworkTest):
     def generate_inputs(self):
         return [np.random.uniform(low=-7, high=7, size=in_shape) for in_shape in self.get_input_shapes()]
 
-    def get_quantization_config(self):
-        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method,
-                                      activation_n_bits=8)
-
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions(
-            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
-                                           weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                           activation_n_bits=8,
-                                           weights_n_bits=8,
-                                           weights_per_channel_threshold=True,
-                                           enable_weights_quantization=True,
-                                           enable_activation_quantization=True,
-                                           quantization_preserving=False,
-                                           fixed_scale=None,
-                                           fixed_zero_point=None,
-                                           weights_multiplier_nbits=None
-                                           )])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'activation_quantization_method': hw_model.QuantizationMethod.SYMMETRIC,
+            'activation_n_bits': 8})
+        return generate_fhw_model_keras(name="symmetric_threshold_test", hardware_model=hwm)
+
+    def get_quantization_config(self):
+        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -20,6 +20,9 @@ from model_compression_toolkit.common.network_editors.node_filters import NodeNa
 from model_compression_toolkit.common.network_editors.actions import EditRule, ChangeCandidatesWeightsQuantConfigAttr
 import model_compression_toolkit as cmo
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 
@@ -58,26 +61,14 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
 
     def get_fw_hw_model(self):
-        qco = hardware_representation.QuantizationConfigOptions([hardware_representation.OpQuantizationConfig(
-            activation_quantization_method=hardware_representation.QuantizationMethod.POWER_OF_TWO,
-            weights_quantization_method=self.quantization_method,
-            activation_n_bits=8,
-            weights_n_bits=8,
-            weights_per_channel_threshold=True,
-            enable_weights_quantization=True,
-            enable_activation_quantization=True,
-            quantization_preserving=False,
-            fixed_scale=None,
-            fixed_zero_point=None,
-            weights_multiplier_nbits=None
-            )])
-        return hardware_representation.FrameworkHardwareModel(hardware_representation.HardwareModel(qco))
+        hwm = generate_test_hw_model({'weights_quantization_method': self.quantization_method,
+                                      'weights_n_bits': self.weights_n_bits,
+                                      'activation_n_bits': 4})
+        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
 
     def get_quantization_config(self):
         return cmo.QuantizationConfig(cmo.QuantizationErrorMethod.MSE,
                                       cmo.QuantizationErrorMethod.MSE,
-                                      4,
-                                      self.weights_n_bits,
                                       False,
                                       False,
                                       True)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -17,7 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
-
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as cmo
 
@@ -34,24 +35,13 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
         return [np.random.uniform(low=-7, high=7, size=in_shape) for in_shape in self.get_input_shapes()]
 
     def get_quantization_config(self):
-        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method,
-                                      activation_n_bits=8)
+        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method)
 
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions(
-            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
-                                           weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                           activation_n_bits=8,
-                                           weights_n_bits=8,
-                                           weights_per_channel_threshold=True,
-                                           enable_weights_quantization=True,
-                                           enable_activation_quantization=True,
-                                           quantization_preserving=False,
-                                           fixed_scale=None,
-                                           fixed_zero_point=None,
-                                           weights_multiplier_nbits=None
-                                           )])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'activation_quantization_method': hw_model.QuantizationMethod.UNIFORM,
+            'activation_n_bits': 8})
+        return generate_fhw_model_keras(name="uniform_range_test", hardware_model=hwm)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/test_networks_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_networks_runner.py
@@ -20,7 +20,7 @@ import numpy as np
 import unittest
 import model_compression_toolkit as mct
 from model_compression_toolkit.keras.gradient_ptq.gptq_loss import multiple_tensors_mse_loss
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, get_16bit_fw_hw_model
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from enum import Enum
 import random
@@ -42,9 +42,7 @@ EIGHT_BIT_QUANTIZATION = generate_fhw_model_keras(name="eight_bit_network_test",
                                                   hardware_model=generate_test_hw_model({'weights_n_bits': 8,
                                                                                          'activation_n_bits': 8}))
 
-FLOAT_QUANTIZATION = generate_fhw_model_keras(name="float_network_test",
-                                              hardware_model=generate_test_hw_model({'weights_n_bits': 16,
-                                                                                     'activation_n_bits': 16}))
+FLOAT_QUANTIZATION = get_16bit_fw_hw_model("float_network_test")
 
 
 

--- a/tests/keras_tests/feature_networks_tests/test_networks_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_networks_runner.py
@@ -13,33 +13,39 @@
 # limitations under the License.
 # ==============================================================================
 import model_compression_toolkit.common.gptq.gptq_config
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 import tensorflow as tf
 import numpy as np
 import unittest
 import model_compression_toolkit as mct
 from model_compression_toolkit.keras.gradient_ptq.gptq_loss import multiple_tensors_mse_loss
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from enum import Enum
 import random
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
-TWO_BIT_QUANTIZATION = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
-                                              weights_error_method=mct.QuantizationErrorMethod.MSE,
-                                              activation_n_bits=2, weights_n_bits=2, relu_bound_to_power_of_2=False,
-                                              weights_bias_correction=False, weights_per_channel_threshold=True)
+QUANTIZATION_CONFIG = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
+                                             weights_error_method=mct.QuantizationErrorMethod.MSE,
+                                             relu_bound_to_power_of_2=False, weights_bias_correction=False,
+                                             weights_per_channel_threshold=True)
 
-EIGHT_BIT_QUANTIZATION = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
-                                                weights_error_method=mct.QuantizationErrorMethod.MSE,
-                                                activation_n_bits=8, weights_n_bits=8, relu_bound_to_power_of_2=False,
-                                                weights_bias_correction=False, weights_per_channel_threshold=True)
+TWO_BIT_QUANTIZATION = generate_fhw_model_keras(name="two_bit_network_test",
+                                                hardware_model=generate_test_hw_model({'weights_n_bits': 2,
+                                                                                       'activation_n_bits': 2}))
 
-FLOAT_QUANTIZATION = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.MSE,
-                                            weights_error_method=mct.QuantizationErrorMethod.MSE,
-                                            activation_n_bits=16, weights_n_bits=16, relu_bound_to_power_of_2=False,
-                                            weights_bias_correction=False, weights_per_channel_threshold=True)
+EIGHT_BIT_QUANTIZATION = generate_fhw_model_keras(name="eight_bit_network_test",
+                                                  hardware_model=generate_test_hw_model({'weights_n_bits': 8,
+                                                                                         'activation_n_bits': 8}))
+
+FLOAT_QUANTIZATION = generate_fhw_model_keras(name="float_network_test",
+                                              hardware_model=generate_test_hw_model({'weights_n_bits': 16,
+                                                                                     'activation_n_bits': 16}))
+
 
 
 class RunMode(Enum):
@@ -48,10 +54,10 @@ class RunMode(Enum):
     FLOAT = 2
 
 
-def run_mode(qc):
-    if qc is FLOAT_QUANTIZATION:
+def run_mode(fw_hw_model):
+    if fw_hw_model is FLOAT_QUANTIZATION:
         return RunMode.FLOAT
-    elif qc is EIGHT_BIT_QUANTIZATION:
+    elif fw_hw_model is EIGHT_BIT_QUANTIZATION:
         return RunMode.EIGHT
     else:
         return RunMode.TWO
@@ -65,21 +71,21 @@ class NetworkTest(object):
         self.num_calibration_iter = num_calibration_iter
         self.gptq = gptq
 
-    def compare(self, inputs_list, quantized_model, qc):
+    def compare(self, inputs_list, quantized_model, qc, fw_hw_model):
         output_q = quantized_model.predict(inputs_list)
         output_f = self.model_float.predict(inputs_list)
         if isinstance(output_f, list):
             cs = np.mean([cosine_similarity(oq, of) for oq, of, in zip(output_q, output_f)])
         else:
             cs = cosine_similarity(output_f, output_q)
-        if run_mode(qc) == RunMode.FLOAT:
+        if run_mode(fw_hw_model) == RunMode.FLOAT:
             self.unit_test.assertTrue(np.isclose(cs, 1, 0.001), msg=f'fail cosine similarity check: {cs}')
-        elif run_mode(qc) == RunMode.EIGHT:
+        elif run_mode(fw_hw_model) == RunMode.EIGHT:
             pass  # remove the cs check for 8 bit quantizaiton at this stage
             # self.unit_test.assertTrue(np.isclose(cs, 1, atol=0.6), msg=f'fail cosine similarity check:{cs}')
-        elif run_mode(qc) == RunMode.TWO:
+        elif run_mode(fw_hw_model) == RunMode.TWO:
             self.unit_test.assertTrue(np.isclose(cs, 0, atol=0.5), msg=f'fail cosine similarity check:{cs}')
-        if run_mode(qc) == RunMode.EIGHT:
+        if run_mode(fw_hw_model) == RunMode.EIGHT:
             # TFLite Converter only support eight bit quantization
             try:
                 converter = tf.lite.TFLiteConverter.from_keras_model(quantized_model)
@@ -88,7 +94,7 @@ class NetworkTest(object):
                 error_msg = e.message if hasattr(e, 'message') else str(e)
                 self.unit_test.assertTrue(False, f'fail TFLite convertion with the following error: {error_msg}')
 
-    def run_network(self, inputs_list, qc):
+    def run_network(self, inputs_list, qc, fw_hw_model):
         def representative_data_gen():
             return inputs_list
 
@@ -102,14 +108,16 @@ class NetworkTest(object):
                                                                                 quant_config=qc,
                                                                                 fw_info=DEFAULT_KERAS_INFO,
                                                                                 n_iter=self.num_calibration_iter,
-                                                                                gptq_config=arc)
+                                                                                gptq_config=arc,
+                                                                                fw_hw_model=fw_hw_model)
         else:
             ptq_model, quantization_info = mct.keras_post_training_quantization(self.model_float,
                                                                                 representative_data_gen,
                                                                                 quant_config=qc,
                                                                                 fw_info=DEFAULT_KERAS_INFO,
-                                                                                n_iter=self.num_calibration_iter)
-        self.compare(inputs_list, ptq_model, qc)
+                                                                                n_iter=self.num_calibration_iter,
+                                                                                fw_hw_model=fw_hw_model)
+        self.compare(inputs_list, ptq_model, qc, fw_hw_model)
 
 
 def set_seed():
@@ -133,11 +141,14 @@ class FeatureNetworkTest(unittest.TestCase):
         inputs_list = FeatureNetworkTest.create_inputs(input_shapes)
 
         NetworkTest(self, model_float, input_shapes, num_calibration_iter, gptq=gptq).run_network(inputs_list,
+                                                                                                  QUANTIZATION_CONFIG,
                                                                                                   EIGHT_BIT_QUANTIZATION)
         if not gptq:
             NetworkTest(self, model_float, input_shapes, num_calibration_iter, gptq=gptq).run_network(inputs_list,
+                                                                                                      QUANTIZATION_CONFIG,
                                                                                                       TWO_BIT_QUANTIZATION)
             NetworkTest(self, model_float, input_shapes, num_calibration_iter, gptq=gptq).run_network(inputs_list,
+                                                                                                      QUANTIZATION_CONFIG,
                                                                                                       FLOAT_QUANTIZATION)
 
     def test_mobilenet_v1(self):

--- a/tests/keras_tests/function_tests/test_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_quantization_configurations.py
@@ -21,7 +21,9 @@ import tensorflow as tf
 from tensorflow.keras import layers
 
 import model_compression_toolkit as mct
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 
 def model_gen():
@@ -63,26 +65,14 @@ class TestQuantizationConfigurations(unittest.TestCase):
 
         model = model_gen()
         for quantize_method, error_method, bias_correction, per_channel, input_scaling in weights_test_combinations:
-            qco = mct.hardware_representation.QuantizationConfigOptions(
-                [mct.hardware_representation.OpQuantizationConfig(
-                    activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                    weights_quantization_method=quantize_method,
-                    activation_n_bits=16,
-                    weights_n_bits=8,
-                    weights_per_channel_threshold=per_channel,
-                    enable_weights_quantization=True,
-                    enable_activation_quantization=True,
-                    quantization_preserving=False,
-                    fixed_scale=None,
-                    fixed_zero_point=None,
-                    weights_multiplier_nbits=None
-                )])
-            fw_hw_model = mct.hardware_representation.FrameworkHardwareModel(
-                mct.hardware_representation.HardwareModel(qco))
+            hwm = generate_test_hw_model({
+                'weights_quantization_method': quantize_method,
+                'weights_n_bits': 8,
+                'activation_n_bits': 16})
+            fw_hw_model = generate_fhw_model_keras(name="quant_config_weights_test", hardware_model=hwm)
+
             qc = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.NOCLIPPING,
                                         weights_error_method=error_method,
-                                        activation_n_bits=16,
-                                        weights_n_bits=8,
                                         relu_bound_to_power_of_2=False,
                                         weights_bias_correction=bias_correction,
                                         weights_per_channel_threshold=per_channel,
@@ -96,27 +86,14 @@ class TestQuantizationConfigurations(unittest.TestCase):
 
         model = model_gen()
         for quantize_method, error_method, relu_bound_to_power_of_2, shift_negative_correction in activation_test_combinations:
-            qco = mct.hardware_representation.QuantizationConfigOptions(
-                [mct.hardware_representation.OpQuantizationConfig(
-                    activation_quantization_method=quantize_method,
-                    weights_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                    activation_n_bits=16,
-                    weights_n_bits=8,
-                    weights_per_channel_threshold=False,
-                    enable_weights_quantization=True,
-                    enable_activation_quantization=True,
-                    quantization_preserving=False,
-                    fixed_scale=None,
-                    fixed_zero_point=None,
-                    weights_multiplier_nbits=None
-                )])
+            hwm = generate_test_hw_model({
+                'activation_quantization_method': quantize_method,
+                'weights_n_bits': 16,
+                'activation_n_bits': 8})
+            fw_hw_model = generate_fhw_model_keras(name="quant_config_activation_test", hardware_model=hwm)
 
-            fw_hw_model = mct.hardware_representation.FrameworkHardwareModel(
-                mct.hardware_representation.HardwareModel(qco))
             qc = mct.QuantizationConfig(activation_error_method=error_method,
                                         weights_error_method=mct.QuantizationErrorMethod.NOCLIPPING,
-                                        activation_n_bits=8,
-                                        weights_n_bits=16,
                                         relu_bound_to_power_of_2=relu_bound_to_power_of_2,
                                         weights_bias_correction=False,
                                         weights_per_channel_threshold=False,

--- a/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
@@ -31,8 +31,10 @@ from model_compression_toolkit.common.quantization.quantization_params_generatio
     calculate_quantization_params
 from model_compression_toolkit.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 
 def get_uniform_weights(kernel, in_channels, out_channels):
@@ -90,31 +92,18 @@ class TestSymmetricThresholdSelectionWeights(unittest.TestCase):
 
     def run_test_for_threshold_method(self, threshold_method, per_channel=True):
         qc = QuantizationConfig(weights_error_method=threshold_method,
-                                weights_n_bits=8,
                                 weights_per_channel_threshold=per_channel)
 
-        qco = mct.hardware_representation.QuantizationConfigOptions(
-            [mct.hardware_representation.OpQuantizationConfig(
-                activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                weights_quantization_method=mct.hardware_representation.QuantizationMethod.SYMMETRIC,
-                activation_n_bits=8,
-                weights_n_bits=8,
-                weights_per_channel_threshold=True,
-                enable_weights_quantization=True,
-                enable_activation_quantization=True,
-                quantization_preserving=False,
-                fixed_scale=None,
-                fixed_zero_point=None,
-                weights_multiplier_nbits=None
-            )])
-        hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'weights_quantization_method': mct.hardware_representation.QuantizationMethod.SYMMETRIC})
+        fw_hw_model = generate_fhw_model_keras(name="symmetric_threshold_selection_test", hardware_model=hwm)
 
         fw_info = DEFAULT_KERAS_INFO
         in_model = create_network()
         keras_impl = KerasImplementation()
         graph = keras_impl.model_reader(in_model, None)  # model reading
         graph.set_fw_info(fw_info)
-        graph.set_fw_hw_model(hw_model)
+        graph.set_fw_hw_model(fw_hw_model)
         graph = set_quantization_configuration_to_graph(graph=graph,
                                                         quant_config=qc)
         for node in graph.nodes:

--- a/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
@@ -31,8 +31,10 @@ from model_compression_toolkit.common.quantization.quantization_params_generatio
 from model_compression_toolkit.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
 from model_compression_toolkit.common.model_collector import ModelCollector
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 
 def get_random_weights(kernel, in_channels, out_channels):
@@ -89,30 +91,17 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
 
     def run_test_for_threshold_method(self, threshold_method, per_channel=True):
         qc = QuantizationConfig(weights_error_method=threshold_method,
-                                weights_n_bits=8,
                                 weights_per_channel_threshold=per_channel)
 
-        qco = mct.hardware_representation.QuantizationConfigOptions(
-            [mct.hardware_representation.OpQuantizationConfig(
-                activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                weights_quantization_method=mct.hardware_representation.QuantizationMethod.UNIFORM,
-                activation_n_bits=8,
-                weights_n_bits=8,
-                weights_per_channel_threshold=True,
-                enable_weights_quantization=True,
-                enable_activation_quantization=True,
-                quantization_preserving=False,
-                fixed_scale=None,
-                fixed_zero_point=None,
-                weights_multiplier_nbits=None
-            )])
-        hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'weights_quantization_method': mct.hardware_representation.QuantizationMethod.UNIFORM})
+        fw_hw_model = generate_fhw_model_keras(name="uniform_range_selection_test", hardware_model=hwm)
 
         fw_info = DEFAULT_KERAS_INFO
         in_model = create_network()
         keras_impl = KerasImplementation()
         graph = keras_impl.model_reader(in_model, None)  # model reading
-        graph.set_fw_hw_model(hw_model)
+        graph.set_fw_hw_model(fw_hw_model)
         graph.set_fw_info(fw_info)
         graph = set_quantization_configuration_to_graph(graph=graph,
                                                         quant_config=qc)

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -2,6 +2,10 @@ from typing import List, Any, Tuple
 
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
     from tensorflow.keras.models import Model
@@ -41,6 +45,17 @@ class BaseKerasLayerTest(BaseLayerTest):
                          quantization_modes=quantization_modes,
                          is_inputs_a_list=is_inputs_a_list,
                          use_cpu=use_cpu)
+
+    def get_fw_hw_model(self):
+        if self.current_mode == LayerTestMode.FLOAT:
+            # Disable all features that are enabled by default:
+            return generate_fhw_model_keras(name="float_layer_test", hardware_model=get_default_hardware_model())
+        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
+            hwm = generate_test_hw_model({'weights_n_bits': 8,
+                                          'activation_n_bits': 8})
+            return generate_fhw_model_keras(name="8bit_layer_test", hardware_model=hwm)
+        else:
+            raise NotImplemented
 
     def get_fw_info(self) -> FrameworkInfo:
         return DEFAULT_KERAS_INFO

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -21,6 +21,7 @@ from torch.nn import Module
 
 from model_compression_toolkit import FrameworkInfo, pytorch_post_training_quantization
 from model_compression_toolkit.common.framework_implementation import FrameworkImplementation
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
 from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder
@@ -28,6 +29,8 @@ from model_compression_toolkit.pytorch.utils import torch_tensor_to_numpy, to_to
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode
 from model_compression_toolkit.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.pytorch.pytorch_implementation import PytorchImplementation
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 
 class LayerTestModel(torch.nn.Module):
     def __init__(self, layer):
@@ -107,6 +110,17 @@ class BasePytorchLayerTest(BaseLayerTest):
                          quantization_modes=quantization_modes,
                          is_inputs_a_list=is_inputs_a_list,
                          use_cpu=use_cpu)
+
+    def get_fw_hw_model(self):
+        if self.current_mode == LayerTestMode.FLOAT:
+            # Disable all features that are enabled by default:
+            return generate_fhw_model_pytorch(name="float_layer_test", hardware_model=get_default_hardware_model())
+        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
+            hwm = generate_test_hw_model({'weights_n_bits': 8,
+                                          'activation_n_bits': 8})
+            return generate_fhw_model_pytorch(name="8bit_layer_test", hardware_model=hwm)
+        else:
+            raise NotImplemented
 
     def get_fw_info(self) -> FrameworkInfo:
         return DEFAULT_PYTORCH_INFO

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -21,6 +21,7 @@ from torch.nn import Module
 
 from model_compression_toolkit import FrameworkInfo, pytorch_post_training_quantization
 from model_compression_toolkit.common.framework_implementation import FrameworkImplementation
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
 from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder
 from model_compression_toolkit.pytorch.utils import torch_tensor_to_numpy, to_torch_tensor
@@ -76,6 +77,13 @@ def get_layer_weights(layer):
     weights.update(named_parameters_weights)
     weights.update(named_buffer_weights)
     return weights
+
+
+def get_layer_test_fw_hw_model_dict(hardware_model, test_name, fhwm_name):
+    return {
+        test_name: generate_fhw_model_pytorch(name=fhwm_name,
+                                              hardware_model=hardware_model),
+    }
 
 
 class BasePytorchLayerTest(BaseLayerTest):

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -49,6 +49,8 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                                                                                           'activation_n_bits': 4})),
         }
 
+    # TODO: We can remove this method and refactor Pytorch tests to run only over
+    #  different hw models (as all configs here are identical)
     def get_quantization_configs(self):
         return {
             'no_quantization': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -17,6 +17,7 @@ from torch.fx import symbolic_trace
 
 from model_compression_toolkit import MixedPrecisionQuantizationConfig, get_model
 from model_compression_toolkit.common.constants import PYTORCH
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.constants import DEFAULT_HWM
 from model_compression_toolkit.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.pytorch.utils import get_working_device, set_model, to_torch_tensor, \
@@ -25,6 +26,7 @@ import model_compression_toolkit as mct
 import torch
 import numpy as np
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 """
 The base test class for the feature networks
@@ -34,21 +36,34 @@ class BasePytorchTest(BaseFeatureNetworkTest):
         super().__init__(unit_test)
         self.float_reconstruction_error = float_reconstruction_error
 
+    def get_fw_hw_model(self):
+        return {
+            'no_quantization': generate_fhw_model_pytorch(name="no_quant_pytorch_test",
+                                                          hardware_model=generate_test_hw_model({'weights_n_bits': 32,
+                                                                                                 'activation_n_bits': 32})),
+            'all_32bit': generate_fhw_model_pytorch(name="32_quant_pytorch_test",
+                                                    hardware_model=generate_test_hw_model({'weights_n_bits': 32,
+                                                                                           'activation_n_bits': 32})),
+            'all_4bit': generate_fhw_model_pytorch(name="4_quant_pytorch_test",
+                                                   hardware_model=generate_test_hw_model({'weights_n_bits': 4,
+                                                                                          'activation_n_bits': 4})),
+        }
+
     def get_quantization_configs(self):
         return {
             'no_quantization': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                       mct.QuantizationErrorMethod.NOCLIPPING,
-                                                      32, 32, False, True, True,
+                                                      False, True, True,
                                                       enable_weights_quantization=False,
                                                       enable_activation_quantization=False),
             'all_32bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                 mct.QuantizationErrorMethod.NOCLIPPING,
-                                                32, 32, False, True, True,
+                                                False, True, True,
                                                 enable_weights_quantization=True,
                                                 enable_activation_quantization=True),
             'all_4bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               4, 4, False, False, True,
+                                               False, False, True,
                                                enable_weights_quantization=True,
                                                enable_activation_quantization=True),
         }
@@ -107,7 +122,10 @@ class BasePytorchTest(BaseFeatureNetworkTest):
 
         ptq_models = {}
         model_float = self.create_feature_network(input_shapes)
-        for model_name, quant_config in self.get_quantization_configs().items():
+        quant_config_dict = self.get_quantization_configs()
+        for model_name in quant_config_dict.keys():
+            quant_config = quant_config_dict[model_name]
+            fw_hw_model = self.get_fw_hw_model()[model_name]
             if isinstance(quant_config, MixedPrecisionQuantizationConfig):
                 ptq_model, quantization_info = mct.pytorch_post_training_quantization_mixed_precision(model_float,
                                                                                                       representative_data_gen,
@@ -117,7 +135,7 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                                                                                                       network_editor=self.get_network_editor(),
                                                                                                       gptq_config=self.get_gptq_config(),
                                                                                                       target_kpi=self.get_kpi(),
-                                                                                                      fw_hw_model=get_model(PYTORCH, DEFAULT_HWM))
+                                                                                                      fw_hw_model=fw_hw_model)
                 ptq_models.update({model_name: ptq_model})
             else:
                 ptq_model, quantization_info = mct.pytorch_post_training_quantization(model_float,
@@ -126,7 +144,7 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                                                                                       quant_config=quant_config,
                                                                                       fw_info=DEFAULT_PYTORCH_INFO,
                                                                                       network_editor=self.get_network_editor(),
-                                                                                      fw_hw_model=get_model(PYTORCH, DEFAULT_HWM))
+                                                                                      fw_hw_model=fw_hw_model)
                 ptq_models.update({model_name: ptq_model})
 
         self.compare(ptq_models, model_float, input_x=x, quantization_info=quantization_info)

--- a/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
@@ -19,6 +19,8 @@ from model_compression_toolkit.common.network_editors.node_filters import NodeNa
 from model_compression_toolkit.common.network_editors.actions import EditRule, \
     ChangeCandidatesWeightsQuantizationMethod
 from model_compression_toolkit.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 
 hw_model = mct.hardware_representation
@@ -75,11 +77,14 @@ class LUTQuantizerTest(BasePytorchTest):
         self.num_conv_channels = 3
         self.kernel = 3
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=generate_test_hw_model({"weights_n_bits": self.weights_n_bits}),
+                                               test_name='lut_quantizer_test',
+                                               fhwm_name='lut_quantizer_pytorch_test')
+
     def get_quantization_configs(self):
         return {'lut_quantizer_test': mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
-                                                             mct.QuantizationErrorMethod.MSE,
-                                                             8,
-                                                             self.weights_n_bits)}
+                                                             mct.QuantizationErrorMethod.MSE)}
 
     def get_network_editor(self):
         return [EditRule(filter=NodeNameFilter(self.node_to_change_name),

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
@@ -18,6 +18,8 @@ from torch.nn import Conv2d
 
 from model_compression_toolkit import MixedPrecisionQuantizationConfig, KPI
 from model_compression_toolkit.common.user_info import UserInformation
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit as mct
 
@@ -30,6 +32,11 @@ class MixedPercisionBaseTest(BasePytorchTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='mixed_precision_model',
+                                               fhwm_name='mixed_precision_pytorch_test')
+
     def get_quantization_configs(self):
         qc = mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
                                     mct.QuantizationErrorMethod.MSE,
@@ -40,7 +47,6 @@ class MixedPercisionBaseTest(BasePytorchTest):
                                     input_scaling=False)
 
         return {"mixed_precision_model": MixedPrecisionQuantizationConfig(qc,
-                                                                          n_bits_candidates=[(2, 8), (8, 8), (4, 8)],
                                                                           num_of_images=1)}
 
     def create_feature_network(self, input_shape):

--- a/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 import torch
+
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 from torch.nn import Conv2d, ReLU, ReLU6, Hardtanh
 from torch.nn.functional import relu, relu6, hardtanh
@@ -92,6 +95,11 @@ class ReLUBoundToPOTNetTest(BasePytorchTest):
     def create_inputs_shape(self):
         return [[self.val_batch_size, 3, 32, 32]]
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='8bit_relu_bound',
+                                               fhwm_name='relu_bound_pytorch_test')
+
     def get_quantization_configs(self):
         quant_config = mct.DEFAULTCONFIG
         quant_config.relu_bound_to_power_of_2 = True
@@ -127,6 +135,11 @@ class HardtanhBoundToPOTNetTest(BasePytorchTest):
 
     def create_inputs_shape(self):
         return [[self.val_batch_size, 3, 32, 32]]
+
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='8bit_relu_bound',
+                                               fhwm_name='relu_bound_pytorch_test')
 
     def get_quantization_configs(self):
         quant_config = mct.DEFAULTCONFIG

--- a/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 import torch
 
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 from model_compression_toolkit.pytorch.utils import to_torch_tensor
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit as mct
 import numpy as np
@@ -51,12 +53,15 @@ class ShiftNegaviteActivationNetTest(BasePytorchTest):
         i[0][0, 0, 0, 1] = -10
         return i
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='all_8bit',
+                                               fhwm_name='sn_pytorch_test')
+
     def get_quantization_configs(self):
         return {
             'all_8bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               8,
-                                               8,
                                                enable_weights_quantization=True,
                                                enable_activation_quantization=True,
                                                shift_negative_activation_correction=True,

--- a/tutorials/example_keras_mobilenet_mixed_precision.py
+++ b/tutorials/example_keras_mobilenet_mixed_precision.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     # will search a mixed-precision configuration (namely, bit width for each layer)
     # and quantize the model according to this configuration.
     # Here, each layer can be quantized by 2, 4 or 8 bits.
-    configuration = MixedPrecisionQuantizationConfig(weights_n_bits=[2, 8, 4])
+    configuration = MixedPrecisionQuantizationConfig()
 
     # Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that
     # should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias

--- a/tutorials/example_keras_mobilenet_mixed_precision.py
+++ b/tutorials/example_keras_mobilenet_mixed_precision.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     # Create a mixed-precision configuration with possible bit widths. MCT
     # will search a mixed-precision configuration (namely, bit width for each layer)
     # and quantize the model according to this configuration.
-    # Here, each layer can be quantized by 2, 4 or 8 bits.
+    # The candidates bitwidth for quantization should be defined in the hardware model:
     configuration = MixedPrecisionQuantizationConfig()
 
     # Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that


### PR DESCRIPTION
Refactor to allow getting quantization n_bits configuration candidates from hardware model instead of quantization config.
Main changes include:

- Remove n_bitsfor both weights and activation from QuantizationConfig and remove n_bits_candidates from MixedPrecisionQuantizationConfig (refactor entire lib accordingly)
- Set node's candidates config with info from hardware model
- Large refactor in tests - to adjust setting test configuration with hw model