### PR TITLE
Get quantization enable info from hw model

### DIFF
--- a/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
+++ b/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
@@ -36,7 +36,7 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     graph = copy.deepcopy(graph_to_apply_bias_correction)
     for n in graph.nodes:
-        if fw_info.in_kernel_ops(n) and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.enable_weights_quantization:
             # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
             # a bias correction term was calculated during model preparation, and is used now in the node's bias term.
             if n.final_weights_quantization_cfg.weights_bias_correction:

--- a/model_compression_toolkit/common/framework_info.py
+++ b/model_compression_toolkit/common/framework_info.py
@@ -42,9 +42,6 @@ class ChannelAxis(Enum):
 class FrameworkInfo(object):
 
     def __init__(self,
-                 kernel_ops: list,
-                 activation_ops: list,
-                 no_quantization_ops: list,
                  activation_quantizer_mapping: Dict[QuantizationMethod, Callable],
                  weights_quantizer_mapping: Dict[QuantizationMethod, Callable],
                  kernel_channels_mapping: DefaultDict,
@@ -62,9 +59,6 @@ class FrameworkInfo(object):
         no_quantization_ops:Layers that should not get quantized (e.g., Reshape, Transpose, etc.)
 
         Args:
-            kernel_ops (list): A list of operators that are in the kernel_ops group.
-            activation_ops (list): A list of operators that are in the activation_ops group.
-            no_quantization_ops (list): A list of operators that are in the no_quantization_ops group.
             activation_quantizer_mapping (Dict[QuantizationMethod, Callable]): A dictionary mapping from QuantizationMethod to a quantization function.
             weights_quantizer_mapping (Dict[QuantizationMethod, Callable]): A dictionary mapping from QuantizationMethod to a quantization function.
             kernel_channels_mapping (DefaultDict): Dictionary from a layer to a tuple of its kernel in/out channels indices.
@@ -83,35 +77,20 @@ class FrameworkInfo(object):
 
             Then, we can create a FrameworkInfo object:
 
-            >>> FrameworkInfo(kernel_ops, [], [], kernel_channels_mapping, {}, {})
-
-            and pass it to :func:`~model_compression_toolkit.keras_post_training_quantization`.
-
-            To quantize the activations of ReLU, we can create a new FrameworkInfo instance:
-
-            >>> activation_ops = [tf.keras.layers.ReLU]
-            >>> FrameworkInfo(kernel_ops, activation_ops, [], kernel_channels_mapping, {}, {})
-
-            If we don't want to quantize a layer (e.g. Reshape), we can add it to the no_no_quantization_ops list:
-
-            >>> no_quantization_ops = [tf.keras.layers.Reshape]
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, {}, {})
+            >>> FrameworkInfo(kernel_channels_mapping, {}, {})
 
             If an activation layer (tf.keras.layers.Activation) should be quantized and we know it's min/max outputs range in advanced, we can add it to activation_min_max_mapping for saving the statistics collection time. For example:
 
             >>> activation_min_max_mapping = {'softmax': (0, 1)}
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, activation_min_max_mapping, {})
+            >>> FrameworkInfo(kernel_channels_mapping, activation_min_max_mapping, {})
 
             If a layer's activations should be quantized and we know it's min/max outputs range in advanced, we can add it to layer_min_max_mapping for saving the statistics collection time. For example:
 
             >>> layer_min_max_mapping = {tf.keras.layers.Softmax: (0, 1)}
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, activation_min_max_mapping, layer_min_max_mapping)
+            >>> FrameworkInfo(kernel_channels_mapping, activation_min_max_mapping, layer_min_max_mapping)
 
         """
 
-        self.kernel_ops = kernel_ops
-        self.activation_ops = activation_ops
-        self.no_quantization_ops = no_quantization_ops
         self.activation_quantizer_mapping = activation_quantizer_mapping
         self.weights_quantizer_mapping = weights_quantizer_mapping
         self.kernel_channels_mapping = kernel_channels_mapping
@@ -158,40 +137,3 @@ class FrameworkInfo(object):
         """
 
         return activation_name in self.activation_min_max_mapping
-
-    def in_kernel_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the kernel_ops group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the kernel_ops group or not.
-        """
-
-        return n.type in self.kernel_ops
-
-    def in_activation_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the activation group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the activation group or not.
-        """
-        return n.type in self.activation_ops
-
-    def in_no_quantization_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the no quantization group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the no quantization group or not.
-        """
-        return n.type in self.no_quantization_ops

--- a/model_compression_toolkit/common/gptq/gptq_config.py
+++ b/model_compression_toolkit/common/gptq/gptq_config.py
@@ -39,8 +39,9 @@ class GradientPTQConfig:
         Args:
             n_iter (int): Number of iterations to train.
             optimizer (Any): Optimizer to use.
-            loss (Callable): The loss to use. should accept 4 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors,
-             the 3rd is a list of quantized weights and the 4th is a list of float weights.
+            loss (Callable): The loss to use. should accept 6 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors,
+             the 3rd is a list of quantized weights, the 4th is a list of float weights, the 5th and 6th lists are the mean and std of the tensors
+             accordingly. see example in multiple_tensors_mse_loss
             log_function (Callable): Function to log information about the GPTQ process.
             train_bias (bool): Whether to update the bias during the training or not.
             lsb_change_per_bit_width (dict): Whether to update the bias during the training or not.

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -45,48 +45,34 @@ def set_bit_widths(quant_config: QuantizationConfig,
     graph = copy.deepcopy(graph_to_set_bit_widths)
 
     if isinstance(quant_config, MixedPrecisionQuantizationConfig):
-        if len(quant_config.n_bits_candidates) == 0:
-            Logger.critical(
-                f'Quantization configuration nbits candidates list has to contain at least one bit width candidate. '
-                f'Length is: '
-                f'{len(quant_config.n_bits_candidates)}')
+        assert all([len(n.candidates_quantization_cfg) > 0 for n in graph.get_configurable_sorted_nodes()]), \
+            "All configurable nodes in graph should have at least one candidate configuration in mixed precision mode"
 
-        # When working in mixed-precision mode, and there's only one bitwidth, we simply set the
-        # only candidate of the node as its final weight and activation quantization configuration.
-        if len(quant_config.n_bits_candidates) == 1:
-            for n in graph.nodes:
-                if n.name in graph.get_configurable_sorted_nodes_names():
-                    assert len(n.candidates_quantization_cfg) == 1
-                    n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
-                    n.final_activation_quantization_cfg = n.candidates_quantization_cfg[0].activation_quantization_cfg
-
-        else:
-            Logger.info(f'Set bit widths from configuration: {bit_widths_config}')
-            # Get a list of nodes' names we need to finalize (that they have at least one weight qc candidate).
-            sorted_nodes_names = graph.get_configurable_sorted_nodes_names()
-            for node in graph.nodes:  # set a specific node qc for each node final weights qc
-                # If it's reused, take the configuration that the base node has
-                node_name = node.name if not node.reuse else '_'.join(node.name.split('_')[:-2])
-                if node_name in sorted_nodes_names:  # only configurable nodes are in this list
-                    node_index_in_graph = sorted_nodes_names.index(node_name)
-                    _set_node_final_qc(bit_widths_config,
-                                       fw_info,
-                                       node,
-                                       node_index_in_graph)
-                else:
-                    # TODO: refactor after adding activation mixed precision
-                    if node.is_activation_quantization_enabled():
-                        assert node.is_all_activation_candidates_equal, "Activation Mixed Precision is not supported"
-                        node.final_activation_quantization_cfg = node.candidates_quantization_cfg[0].activation_quantization_cfg
+        Logger.info(f'Set bit widths from configuration: {bit_widths_config}')
+        # Get a list of nodes' names we need to finalize (that they have at least one weight qc candidate).
+        sorted_nodes_names = graph.get_configurable_sorted_nodes_names()
+        for node in graph.nodes:  # set a specific node qc for each node final weights qc
+            # If it's reused, take the configuration that the base node has
+            node_name = node.name if not node.reuse else '_'.join(node.name.split('_')[:-2])
+            if node_name in sorted_nodes_names:  # only configurable nodes are in this list
+                node_index_in_graph = sorted_nodes_names.index(node_name)
+                _set_node_final_qc(bit_widths_config,
+                                   fw_info,
+                                   node,
+                                   node_index_in_graph)
+            else:
+                # TODO: refactor after adding activation mixed precision
+                if node.is_activation_quantization_enabled():
+                    assert node.is_all_activation_candidates_equal, "Activation Mixed Precision is not supported"
+                    node.final_activation_quantization_cfg = node.candidates_quantization_cfg[
+                        0].activation_quantization_cfg
 
     # When working in non-mixed-precision mode, there's only one bitwidth, and we simply set the
-    # only candidate of the node as its final weight quantization configuration.
+    # only candidate of the node as its final weight and activation quantization configuration.
     else:
         for n in graph.nodes:
             assert len(n.candidates_quantization_cfg) == 1
-            if fw_info.in_kernel_ops(n):
-                n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
-            # TODO: do we need to set final config only to specific layer (fake quant?) or is setting to all layers is fine?
+            n.final_weights_quantization_cfg = n.candidates_quantization_cfg[0].weights_quantization_cfg
             n.final_activation_quantization_cfg = n.candidates_quantization_cfg[0].activation_quantization_cfg
 
     return graph
@@ -141,5 +127,5 @@ def _set_node_final_qc(bit_width_cfg: List[int],
     else:
         if fw_info.in_kernel_ops(node):
             node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
-        # TODO: do we need to set final config only to specific layer (fake quant?) or is setting to all layers is fine?
+        node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_activation_quantization_cfg = node_qc.activation_quantization_cfg

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -125,7 +125,5 @@ def _set_node_final_qc(bit_width_cfg: List[int],
         Logger.critical(f'Node {node.name} quantization configuration from configuration file'
                         f' was not found in candidates configurations.')
     else:
-        if fw_info.in_kernel_ops(node):
-            node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_weights_quantization_cfg = node_qc.weights_quantization_cfg
         node.final_activation_quantization_cfg = node_qc.activation_quantization_cfg

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -25,7 +25,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
     def __init__(self,
                  qc: QuantizationConfig = DEFAULTCONFIG,
-                 n_bits_candidates: List[Tuple[int, int]] = None,
                  compute_distance_fn: Callable = compute_mse,
                  distance_weighting_method: Callable = get_average_weights,
                  num_of_images: int = 32,
@@ -37,8 +36,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
         Args:
             qc (QuantizationConfig): QuantizationConfig object containing parameters of how the model should be quantized.
-            n_bits_candidates (List[Tuple[int, int]]): List of possible number of bits to quantize the coefficients and
-                activations (Tuple of (weights n_bits, activations n_bits)).
             compute_distance_fn (Callable): Function to compute a distance between two tensors.
             distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
             num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
@@ -47,8 +44,6 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
         """
 
         super().__init__(**qc.__dict__)
-        self.n_bits_candidates = n_bits_candidates if n_bits_candidates is not None else [(qc.weights_n_bits,
-                                                                                           qc.activation_n_bits)]
         self.compute_distance_fn = compute_distance_fn
         self.distance_weighting_method = distance_weighting_method
         self.num_of_images = num_of_images
@@ -57,6 +52,5 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
 # Default quantization configuration the library use.
 DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
-                                                                 [(2, 8), (4, 8), (8, 8)],  # mixed precision only for weights
                                                                  compute_mse,
                                                                  get_average_weights)

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -461,8 +461,7 @@ def _prepare_model_for_quantization(in_model: Any,
     ######################################
     # Shift Negative Activations
     ######################################
-    if quant_config.shift_negative_activation_correction and \
-            quant_config.enable_activation_quantization:
+    if quant_config.shift_negative_activation_correction:
         transformed_graph = fw_impl.shift_negative_correction(transformed_graph,
                                                               quant_config,
                                                               fw_info)

--- a/model_compression_toolkit/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/node_quantization_config.py
@@ -83,7 +83,7 @@ class NodeActivationQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.activation_quantization_method = op_cfg.activation_quantization_method
         self.activation_n_bits = op_cfg.activation_n_bits
         self.relu_bound_to_power_of_2 = qc.relu_bound_to_power_of_2
-        self.enable_activation_quantization = qc.enable_activation_quantization
+        self.enable_activation_quantization = op_cfg.enable_activation_quantization
         self.activation_channel_equalization = qc.activation_channel_equalization
         self.input_scaling = qc.input_scaling
         self.min_threshold = qc.min_threshold
@@ -217,7 +217,7 @@ class NodeWeightsQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.weights_n_bits = op_cfg.weights_n_bits
         self.weights_bias_correction = qc.weights_bias_correction
         self.weights_per_channel_threshold = qc.weights_per_channel_threshold
-        self.enable_weights_quantization = qc.enable_weights_quantization
+        self.enable_weights_quantization = op_cfg.enable_weights_quantization
         self.min_threshold = qc.min_threshold
         self.l_p_value = qc.l_p_value
 

--- a/model_compression_toolkit/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/node_quantization_config.py
@@ -81,7 +81,7 @@ class NodeActivationQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.activation_quantization_params = {}
         self.activation_error_method = qc.activation_error_method
         self.activation_quantization_method = op_cfg.activation_quantization_method
-        self.activation_n_bits = qc.activation_n_bits
+        self.activation_n_bits = op_cfg.activation_n_bits
         self.relu_bound_to_power_of_2 = qc.relu_bound_to_power_of_2
         self.enable_activation_quantization = qc.enable_activation_quantization
         self.activation_channel_equalization = qc.activation_channel_equalization
@@ -214,7 +214,7 @@ class NodeWeightsQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.weights_quantization_params = {}
         self.weights_error_method = qc.weights_error_method
         self.weights_quantization_method = op_cfg.weights_quantization_method
-        self.weights_n_bits = qc.weights_n_bits
+        self.weights_n_bits = op_cfg.weights_n_bits
         self.weights_bias_correction = qc.weights_bias_correction
         self.weights_per_channel_threshold = qc.weights_per_channel_threshold
         self.enable_weights_quantization = qc.enable_weights_quantization

--- a/model_compression_toolkit/common/quantization/quantization_analyzer.py
+++ b/model_compression_toolkit/common/quantization/quantization_analyzer.py
@@ -60,7 +60,7 @@ def analyzer_graph(node_analyze_func: Callable,
         # If we use bias correction, and the node has coefficients to quantize, we need to make sure
         # its previous nodes' tensors are consistent with this node.
         # TODO: factor tensor marking in case of bias correction.
-        if qc.weights_bias_correction and fw_info.in_kernel_ops(n):
+        if qc.weights_bias_correction and n.is_weights_quantization_enabled():
             for ie in graph.incoming_edges(n):
                 input_node = ie.source_node
                 create_tensor2node(graph,

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -49,8 +49,6 @@ class QuantizationConfig(object):
     def __init__(self,
                  activation_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
                  weights_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
-                 activation_n_bits: int = 8,
-                 weights_n_bits: int = 8,
                  relu_bound_to_power_of_2: bool = False,
                  weights_bias_correction: bool = True,
                  weights_per_channel_threshold: bool = True,
@@ -70,8 +68,6 @@ class QuantizationConfig(object):
         Args:
             activation_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
             weights_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
-            activation_n_bits (int): Number of bits to quantize the activations.
-            weights_n_bits (int): Number of bits to quantize the coefficients.
             relu_bound_to_power_of_2 (bool): Whether to use relu to power of 2 scaling correction or not.
             weights_bias_correction (bool): Whether to use weights bias correction or not.
             weights_per_channel_threshold (bool): Whether to quantize the weights per-channel or not (per-tensor).
@@ -94,23 +90,16 @@ class QuantizationConfig(object):
             enabling relu_bound_to_power_of_2, weights_bias_correction, and quantizing the weights per-channel,
             one can instantiate a quantization configuration:
 
-            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,activation_n_bits=6,weights_n_bits=7,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
+            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
 
 
             The QuantizationConfig instanse can then be passed to
             :func:`~model_compression_toolkit.keras_post_training_quantization`
 
-            In order to use a different quantization method (than power-of-two that is used by default),
-            one may pass a desired QuantizationMethod when instantiating a QuantizationConfig. For example:
-
-            >>> qc = QuantizationConfig(activation_quantization_method=QuantizationMethod.LUT_QUANTIZER)
-
         """
 
         self.activation_error_method = activation_error_method
         self.weights_error_method = weights_error_method
-        self.activation_n_bits = activation_n_bits
-        self.weights_n_bits = weights_n_bits
         self.relu_bound_to_power_of_2 = relu_bound_to_power_of_2
         self.weights_bias_correction = weights_bias_correction
         self.weights_per_channel_threshold = weights_per_channel_threshold
@@ -132,8 +121,6 @@ class QuantizationConfig(object):
 # Default quantization configuration the library use.
 DEFAULTCONFIG = QuantizationConfig(QuantizationErrorMethod.MSE,
                                    QuantizationErrorMethod.MSE,
-                                   activation_n_bits=8,
-                                   weights_n_bits=8,
                                    relu_bound_to_power_of_2=False,
                                    weights_bias_correction=True,
                                    weights_per_channel_threshold=True,

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -53,8 +53,6 @@ class QuantizationConfig(object):
                  weights_bias_correction: bool = True,
                  weights_per_channel_threshold: bool = True,
                  input_scaling: bool = False,
-                 enable_weights_quantization: bool = True,
-                 enable_activation_quantization: bool = True,
                  shift_negative_activation_correction: bool = False,
                  activation_channel_equalization: bool = False,
                  z_threshold: float = math.inf,
@@ -72,8 +70,6 @@ class QuantizationConfig(object):
             weights_bias_correction (bool): Whether to use weights bias correction or not.
             weights_per_channel_threshold (bool): Whether to quantize the weights per-channel or not (per-tensor).
             input_scaling (bool): Whether to use input scaling or not.
-            enable_weights_quantization (bool): Whether to quantize the model weights or not.
-            enable_activation_quantization (bool): Whether to quantize the model activations or not.
             shift_negative_activation_correction (bool): Whether to use shifting negative activation correction or not.
             activation_channel_equalization (bool): Whether to use activation channel equalization correction or not.
             z_threshold (float): Value of z score for outliers removal.
@@ -90,7 +86,7 @@ class QuantizationConfig(object):
             enabling relu_bound_to_power_of_2, weights_bias_correction, and quantizing the weights per-channel,
             one can instantiate a quantization configuration:
 
-            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
+            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
 
 
             The QuantizationConfig instanse can then be passed to
@@ -103,8 +99,6 @@ class QuantizationConfig(object):
         self.relu_bound_to_power_of_2 = relu_bound_to_power_of_2
         self.weights_bias_correction = weights_bias_correction
         self.weights_per_channel_threshold = weights_per_channel_threshold
-        self.enable_weights_quantization = enable_weights_quantization
-        self.enable_activation_quantization = enable_activation_quantization
         self.activation_channel_equalization = activation_channel_equalization
         self.input_scaling = input_scaling
         self.min_threshold = min_threshold

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
@@ -51,40 +51,22 @@ def calculate_quantization_params(graph: Graph,
     nodes_list: List[BaseNode] = nodes if specific_nodes else graph.nodes()
 
     for n in nodes_list:  # iterate only nodes that we should compute their thresholds
-
-        weights_params, activation_params, activation_is_signed, output_channels_axis, \
-        input_channels_axis, activation_threshold_float = {}, {}, None, None, None, None
-
         for candidate_qc in n.candidates_quantization_cfg:
-            if fw_info.in_kernel_ops(n):  # If the node has a kernel to quantize
-                if n.is_weights_quantization_enabled():
-                    output_channels_axis, _ = get_channels_axis(candidate_qc.weights_quantization_cfg, fw_info, n.type)
-                    weights_params = get_weights_qparams(n.get_weights_by_keys(fw_impl.constants.KERNEL),
-                                                         candidate_qc.weights_quantization_cfg,
-                                                         output_channels_axis)
+            if n.is_weights_quantization_enabled():
+                # If node's weights should be quantized, we compute its weights' quantization parameters
+                output_channels_axis, _ = get_channels_axis(candidate_qc.weights_quantization_cfg, fw_info, n.type)
+                weights_params = get_weights_qparams(n.get_weights_by_keys(fw_impl.constants.KERNEL),
+                                                     candidate_qc.weights_quantization_cfg,
+                                                     output_channels_axis)
 
-                    candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
-                    candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
+                candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
+                candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
 
-                if n.is_activation_quantization_enabled():
-                    # If node's activations should be quantized as well, we compute its activation threshold
-                    activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
-                                                                nodes_prior_info=n.prior_info,
-                                                                out_stats_container=graph.get_out_stats_collector(n))
-
-            elif fw_info.in_activation_ops(n):  # If node has no kernel, but its activations should be quantized
-                if n.is_activation_quantization_enabled():
-                    activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
-                                                                nodes_prior_info=n.prior_info,
-                                                                out_stats_container=graph.get_out_stats_collector(n))
-            # If node should not be quantized at all
-            elif fw_info.in_no_quantization_ops(n):
-                pass  # pragma: no cover
-
-            # Create a NodeQuantizationConfig containing all quantization params and attach it to the node
             if n.is_activation_quantization_enabled():
+                # If node's activations should be quantized as well, we compute its activation quantization parameters
+                activation_params = get_activations_qparams(
+                    activation_quant_cfg=candidate_qc.activation_quantization_cfg,
+                    nodes_prior_info=n.prior_info,
+                    out_stats_container=graph.get_out_stats_collector(n))
+                # Create a NodeQuantizationConfig containing all quantization params and attach it to the node
                 candidate_qc.activation_quantization_cfg.set_activation_quantization_param(activation_params)
-
-        # If layer type is not in framework info, log a warning.
-        if not fw_info.in_no_quantization_ops(n) and not fw_info.in_activation_ops(n) and not fw_info.in_kernel_ops(n):
-            Logger.warning(f"Warning: unknown layer: {n.type.__name__}")

--- a/model_compression_toolkit/common/quantization/quantize_graph_weights.py
+++ b/model_compression_toolkit/common/quantization/quantize_graph_weights.py
@@ -42,7 +42,7 @@ def quantize_graph_weights(graph_to_quantize: Graph,
     # (according to operators groups in framework info).
     for n in graph.nodes():
 
-        if fw_info.in_kernel_ops(n) and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.enable_weights_quantization:
             quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
                                                                                     n,
                                                                                     n.final_weights_quantization_cfg,

--- a/model_compression_toolkit/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/set_node_quantization_config.py
@@ -78,15 +78,11 @@ def set_quantization_configs_to_node(node: BaseNode,
                                                                   weight_channel_axis,
                                                                   node_qc_options)
 
-    enable_activation_quantization = quant_config.enable_activation_quantization \
-                                     and (fw_info.in_activation_ops(node) or fw_info.in_kernel_ops(node)) \
-                                     and node.get_has_activation()
-    enable_weights_quantization = quant_config.enable_weights_quantization \
-                                  and fw_info.in_kernel_ops(node) \
-                                  and node.has_weights_to_quantize(fw_info)
     for candidate_qc in node.candidates_quantization_cfg:
-        candidate_qc.weights_quantization_cfg.enable_weights_quantization = enable_weights_quantization
-        candidate_qc.activation_quantization_cfg.enable_activation_quantization = enable_activation_quantization
+        candidate_qc.weights_quantization_cfg.enable_weights_quantization = \
+            candidate_qc.weights_quantization_cfg.enable_weights_quantization and node.has_weights_to_quantize(fw_info)
+        candidate_qc.activation_quantization_cfg.enable_activation_quantization =\
+            candidate_qc.activation_quantization_cfg.enable_activation_quantization and node.get_has_activation()
 
 
 def create_node_activation_qc(qc: QuantizationConfig,

--- a/model_compression_toolkit/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/common/substitutions/shift_negative_activation.py
@@ -328,12 +328,13 @@ def shift_negative_function(graph: Graph,
                     bypass_candidate_qc.activation_quantization_cfg.activation_quantization_params[SIGNED] = False
                     graph.shift_stats_collector(bypass_node, np.array(shift_value))
 
-    for candidate_qc in add_node.candidates_quantization_cfg:
+    add_node_qco = graph.fw_hw_model.get_qco_by_node(add_node).quantization_config_list
+    for op_qc_idx, candidate_qc in enumerate(add_node.candidates_quantization_cfg):
         candidate_qc.weights_quantization_cfg.enable_weights_quantization = False
 
         candidate_qc.activation_quantization_cfg = create_node_activation_qc(qc,
                                                                              fw_info,
-                                                                             graph.fw_hw_model.get_default_op_qc())
+                                                                             add_node_qco[op_qc_idx])
 
         candidate_qc.activation_quantization_cfg.set_activation_quantization_param({THRESHOLD: activation_threshold,
                                                                                     SIGNED: False})
@@ -461,13 +462,14 @@ def apply_shift_negative_correction(graph: Graph,
     Returns:
         Graph after applying shift negative on selected activations.
     """
-    # Skip substitution if QuantizationMethod is uniform.
-    op_qc = graph.fw_hw_model.get_default_op_qc()
-    if op_qc.activation_quantization_method is QuantizationMethod.UNIFORM:
-        return graph
-
     nodes = list(graph.nodes())
     for n in nodes:
+        # Skip substitution if QuantizationMethod is uniform.
+        node_qco = graph.fw_hw_model.get_qco_by_node(n)
+        if any([op_qc.activation_quantization_method is QuantizationMethod.UNIFORM
+                for op_qc in node_qco.quantization_config_list]):
+            continue
+
         if snc_node_types.apply(n):
             linear_node, pad_node, bypass_nodes = get_next_nodes_to_correct(n,
                                                                             graph,
@@ -476,7 +478,7 @@ def apply_shift_negative_correction(graph: Graph,
                                                                             pad_node_types,
                                                                             is_padding_node_and_node_has_padding
                                                                             )
-            if linear_node is not None:
+            if linear_node is not None and n.is_activation_quantization_enabled():
                 graph = shift_negative_function(graph,
                                                 quant_config,
                                                 n,

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -17,13 +17,9 @@
 import tensorflow as tf
 
 if tf.__version__ < "2.6":
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, Dropout, \
-        MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, InputLayer, \
-        Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute, LayerNormalization
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 else:
-    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
-    Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, \
-    InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute, LayerNormalization
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -35,75 +31,6 @@ from model_compression_toolkit.common.quantization.quantizers.uniform_quantizers
 from model_compression_toolkit.keras.constants import SOFTMAX, LINEAR, RELU, SWISH, SIGMOID, IDENTITY, TANH, SELU, \
     KERNEL, DEPTHWISE_KERNEL
 from model_compression_toolkit.keras.quantizer.fake_quant_builder import power_of_two_quantization, symmetric_quantization, uniform_quantization
-
-"""
-Division of Keras layers by how they should be quantized.
-KERNEL_OPS: Layers that their coefficients should be quantized.
-ACTIVATION: Layers that their activation should be quantized.
-NO_QUANTIZATION: Layers that should not be quantized.
-"""
-
-KERNEL_OPS = [Conv2D,
-              DepthwiseConv2D,
-              Dense,
-              Conv2DTranspose]
-
-NO_QUANTIZATION = [Reshape,
-                   tf.reshape,
-                   Flatten,
-                   Permute,
-                   Cropping2D,
-                   ZeroPadding2D,
-                   Dropout,
-                   MaxPooling2D,
-                   tf.reshape,
-                   tf.split,
-                   tf.quantization.fake_quant_with_min_max_vars]  # TODO:  replace with marking
-
-ACTIVATION = [Activation,
-              ReLU,
-              tf.nn.relu,
-              tf.nn.relu6,
-              tf.nn.leaky_relu,
-              Softmax,
-              GlobalAveragePooling2D,
-              Add,
-              Multiply,
-              AveragePooling2D,
-              UpSampling2D,
-              InputLayer,
-              Concatenate,
-              PReLU,
-              ELU,
-              tf.nn.silu,
-              tf.nn.swish,
-              tf.nn.sigmoid,
-              tf.nn.tanh,
-              tf.nn.relu,
-              tf.nn.relu6,
-              tf.nn.leaky_relu,
-              LeakyReLU,
-              tf.nn.softsign,
-              tf.nn.gelu,
-              tf.nn.elu,
-              tf.nn.selu,
-              tf.nn.softplus,
-              tf.nn.softmax,
-              Dot,
-              LayerNormalization,
-              tf.add,
-              tf.multiply,
-              tf.reduce_mean,
-              tf.reduce_min,
-              tf.reduce_sum,
-              tf.reduce_max,
-              tf.image.resize,
-              tf.image.crop_and_resize,
-              tf.concat,
-              ]
-
-
-
 
 """
 Map each layer to a list of its' weights attributes that should get quantized.
@@ -178,10 +105,7 @@ Output channel index of the model's layers
 """
 OUTPUT_CHANNEL_INDEX = ChannelAxis.NHWC
 
-DEFAULT_KERAS_INFO = FrameworkInfo(KERNEL_OPS,
-                                   ACTIVATION,
-                                   NO_QUANTIZATION,
-                                   ACTIVATION_QUANTIZER_MAPPING,
+DEFAULT_KERAS_INFO = FrameworkInfo(ACTIVATION_QUANTIZER_MAPPING,
                                    WEIGHTS_QUANTIZER_MAPPING,
                                    DEFAULT_CHANNEL_AXIS_DICT,
                                    ACTIVATION2MINMAX,

--- a/model_compression_toolkit/keras/gradient_ptq/gptq_loss.py
+++ b/model_compression_toolkit/keras/gradient_ptq/gptq_loss.py
@@ -36,7 +36,10 @@ def mse_loss(y: tf.Tensor, x: tf.Tensor, normalized: bool = True) -> tf.Tensor:
 def multiple_tensors_mse_loss(y_list: List[tf.Tensor],
                               x_list: List[tf.Tensor],
                               fxp_w_list: List[List[tf.Tensor]],
-                              flp_w_list: List[List[tf.Tensor]]) -> tf.Tensor:
+                              flp_w_list: List[List[tf.Tensor]],
+                              act_bn_mean: List,
+                              act_bn_std: List,
+                              ) -> tf.Tensor:
     """
     Compute MSE similarity between two lists of tensors
 
@@ -45,6 +48,8 @@ def multiple_tensors_mse_loss(y_list: List[tf.Tensor],
         x_list: Second list of tensors.
         fxp_w_list: list of lists each containing a quantized model layer's trainable weights - quantized
         flp_w_list: list of lists each containing a float model layer's weights - not quantized
+        act_bn_mean: list of prior activations mean collected from batch normalization. None is there's no info
+        act_bn_std: list of prior activations std collected from batch normalization. None is there's no info
 
     Returns:
         A single loss value which is the average of all MSE loss of all tensor pairs

--- a/model_compression_toolkit/keras/gradient_ptq/graph_info.py
+++ b/model_compression_toolkit/keras/gradient_ptq/graph_info.py
@@ -75,7 +75,9 @@ def get_trainable_parameters(fxp_model: Model,
             # collect trainable weights per layer
             layer_trainable_weights = layer.quantize_config.get_trainable_quantizer_parameters()
             if add_bias:
-                use_bias = isinstance(layer.layer, tuple(fw_info.kernel_ops)) and layer.layer.get_config().get(USE_BIAS)
+                kernel_ops_attrs = fw_info.kernel_ops_attributes_mapping.get(type(layer.layer))
+                use_bias = kernel_ops_attrs is not None and kernel_ops_attrs[0] is not None \
+                           and layer.layer.get_config().get(USE_BIAS)
                 if use_bias is not None and use_bias:
                     layer_trainable_weights.append(layer.layer.bias)
             trainable_weights.append(layer_trainable_weights)

--- a/model_compression_toolkit/keras/gradient_ptq/graph_info.py
+++ b/model_compression_toolkit/keras/gradient_ptq/graph_info.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 
 
-import numpy as np
 import tensorflow as tf
 from tensorflow_model_optimization.python.core.quantization.keras.quantize_wrapper import QuantizeWrapper
 from typing import Tuple, List
@@ -27,23 +26,31 @@ from model_compression_toolkit.common.framework_info import FrameworkInfo
 from tensorflow.keras.models import Model
 
 
-def get_compare_points(input_graph: Graph) -> Tuple[List[BaseNode], List[str]]:
+def get_compare_points(input_graph: Graph) -> Tuple[List[BaseNode], List[str], List, List]:
     """
     Create a list of nodes with weights in a graph and a corresponding list
-    of their names for tensors comparison purposes.
+    of their names for tensors comparison purposes. Also outputs 2 list of activations
+    prior information collected from batch normalization nodes (if exists)
     Args:
         input_graph: Graph to get its points to compare.
 
     Returns:
-        A list of nodes in a graph, and a list of the their names.
+        A list of nodes in a graph
+        A list of the their names.
+        A list of nodes mean collected from BatchNorms in the graph
+        A list of nodes std collected from BatchNorms in the graph
     """
     compare_points = []
+    compare_points_mean = []
+    compare_points_std = []
     compare_points_name = []
     for n in input_graph.get_topo_sorted_nodes():
         if len(n.weights) > 0:
             compare_points.append(n)
             compare_points_name.append(n.name)
-    return compare_points, compare_points_name
+            compare_points_std.append(n.prior_info.std_output)
+            compare_points_mean.append(n.prior_info.mean_output)
+    return compare_points, compare_points_name, compare_points_mean, compare_points_std
 
 
 def get_trainable_parameters(fxp_model: Model,

--- a/model_compression_toolkit/keras/gradient_ptq/training_wrapper.py
+++ b/model_compression_toolkit/keras/gradient_ptq/training_wrapper.py
@@ -57,7 +57,7 @@ def gptq_training_wrapper(tg: Graph,
     #########################################
     # Build two models and compare points
     #########################################
-    compare_points, _ = get_compare_points(tg)  # get compare points
+    compare_points, _, compare_points_mean, compare_points_std = get_compare_points(tg)  # get compare points
 
     float_model, float_user_info = model_builder(tg,
                                                  mode=ModelBuilderMode.FLOAT,
@@ -101,7 +101,8 @@ def gptq_training_wrapper(tg: Graph,
         y_float = float_model(input_data)  # running float model
         with tf.GradientTape(persistent=True) as tape:
             y_fxp = fxp_model(input_data)  # running fxp model
-            loss_value = gptq_config.loss(y_fxp, y_float, fxp_weights_list, flp_weights_list)
+            loss_value = gptq_config.loss(y_fxp, y_float, fxp_weights_list, flp_weights_list,
+                                          compare_points_mean, compare_points_std)
 
         # Use the gradient tape to automatically retrieve
         # the gradients of the trainable variables with respect to the loss.

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -215,7 +215,7 @@ if importlib.util.find_spec("tensorflow") is not None\
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
              Here, each layer can be quantized by 2, 4 or 8 bits:
 
-             >>> config = mct.MixedPrecisionQuantizationConfig(weights_n_bits=[4, 2, 8])
+             >>> config = mct.MixedPrecisionQuantizationConfig()
 
              Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias will not):
 
@@ -232,16 +232,9 @@ if importlib.util.find_spec("tensorflow") is not None\
                              fw_info=fw_info).validate()
 
         if target_kpi is None:
-            # Before starting non-mixed-precision process, we need to set only single bit width, so we take the best
-            # option which is the maximal number of bits.
-            single_bitwidth_candidate = quant_config.n_bits_candidates[0]
-            quant_config.weights_n_bits = [single_bitwidth_candidate[0]]
-            quant_config.activation_n_bits = [single_bitwidth_candidate[1]]
-            quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
-                f"weights_n_bits={quant_config.weights_n_bits} "
-                f"and activation_n_bits={quant_config.activation_n_bits}...")
+                f"base_config defined in the given hardware model...")
             return keras_post_training_quantization(in_model,
                                                     representative_data_gen,
                                                     n_iter,

--- a/model_compression_toolkit/pytorch/default_framework_info.py
+++ b/model_compression_toolkit/pytorch/default_framework_info.py
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import torch
-from torch.nn import Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, \
-    Sigmoid, Softplus, Softsign, Tanh
-from torch.nn.functional import hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, \
-    softplus, softsign
-from torch.nn import UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d
-from torch.nn.functional import upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d
-from torch.nn import Conv2d, ConvTranspose2d, Linear, BatchNorm2d
-from torch.nn import Dropout, Flatten
-from torch import add, multiply, mul, sub, flatten, reshape, split, unsqueeze, concat, cat,\
-    mean, dropout, sigmoid, tanh
-import operator
+from torch.nn import Hardsigmoid, ReLU, ReLU6, Softmax, Sigmoid
+from torch.nn.functional import hardsigmoid, relu, relu6, softmax
+from torch.nn import Conv2d, ConvTranspose2d, Linear
+from torch import sigmoid
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -35,30 +27,6 @@ from model_compression_toolkit.common.quantization.quantizers.uniform_quantizers
 from model_compression_toolkit.pytorch.constants import KERNEL
 from model_compression_toolkit.pytorch.quantizer.fake_quant_builder import power_of_two_quantization, \
     symmetric_quantization, uniform_quantization
-from model_compression_toolkit.pytorch.quantizer.fake_quant_builder import power_of_two_quantization
-from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder, ConstantHolder
-
-"""
-Division of Pytorch modules by how they should be quantized.
-KERNEL_OPS: Layers that their coefficients should be quantized.
-ACTIVATION: Layers that their activation should be quantized.
-NO_QUANTIZATION: Layers that should not be quantized.
-"""
-
-KERNEL_OPS = [Conv2d, Linear, ConvTranspose2d]
-
-NO_QUANTIZATION = [Dropout, Flatten, ConstantHolder] + \
-                  [dropout, flatten, split, operator.getitem, reshape, unsqueeze]
-
-ACTIVATION = [DummyPlaceHolder] + \
-    [Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, Sigmoid, Softplus, Softsign, Tanh] + \
-    [hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, sigmoid, softplus, softsign, tanh] + \
-    [torch.relu] + \
-    [UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d] + \
-    [upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d] + \
-    [add, sub, mul, multiply] + \
-    [operator.add, operator.sub, operator.mul] + \
-    [BatchNorm2d, concat, cat, mean]
 
 """
 Map each layer to a list of its' weights attributes that should get quantized.
@@ -121,10 +89,7 @@ Output channel index of the model's layers
 """
 OUTPUT_CHANNEL_INDEX = ChannelAxis.NCHW
 
-DEFAULT_PYTORCH_INFO = FrameworkInfo(KERNEL_OPS,
-                                     ACTIVATION,
-                                     NO_QUANTIZATION,
-                                     ACTIVATION_QUANTIZER_MAPPING,
+DEFAULT_PYTORCH_INFO = FrameworkInfo(ACTIVATION_QUANTIZER_MAPPING,
                                      WEIGHTS_QUANTIZER_MAPPING,
                                      DEFAULT_CHANNEL_AXIS_DICT,
                                      ACTIVATION2MINMAX,

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -166,7 +166,7 @@ if importlib.util.find_spec("torch") is not None:
              Create a mixed-precision configuration, to quantize a model with different bitwidths for different layers.
              Here, each layer can be quantized by 2, 4 or 8 bits:
 
-             >>> config = mct.MixedPrecisionQuantizationConfig(weights_n_bits=[4, 2, 8])
+             >>> config = mct.MixedPrecisionQuantizationConfig()
 
              Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias will not):
 
@@ -180,16 +180,9 @@ if importlib.util.find_spec("torch") is not None:
 
          """
         if target_kpi is None:
-            # Before starting non-mixed-precision process, we need to set only single bit width, so we take the best
-            # option which is the maximal number of bits.
-            single_bitwidth_candidate = quant_config.n_bits_candidates[0]
-            quant_config.weights_n_bits = [single_bitwidth_candidate[0]]
-            quant_config.activation_n_bits = [single_bitwidth_candidate[1]]
-            quant_config.n_bits_candidates = [single_bitwidth_candidate]
             common.Logger.warning(
                 f"No KPI was passed. Using non mixed-precision compression process with "
-                f"weights_n_bits={quant_config.weights_n_bits} "
-                f"and activation_n_bits={quant_config.activation_n_bits}...")
+                f"base_config defined in the given hardware model...")
             return pytorch_post_training_quantization(in_model,
                                                       representative_data_gen,
                                                       n_iter,

--- a/tests/common_tests/base_layer_test.py
+++ b/tests/common_tests/base_layer_test.py
@@ -44,6 +44,9 @@ class BaseLayerTest(BaseTest):
     def get_layers(self):
         return self.layers
 
+    def get_fw_hw_model(self):
+        raise NotImplemented
+
     def get_quantization_config(self):
         qc = copy.deepcopy(DEFAULTCONFIG)
         qc.weights_bias_correction = False
@@ -51,11 +54,6 @@ class BaseLayerTest(BaseTest):
             # Disable all features that are enabled by default:
             qc.enable_activation_quantization = False
             qc.enable_weights_quantization = False
-        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
-            qc.weights_n_bits = 8
-            qc.activation_n_bits = 8
-        else:
-            raise NotImplemented
         return qc
 
     def run_test(self):
@@ -70,13 +68,15 @@ class BaseLayerTest(BaseTest):
                                                                                          self.representative_data_gen,
                                                                                          n_iter=self.num_calibration_iter,
                                                                                          quant_config=qc,
-                                                                                         fw_info=self.get_fw_info())
+                                                                                         fw_info=self.get_fw_info(),
+                                                                                         fw_hw_model=self.get_fw_hw_model())
                 else:
                     ptq_model, quantization_info = self.get_ptq_facade()(model_float,
                                                                          self.representative_data_gen,
                                                                          n_iter=self.num_calibration_iter,
                                                                          quant_config=qc,
-                                                                         fw_info=self.get_fw_info())
+                                                                         fw_info=self.get_fw_info(),
+                                                                         fw_hw_model=self.get_fw_hw_model())
 
                 self.compare(ptq_model, model_float, input_x=self.representative_data_gen(),
                              quantization_info=quantization_info)

--- a/tests/common_tests/helpers/generate_test_hw_model.py
+++ b/tests/common_tests/helpers/generate_test_hw_model.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from model_compression_toolkit.hardware_models.default_hwm import get_op_quantization_configs, generate_hardware_model
+import model_compression_toolkit as mct
+
+hwm = mct.hardware_representation
+
+
+def generate_test_hw_model(edit_params_dict, name=""):
+    base_config, mixed_precision_cfg_list = get_op_quantization_configs()
+    updated_config = base_config.clone_and_edit(**edit_params_dict)
+
+    return generate_hardware_model(updated_config, mixed_precision_cfg_list, name=name)
+
+
+def generate_mixed_precision_test_hw_model(base_cfg, mp_bitwidth_candidates_list, name=""):
+    mp_op_cfg_list = []
+    for weights_n_bits, activation_n_bits in mp_bitwidth_candidates_list:
+        candidate_cfg = base_cfg.clone_and_edit(weights_n_bits=weights_n_bits,
+                                                activation_n_bits=activation_n_bits)
+        mp_op_cfg_list.append(candidate_cfg)
+
+    return generate_hardware_model(base_cfg, mp_op_cfg_list, name=name)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -17,7 +17,9 @@
 import tensorflow as tf
 import numpy as np
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.constants import ACTIVATION, LINEAR
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as mct
@@ -31,8 +33,13 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
         self.activation_function = activation_function
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="activation_decomp_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -39,13 +39,14 @@ class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
 
     def get_fw_hw_model(self):
         hwm = generate_test_hw_model({'weights_n_bits': 16,
-                                      'activation_n_bits': 16})
-        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
+                                      'activation_n_bits': 16,
+                                      'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="bn_folding_test", hardware_model=hwm)
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      False, False, True, enable_weights_quantization=False,
-                                      enable_activation_quantization=False)
+                                      False, False, True)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         y = float_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -16,17 +16,20 @@
 
 from abc import ABC
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
 
 from tests.common_tests.base_layer_test import LayerTestMode
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 
 keras = tf.keras
 layers = keras.layers
+hw_model = mct.hardware_representation
 
 
 class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
@@ -34,8 +37,13 @@ class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
     def __init__(self, unit_test):
         super(BaseBatchNormalizationFolding, self).__init__(unit_test=unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
                                       False, False, True, enable_weights_quantization=False,
                                       enable_activation_quantization=False)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/conv_bn_relu_residual_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/conv_bn_relu_residual_test.py
@@ -38,6 +38,6 @@ class ConvBnReluResidualTest(BaseKerasFeatureNetworkTest):
         self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
         self.unit_test.assertTrue(quantized_model.layers[3].function == tf.quantization.fake_quant_with_min_max_vars)
         self.unit_test.assertTrue(quantized_model.layers[3].input.ref() == quantized_model.layers[2].output.ref())
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[7], layers.Add))
-        self.unit_test.assertTrue(quantized_model.layers[3].output.ref() in [t.ref() for t in quantized_model.layers[7].input])
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[8], layers.Add))
+        self.unit_test.assertTrue(quantized_model.layers[3].output.ref() in [t.ref() for t in quantized_model.layers[8].input])
         self.unit_test.assertTrue(isinstance(quantized_model.layers[4], layers.BatchNormalization)) # assert not folding

--- a/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/input_scaling_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.keras.back2framework.model_builder import is_layer_fake_quant
@@ -26,10 +29,14 @@ class BaseInputScalingTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="input_scaling_range_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                       mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       input_scaling=True)
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
 import model_compression_toolkit as mct
@@ -44,9 +44,13 @@ class MultiHeadAttentionTest(BaseKerasFeatureNetworkTest):
         self.separate_key_value = separate_key_value
         self.output_dim = output_dim
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="multi_head_attention_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return QuantizationConfig(enable_weights_quantization=False,
-                                  enable_activation_quantization=False)
+        return QuantizationConfig()
 
     def get_input_shapes(self):
         if self.separate_key_value:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -26,8 +29,13 @@ class MultiInputsToNodeTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="multi_input_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       True, True, True, input_scaling=True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -27,9 +30,13 @@ class MultipleInputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="multiple_inputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       True, False, True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -29,9 +30,13 @@ class MultipleOutputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="multiple_outputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_activation_quantization=False,
-                                      enable_weights_quantization=False)
+        return mct.QuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -16,6 +16,9 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -35,8 +38,13 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="nested_multi_inputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       True, True, True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -17,6 +17,9 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -35,11 +38,14 @@ class NestedModelMultipleOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, val_batch_size=10)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="nested_multi_outputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
                                       mct.QuantizationErrorMethod.MSE,
-                                      16,
-                                      16,
                                       True,
                                       True,
                                       True)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -15,6 +15,10 @@
 
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -36,8 +40,13 @@ class NestedModelUnusedInputsOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="nested_model_unused_inputs_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     def inner_functional_model(self, input_shape):
         inputs = layers.Input(shape=input_shape[1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -37,8 +41,13 @@ class NestedTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="nested_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     # Dummy model to test reader's recursively model parsing
     def dummy_model(self, input_shape):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
@@ -18,6 +18,9 @@ from model_compression_toolkit.common.quantization.quantization_params_fn_select
 
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from model_compression_toolkit.common.network_editors.node_filters import NodeNameFilter, NodeNameScopeFilter, \
@@ -52,8 +55,13 @@ class ScopeFilterTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="scope_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, True)
 
     def get_network_editor(self):
@@ -123,8 +131,13 @@ class NameFilterTest(BaseKerasFeatureNetworkTest):
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="name_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, True)
 
     def get_network_editor(self):
@@ -183,8 +196,13 @@ class TypeFilterTest(BaseKerasFeatureNetworkTest):
             hw_model.QuantizationMethod.POWER_OF_TWO,
             mct.QuantizationErrorMethod.NOCLIPPING)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="type_filter_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, False)
 
     def get_network_editor(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/remove_upper_bound_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -26,9 +29,13 @@ class RemoveUpperBoundTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, num_calibration_iter=1, val_batch_size=32)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="remove_upper_bound_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      16, 16,
                                       False, False, False)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
@@ -17,6 +17,8 @@
 import numpy as np
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
 import model_compression_toolkit as mct
@@ -34,9 +36,13 @@ class ScaleEqualizationTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="scale_equalization_bound_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
-                                      16, 16,
                                       relu_bound_to_power_of_2=False, weights_bias_correction=False,
                                       weights_per_channel_threshold=True, activation_channel_equalization=True)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
 else:
@@ -36,8 +40,13 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
         self.bypass_op_list = bypass_op_list
         super().__init__(unit_test, input_shape=input_shape, num_calibration_iter=100)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="shift_negative_test", hardware_model=hwm)
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,16, 16,
+        return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE, mct.QuantizationErrorMethod.MSE,
                                       False, False, True, shift_negative_activation_correction=True,
                                       shift_negative_ratio=np.inf)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -27,10 +30,14 @@ class SplitConvBugTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16})
+        return generate_fhw_model_keras(name="split_conv_bug_test", hardware_model=hwm)
+
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
                                       mct.QuantizationErrorMethod.MSE,
-                                      16, 16,
                                       True, True, True, input_scaling=True)
 
     def get_input_shapes(self):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -17,6 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as cmo
 
@@ -33,25 +35,14 @@ class SymmetricThresholdSelectionActivationTest(BaseKerasFeatureNetworkTest):
     def generate_inputs(self):
         return [np.random.uniform(low=-7, high=7, size=in_shape) for in_shape in self.get_input_shapes()]
 
-    def get_quantization_config(self):
-        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method,
-                                      activation_n_bits=8)
-
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions(
-            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.SYMMETRIC,
-                                           weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                           activation_n_bits=8,
-                                           weights_n_bits=8,
-                                           weights_per_channel_threshold=True,
-                                           enable_weights_quantization=True,
-                                           enable_activation_quantization=True,
-                                           quantization_preserving=False,
-                                           fixed_scale=None,
-                                           fixed_zero_point=None,
-                                           weights_multiplier_nbits=None
-                                           )])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'activation_quantization_method': hw_model.QuantizationMethod.SYMMETRIC,
+            'activation_n_bits': 8})
+        return generate_fhw_model_keras(name="symmetric_threshold_test", hardware_model=hwm)
+
+    def get_quantization_config(self):
+        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -20,6 +20,9 @@ from model_compression_toolkit.common.network_editors.node_filters import NodeNa
 from model_compression_toolkit.common.network_editors.actions import EditRule, ChangeCandidatesWeightsQuantConfigAttr
 import model_compression_toolkit as cmo
 import tensorflow as tf
+
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 
@@ -58,26 +61,14 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
 
     def get_fw_hw_model(self):
-        qco = hardware_representation.QuantizationConfigOptions([hardware_representation.OpQuantizationConfig(
-            activation_quantization_method=hardware_representation.QuantizationMethod.POWER_OF_TWO,
-            weights_quantization_method=self.quantization_method,
-            activation_n_bits=8,
-            weights_n_bits=8,
-            weights_per_channel_threshold=True,
-            enable_weights_quantization=True,
-            enable_activation_quantization=True,
-            quantization_preserving=False,
-            fixed_scale=None,
-            fixed_zero_point=None,
-            weights_multiplier_nbits=None
-            )])
-        return hardware_representation.FrameworkHardwareModel(hardware_representation.HardwareModel(qco))
+        hwm = generate_test_hw_model({'weights_quantization_method': self.quantization_method,
+                                      'weights_n_bits': self.weights_n_bits,
+                                      'activation_n_bits': 4})
+        return generate_fhw_model_keras(name="kmean_quantizer_test", hardware_model=hwm)
 
     def get_quantization_config(self):
         return cmo.QuantizationConfig(cmo.QuantizationErrorMethod.MSE,
                                       cmo.QuantizationErrorMethod.MSE,
-                                      4,
-                                      self.weights_n_bits,
                                       False,
                                       False,
                                       True)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -17,7 +17,8 @@
 import tensorflow as tf
 import numpy as np
 
-
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as cmo
 
@@ -34,24 +35,13 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
         return [np.random.uniform(low=-7, high=7, size=in_shape) for in_shape in self.get_input_shapes()]
 
     def get_quantization_config(self):
-        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method,
-                                      activation_n_bits=8)
+        return cmo.QuantizationConfig(activation_error_method=self.activation_threshold_method)
 
     def get_fw_hw_model(self):
-        qco = hw_model.QuantizationConfigOptions(
-            [hw_model.OpQuantizationConfig(activation_quantization_method=hw_model.QuantizationMethod.UNIFORM,
-                                           weights_quantization_method=hw_model.QuantizationMethod.POWER_OF_TWO,
-                                           activation_n_bits=8,
-                                           weights_n_bits=8,
-                                           weights_per_channel_threshold=True,
-                                           enable_weights_quantization=True,
-                                           enable_activation_quantization=True,
-                                           quantization_preserving=False,
-                                           fixed_scale=None,
-                                           fixed_zero_point=None,
-                                           weights_multiplier_nbits=None
-                                           )])
-        return hw_model.FrameworkHardwareModel(hw_model.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'activation_quantization_method': hw_model.QuantizationMethod.UNIFORM,
+            'activation_n_bits': 8})
+        return generate_fhw_model_keras(name="uniform_range_test", hardware_model=hwm)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
@@ -80,13 +80,13 @@ class TestQuantizationConfigurations(unittest.TestCase):
             hwm = generate_test_hw_model({
                 'activation_quantization_method': quantize_method,
                 'weights_n_bits': 8,
-                'activation_n_bits': 8})
+                'activation_n_bits': 8,
+                'enable_weights_quantization': False})
             fw_hw_model = generate_fhw_model_keras(name="kl_quant_config_activation_test", hardware_model=hwm)
 
             qc = mct.QuantizationConfig(activation_error_method=error_method,
                                         relu_bound_to_power_of_2=relu_bound_to_power_of_2,
-                                        shift_negative_activation_correction=False,
-                                        enable_weights_quantization=False)
+                                        shift_negative_activation_correction=False)
 
             q_model, quantization_info = mct.keras_post_training_quantization(model,
                                                                               representative_data_gen,

--- a/tests/keras_tests/function_tests/test_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_quantization_configurations.py
@@ -21,7 +21,9 @@ import tensorflow as tf
 from tensorflow.keras import layers
 
 import model_compression_toolkit as mct
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 
 def model_gen():
@@ -63,26 +65,14 @@ class TestQuantizationConfigurations(unittest.TestCase):
 
         model = model_gen()
         for quantize_method, error_method, bias_correction, per_channel, input_scaling in weights_test_combinations:
-            qco = mct.hardware_representation.QuantizationConfigOptions(
-                [mct.hardware_representation.OpQuantizationConfig(
-                    activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                    weights_quantization_method=quantize_method,
-                    activation_n_bits=16,
-                    weights_n_bits=8,
-                    weights_per_channel_threshold=per_channel,
-                    enable_weights_quantization=True,
-                    enable_activation_quantization=True,
-                    quantization_preserving=False,
-                    fixed_scale=None,
-                    fixed_zero_point=None,
-                    weights_multiplier_nbits=None
-                )])
-            fw_hw_model = mct.hardware_representation.FrameworkHardwareModel(
-                mct.hardware_representation.HardwareModel(qco))
+            hwm = generate_test_hw_model({
+                'weights_quantization_method': quantize_method,
+                'weights_n_bits': 8,
+                'activation_n_bits': 16})
+            fw_hw_model = generate_fhw_model_keras(name="quant_config_weights_test", hardware_model=hwm)
+
             qc = mct.QuantizationConfig(activation_error_method=mct.QuantizationErrorMethod.NOCLIPPING,
                                         weights_error_method=error_method,
-                                        activation_n_bits=16,
-                                        weights_n_bits=8,
                                         relu_bound_to_power_of_2=False,
                                         weights_bias_correction=bias_correction,
                                         weights_per_channel_threshold=per_channel,
@@ -96,27 +86,14 @@ class TestQuantizationConfigurations(unittest.TestCase):
 
         model = model_gen()
         for quantize_method, error_method, relu_bound_to_power_of_2, shift_negative_correction in activation_test_combinations:
-            qco = mct.hardware_representation.QuantizationConfigOptions(
-                [mct.hardware_representation.OpQuantizationConfig(
-                    activation_quantization_method=quantize_method,
-                    weights_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                    activation_n_bits=16,
-                    weights_n_bits=8,
-                    weights_per_channel_threshold=False,
-                    enable_weights_quantization=True,
-                    enable_activation_quantization=True,
-                    quantization_preserving=False,
-                    fixed_scale=None,
-                    fixed_zero_point=None,
-                    weights_multiplier_nbits=None
-                )])
+            hwm = generate_test_hw_model({
+                'activation_quantization_method': quantize_method,
+                'weights_n_bits': 16,
+                'activation_n_bits': 8})
+            fw_hw_model = generate_fhw_model_keras(name="quant_config_activation_test", hardware_model=hwm)
 
-            fw_hw_model = mct.hardware_representation.FrameworkHardwareModel(
-                mct.hardware_representation.HardwareModel(qco))
             qc = mct.QuantizationConfig(activation_error_method=error_method,
                                         weights_error_method=mct.QuantizationErrorMethod.NOCLIPPING,
-                                        activation_n_bits=8,
-                                        weights_n_bits=16,
                                         relu_bound_to_power_of_2=relu_bound_to_power_of_2,
                                         weights_bias_correction=False,
                                         weights_per_channel_threshold=False,

--- a/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
@@ -31,8 +31,10 @@ from model_compression_toolkit.common.quantization.quantization_params_generatio
     calculate_quantization_params
 from model_compression_toolkit.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 
 def get_uniform_weights(kernel, in_channels, out_channels):
@@ -90,31 +92,18 @@ class TestSymmetricThresholdSelectionWeights(unittest.TestCase):
 
     def run_test_for_threshold_method(self, threshold_method, per_channel=True):
         qc = QuantizationConfig(weights_error_method=threshold_method,
-                                weights_n_bits=8,
                                 weights_per_channel_threshold=per_channel)
 
-        qco = mct.hardware_representation.QuantizationConfigOptions(
-            [mct.hardware_representation.OpQuantizationConfig(
-                activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                weights_quantization_method=mct.hardware_representation.QuantizationMethod.SYMMETRIC,
-                activation_n_bits=8,
-                weights_n_bits=8,
-                weights_per_channel_threshold=True,
-                enable_weights_quantization=True,
-                enable_activation_quantization=True,
-                quantization_preserving=False,
-                fixed_scale=None,
-                fixed_zero_point=None,
-                weights_multiplier_nbits=None
-            )])
-        hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'weights_quantization_method': mct.hardware_representation.QuantizationMethod.SYMMETRIC})
+        fw_hw_model = generate_fhw_model_keras(name="symmetric_threshold_selection_test", hardware_model=hwm)
 
         fw_info = DEFAULT_KERAS_INFO
         in_model = create_network()
         keras_impl = KerasImplementation()
         graph = keras_impl.model_reader(in_model, None)  # model reading
         graph.set_fw_info(fw_info)
-        graph.set_fw_hw_model(hw_model)
+        graph.set_fw_hw_model(fw_hw_model)
         graph = set_quantization_configuration_to_graph(graph=graph,
                                                         quant_config=qc)
         for node in graph.nodes:

--- a/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
@@ -31,8 +31,10 @@ from model_compression_toolkit.common.quantization.quantization_params_generatio
 from model_compression_toolkit.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
 from model_compression_toolkit.common.model_collector import ModelCollector
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 
 def get_random_weights(kernel, in_channels, out_channels):
@@ -89,30 +91,17 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
 
     def run_test_for_threshold_method(self, threshold_method, per_channel=True):
         qc = QuantizationConfig(weights_error_method=threshold_method,
-                                weights_n_bits=8,
                                 weights_per_channel_threshold=per_channel)
 
-        qco = mct.hardware_representation.QuantizationConfigOptions(
-            [mct.hardware_representation.OpQuantizationConfig(
-                activation_quantization_method=mct.hardware_representation.QuantizationMethod.POWER_OF_TWO,
-                weights_quantization_method=mct.hardware_representation.QuantizationMethod.UNIFORM,
-                activation_n_bits=8,
-                weights_n_bits=8,
-                weights_per_channel_threshold=True,
-                enable_weights_quantization=True,
-                enable_activation_quantization=True,
-                quantization_preserving=False,
-                fixed_scale=None,
-                fixed_zero_point=None,
-                weights_multiplier_nbits=None
-            )])
-        hw_model = mct.hardware_representation.FrameworkHardwareModel(mct.hardware_representation.HardwareModel(qco))
+        hwm = generate_test_hw_model({
+            'weights_quantization_method': mct.hardware_representation.QuantizationMethod.UNIFORM})
+        fw_hw_model = generate_fhw_model_keras(name="uniform_range_selection_test", hardware_model=hwm)
 
         fw_info = DEFAULT_KERAS_INFO
         in_model = create_network()
         keras_impl = KerasImplementation()
         graph = keras_impl.model_reader(in_model, None)  # model reading
-        graph.set_fw_hw_model(hw_model)
+        graph.set_fw_hw_model(fw_hw_model)
         graph.set_fw_info(fw_info)
         graph = set_quantization_configuration_to_graph(graph=graph,
                                                         quant_config=qc)

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -2,6 +2,10 @@ from typing import List, Any, Tuple
 
 import tensorflow as tf
 
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
     from tensorflow.keras.models import Model
@@ -41,6 +45,17 @@ class BaseKerasLayerTest(BaseLayerTest):
                          quantization_modes=quantization_modes,
                          is_inputs_a_list=is_inputs_a_list,
                          use_cpu=use_cpu)
+
+    def get_fw_hw_model(self):
+        if self.current_mode == LayerTestMode.FLOAT:
+            # Disable all features that are enabled by default:
+            return generate_fhw_model_keras(name="float_layer_test", hardware_model=get_default_hardware_model())
+        elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
+            hwm = generate_test_hw_model({'weights_n_bits': 8,
+                                          'activation_n_bits': 8})
+            return generate_fhw_model_keras(name="8bit_layer_test", hardware_model=hwm)
+        else:
+            raise NotImplemented
 
     def get_fw_info(self) -> FrameworkInfo:
         return DEFAULT_KERAS_INFO

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -10,9 +10,17 @@ if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Input
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, \
+        UpSampling2D, InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute, \
+        LayerNormalization
 else:
     from keras.layers.core import TFOpLambda
     from keras import Input, Model
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, \
+        UpSampling2D, InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute, \
+        LayerNormalization
 
 from model_compression_toolkit import FrameworkInfo, keras_post_training_quantization, \
     keras_post_training_quantization_mixed_precision
@@ -22,6 +30,21 @@ from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode
 import numpy as np
+
+KERAS_LAYER_TEST_OPS = {
+    "kernel_ops": [Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose],
+
+    "no_quantization": [Reshape, tf.reshape, Flatten, Permute, Cropping2D, ZeroPadding2D, Dropout, MaxPooling2D,
+                        tf.reshape, tf.split, tf.quantization.fake_quant_with_min_max_vars],
+
+    "activation": [Activation, ReLU, tf.nn.relu, tf.nn.relu6, tf.nn.leaky_relu, Softmax, GlobalAveragePooling2D, Add,
+                   Multiply, AveragePooling2D, UpSampling2D, InputLayer, Concatenate, PReLU, ELU, tf.nn.silu,
+                   tf.nn.swish, tf.nn.sigmoid, tf.nn.tanh, tf.nn.relu, tf.nn.relu6, tf.nn.leaky_relu, LeakyReLU,
+                   tf.nn.softsign, tf.nn.gelu, tf.nn.elu, tf.nn.selu, tf.nn.softplus, tf.nn.softmax, Dot,
+                   LayerNormalization, tf.add, tf.multiply, tf.reduce_mean, tf.reduce_min, tf.reduce_sum, tf.reduce_max,
+                   tf.image.resize, tf.image.crop_and_resize, tf.concat,
+                   ]
+}
 
 
 class BaseKerasLayerTest(BaseLayerTest):
@@ -49,7 +72,9 @@ class BaseKerasLayerTest(BaseLayerTest):
     def get_fw_hw_model(self):
         if self.current_mode == LayerTestMode.FLOAT:
             # Disable all features that are enabled by default:
-            return generate_fhw_model_keras(name="float_layer_test", hardware_model=get_default_hardware_model())
+            hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                          'enable_activation_quantization': False})
+            return generate_fhw_model_keras(name="base_layer_test", hardware_model=hwm)
         elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
             hwm = generate_test_hw_model({'weights_n_bits': 8,
                                           'activation_n_bits': 8})
@@ -115,18 +140,18 @@ class BaseKerasLayerTest(BaseLayerTest):
         fw_info = self.get_fw_info()
         for layer in quantized_model.layers:
             op = layer.function if isinstance(layer, TFOpLambda) else type(layer)
-            if op in fw_info.kernel_ops:
+            if op in KERAS_LAYER_TEST_OPS['kernel_ops']:
                 for attr in fw_info.get_kernel_op_attributes(type(layer)):
                     self.unit_test.assertTrue(np.sum(np.abs(
                         getattr(layer, attr) - getattr(float_model.get_layer(layer.name), attr))) > 0.0)
                 for next_layer in [node.layer for node in layer.outbound_nodes]:
                     self.unit_test.assertTrue(is_layer_fake_quant(next_layer))
 
-            elif op in fw_info.activation_ops:
+            elif op in KERAS_LAYER_TEST_OPS['activation']:
                 for next_layer in [node.layer for node in layer.outbound_nodes]:
                     self.unit_test.assertTrue(is_layer_fake_quant(next_layer))
 
-            elif op in fw_info.no_quantization_ops:
+            elif op in KERAS_LAYER_TEST_OPS['no_quantization']:
                 for next_layer in [node.layer for node in layer.outbound_nodes]:
                     self.unit_test.assertFalse(is_layer_fake_quant(next_layer))
 

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -21,6 +21,7 @@ from torch.nn import Module
 
 from model_compression_toolkit import FrameworkInfo, pytorch_post_training_quantization
 from model_compression_toolkit.common.framework_implementation import FrameworkImplementation
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
 from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder
 from model_compression_toolkit.pytorch.utils import torch_tensor_to_numpy, to_torch_tensor
@@ -76,6 +77,13 @@ def get_layer_weights(layer):
     weights.update(named_parameters_weights)
     weights.update(named_buffer_weights)
     return weights
+
+
+def get_layer_test_fw_hw_model_dict(hardware_model, test_name, fhwm_name):
+    return {
+        test_name: generate_fhw_model_pytorch(name=fhwm_name,
+                                              hardware_model=hardware_model),
+    }
 
 
 class BasePytorchLayerTest(BaseLayerTest):

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -17,6 +17,7 @@ from torch.fx import symbolic_trace
 
 from model_compression_toolkit import MixedPrecisionQuantizationConfig, get_model
 from model_compression_toolkit.common.constants import PYTORCH
+from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.constants import DEFAULT_HWM
 from model_compression_toolkit.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.pytorch.utils import get_working_device, set_model, to_torch_tensor, \
@@ -25,6 +26,7 @@ import model_compression_toolkit as mct
 import torch
 import numpy as np
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
 
 """
 The base test class for the feature networks
@@ -34,21 +36,34 @@ class BasePytorchTest(BaseFeatureNetworkTest):
         super().__init__(unit_test)
         self.float_reconstruction_error = float_reconstruction_error
 
+    def get_fw_hw_model(self):
+        return {
+            'no_quantization': generate_fhw_model_pytorch(name="no_quant_pytorch_test",
+                                                          hardware_model=generate_test_hw_model({'weights_n_bits': 32,
+                                                                                                 'activation_n_bits': 32})),
+            'all_32bit': generate_fhw_model_pytorch(name="32_quant_pytorch_test",
+                                                    hardware_model=generate_test_hw_model({'weights_n_bits': 32,
+                                                                                           'activation_n_bits': 32})),
+            'all_4bit': generate_fhw_model_pytorch(name="4_quant_pytorch_test",
+                                                   hardware_model=generate_test_hw_model({'weights_n_bits': 4,
+                                                                                          'activation_n_bits': 4})),
+        }
+
     def get_quantization_configs(self):
         return {
             'no_quantization': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                       mct.QuantizationErrorMethod.NOCLIPPING,
-                                                      32, 32, False, True, True,
+                                                      False, True, True,
                                                       enable_weights_quantization=False,
                                                       enable_activation_quantization=False),
             'all_32bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                 mct.QuantizationErrorMethod.NOCLIPPING,
-                                                32, 32, False, True, True,
+                                                False, True, True,
                                                 enable_weights_quantization=True,
                                                 enable_activation_quantization=True),
             'all_4bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               4, 4, False, False, True,
+                                               False, False, True,
                                                enable_weights_quantization=True,
                                                enable_activation_quantization=True),
         }
@@ -107,7 +122,10 @@ class BasePytorchTest(BaseFeatureNetworkTest):
 
         ptq_models = {}
         model_float = self.create_feature_network(input_shapes)
-        for model_name, quant_config in self.get_quantization_configs().items():
+        quant_config_dict = self.get_quantization_configs()
+        for model_name in quant_config_dict.keys():
+            quant_config = quant_config_dict[model_name]
+            fw_hw_model = self.get_fw_hw_model()[model_name]
             if isinstance(quant_config, MixedPrecisionQuantizationConfig):
                 ptq_model, quantization_info = mct.pytorch_post_training_quantization_mixed_precision(model_float,
                                                                                                       representative_data_gen,
@@ -117,7 +135,7 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                                                                                                       network_editor=self.get_network_editor(),
                                                                                                       gptq_config=self.get_gptq_config(),
                                                                                                       target_kpi=self.get_kpi(),
-                                                                                                      fw_hw_model=get_model(PYTORCH, DEFAULT_HWM))
+                                                                                                      fw_hw_model=fw_hw_model)
                 ptq_models.update({model_name: ptq_model})
             else:
                 ptq_model, quantization_info = mct.pytorch_post_training_quantization(model_float,
@@ -126,7 +144,7 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                                                                                       quant_config=quant_config,
                                                                                       fw_info=DEFAULT_PYTORCH_INFO,
                                                                                       network_editor=self.get_network_editor(),
-                                                                                      fw_hw_model=get_model(PYTORCH, DEFAULT_HWM))
+                                                                                      fw_hw_model=fw_hw_model)
                 ptq_models.update({model_name: ptq_model})
 
         self.compare(ptq_models, model_float, input_x=x, quantization_info=quantization_info)

--- a/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
@@ -19,6 +19,8 @@ from model_compression_toolkit.common.network_editors.node_filters import NodeNa
 from model_compression_toolkit.common.network_editors.actions import EditRule, \
     ChangeCandidatesWeightsQuantizationMethod
 from model_compression_toolkit.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 
 hw_model = mct.hardware_representation
@@ -75,11 +77,14 @@ class LUTQuantizerTest(BasePytorchTest):
         self.num_conv_channels = 3
         self.kernel = 3
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=generate_test_hw_model({"weights_n_bits": self.weights_n_bits}),
+                                               test_name='lut_quantizer_test',
+                                               fhwm_name='lut_quantizer_pytorch_test')
+
     def get_quantization_configs(self):
         return {'lut_quantizer_test': mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
-                                                             mct.QuantizationErrorMethod.MSE,
-                                                             8,
-                                                             self.weights_n_bits)}
+                                                             mct.QuantizationErrorMethod.MSE)}
 
     def get_network_editor(self):
         return [EditRule(filter=NodeNameFilter(self.node_to_change_name),

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_test.py
@@ -18,6 +18,8 @@ from torch.nn import Conv2d
 
 from model_compression_toolkit import MixedPrecisionQuantizationConfig, KPI
 from model_compression_toolkit.common.user_info import UserInformation
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit as mct
 
@@ -30,6 +32,11 @@ class MixedPercisionBaseTest(BasePytorchTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='mixed_precision_model',
+                                               fhwm_name='mixed_precision_pytorch_test')
+
     def get_quantization_configs(self):
         qc = mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
                                     mct.QuantizationErrorMethod.MSE,
@@ -40,7 +47,6 @@ class MixedPercisionBaseTest(BasePytorchTest):
                                     input_scaling=False)
 
         return {"mixed_precision_model": MixedPrecisionQuantizationConfig(qc,
-                                                                          n_bits_candidates=[(2, 8), (8, 8), (4, 8)],
                                                                           num_of_images=1)}
 
     def create_feature_network(self, input_shape):

--- a/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 import torch
+
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 from torch.nn import Conv2d, ReLU, ReLU6, Hardtanh
 from torch.nn.functional import relu, relu6, hardtanh
@@ -92,6 +95,11 @@ class ReLUBoundToPOTNetTest(BasePytorchTest):
     def create_inputs_shape(self):
         return [[self.val_batch_size, 3, 32, 32]]
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='8bit_relu_bound',
+                                               fhwm_name='relu_bound_pytorch_test')
+
     def get_quantization_configs(self):
         quant_config = mct.DEFAULTCONFIG
         quant_config.relu_bound_to_power_of_2 = True
@@ -127,6 +135,11 @@ class HardtanhBoundToPOTNetTest(BasePytorchTest):
 
     def create_inputs_shape(self):
         return [[self.val_batch_size, 3, 32, 32]]
+
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='8bit_relu_bound',
+                                               fhwm_name='relu_bound_pytorch_test')
 
     def get_quantization_configs(self):
         quant_config = mct.DEFAULTCONFIG

--- a/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 import torch
 
+from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 from model_compression_toolkit.pytorch.utils import to_torch_tensor
+from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit as mct
 import numpy as np
@@ -51,12 +53,15 @@ class ShiftNegaviteActivationNetTest(BasePytorchTest):
         i[0][0, 0, 0, 1] = -10
         return i
 
+    def get_fw_hw_model(self):
+        return get_layer_test_fw_hw_model_dict(hardware_model=get_default_hardware_model(),
+                                               test_name='all_8bit',
+                                               fhwm_name='sn_pytorch_test')
+
     def get_quantization_configs(self):
         return {
             'all_8bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               8,
-                                               8,
                                                enable_weights_quantization=True,
                                                enable_activation_quantization=True,
                                                shift_negative_activation_correction=True,

--- a/tutorials/example_keras_mobilenet_mixed_precision.py
+++ b/tutorials/example_keras_mobilenet_mixed_precision.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     # will search a mixed-precision configuration (namely, bit width for each layer)
     # and quantize the model according to this configuration.
     # Here, each layer can be quantized by 2, 4 or 8 bits.
-    configuration = MixedPrecisionQuantizationConfig(weights_n_bits=[2, 8, 4])
+    configuration = MixedPrecisionQuantizationConfig()
 
     # Create a KPI object to limit our returned model's size. Note that this value affects only coefficients that
     # should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value, while the bias


### PR DESCRIPTION
Refactor to allow getting is quantization enabled from hardware model instead of quantization config.
Main changes include:

- Remove enable_quantization for both weights and activation from QuantizationConfig (refactor entire lib accordingly).
- Removed operations lists from framework info - required modification in several conditions checks throughout the code.
- Large refactor in tests - to adjust setting test configuration with hw model