### PR TITLE
Get quantization enable info from hw model

### DIFF
--- a/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
+++ b/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
@@ -36,7 +36,7 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     graph = copy.deepcopy(graph_to_apply_bias_correction)
     for n in graph.nodes:
-        if fw_info.in_kernel_ops(n) and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.enable_weights_quantization:
             # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
             # a bias correction term was calculated during model preparation, and is used now in the node's bias term.
             if n.final_weights_quantization_cfg.weights_bias_correction:

--- a/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
+++ b/model_compression_toolkit/common/bias_correction/apply_bias_correction_to_graph.py
@@ -36,7 +36,7 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     graph = copy.deepcopy(graph_to_apply_bias_correction)
     for n in graph.nodes:
-        if n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.is_weights_quantization_enabled():
             # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
             # a bias correction term was calculated during model preparation, and is used now in the node's bias term.
             if n.final_weights_quantization_cfg.weights_bias_correction:

--- a/model_compression_toolkit/common/bias_correction/compute_bias_correction_of_graph.py
+++ b/model_compression_toolkit/common/bias_correction/compute_bias_correction_of_graph.py
@@ -45,7 +45,7 @@ def compute_bias_correction_of_graph(graph_co_compute_bias: Graph,
 
     graph = copy.deepcopy(graph_co_compute_bias)
     for n in graph.nodes:
-        if fw_info.in_kernel_ops(n):
+        if n.is_weights_quantization_enabled():
             _compute_bias_correction_per_candidate_qc(n,
                                                       fw_info,
                                                       graph.get_in_stats_collector(n),
@@ -69,26 +69,25 @@ def _compute_bias_correction_per_candidate_qc(node: BaseNode,
 
     """
 
-    if node.is_weights_quantization_enabled():
-        for candidate_qc in node.candidates_quantization_cfg:
-            if fw_info.in_kernel_ops(node):
-                quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
-                                                                                        node,
-                                                                                        candidate_qc.weights_quantization_cfg,
-                                                                                        fw_impl=fw_impl)
+    for candidate_qc in node.candidates_quantization_cfg:
+        if candidate_qc.weights_quantization_cfg.enable_weights_quantization:
+            quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
+                                                                                    node,
+                                                                                    candidate_qc.weights_quantization_cfg,
+                                                                                    fw_impl=fw_impl)
 
-                # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
-                # a bias correction term is being calculated and used in the node's bias term.
-                if candidate_qc.weights_quantization_cfg.weights_bias_correction:
-                    bias_correction_term = _get_bias_correction_term_of_node(io_channels_axes[0],
-                                                                             node,
-                                                                             node_in_stats_collector,
-                                                                             io_channels_axes[1],
-                                                                             quantized_kernel,
-                                                                             fw_impl=fw_impl)
+            # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
+            # a bias correction term is being calculated and used in the node's bias term.
+            if candidate_qc.weights_quantization_cfg.weights_bias_correction:
+                bias_correction_term = _get_bias_correction_term_of_node(io_channels_axes[0],
+                                                                         node,
+                                                                         node_in_stats_collector,
+                                                                         io_channels_axes[1],
+                                                                         quantized_kernel,
+                                                                         fw_impl=fw_impl)
 
-                    # Store the correction term to use it later,
-                    candidate_qc.weights_quantization_cfg.bias_corrected = bias_correction_term
+                # Store the correction term to use it later,
+                candidate_qc.weights_quantization_cfg.bias_corrected = bias_correction_term
 
 
 def _compute_bias_correction(kernel: np.ndarray,

--- a/model_compression_toolkit/common/framework_info.py
+++ b/model_compression_toolkit/common/framework_info.py
@@ -42,9 +42,6 @@ class ChannelAxis(Enum):
 class FrameworkInfo(object):
 
     def __init__(self,
-                 kernel_ops: list,
-                 activation_ops: list,
-                 no_quantization_ops: list,
                  activation_quantizer_mapping: Dict[QuantizationMethod, Callable],
                  weights_quantizer_mapping: Dict[QuantizationMethod, Callable],
                  kernel_channels_mapping: DefaultDict,
@@ -62,9 +59,6 @@ class FrameworkInfo(object):
         no_quantization_ops:Layers that should not get quantized (e.g., Reshape, Transpose, etc.)
 
         Args:
-            kernel_ops (list): A list of operators that are in the kernel_ops group.
-            activation_ops (list): A list of operators that are in the activation_ops group.
-            no_quantization_ops (list): A list of operators that are in the no_quantization_ops group.
             activation_quantizer_mapping (Dict[QuantizationMethod, Callable]): A dictionary mapping from QuantizationMethod to a quantization function.
             weights_quantizer_mapping (Dict[QuantizationMethod, Callable]): A dictionary mapping from QuantizationMethod to a quantization function.
             kernel_channels_mapping (DefaultDict): Dictionary from a layer to a tuple of its kernel in/out channels indices.
@@ -83,35 +77,20 @@ class FrameworkInfo(object):
 
             Then, we can create a FrameworkInfo object:
 
-            >>> FrameworkInfo(kernel_ops, [], [], kernel_channels_mapping, {}, {})
-
-            and pass it to :func:`~model_compression_toolkit.keras_post_training_quantization`.
-
-            To quantize the activations of ReLU, we can create a new FrameworkInfo instance:
-
-            >>> activation_ops = [tf.keras.layers.ReLU]
-            >>> FrameworkInfo(kernel_ops, activation_ops, [], kernel_channels_mapping, {}, {})
-
-            If we don't want to quantize a layer (e.g. Reshape), we can add it to the no_no_quantization_ops list:
-
-            >>> no_quantization_ops = [tf.keras.layers.Reshape]
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, {}, {})
+            >>> FrameworkInfo(kernel_channels_mapping, {}, {})
 
             If an activation layer (tf.keras.layers.Activation) should be quantized and we know it's min/max outputs range in advanced, we can add it to activation_min_max_mapping for saving the statistics collection time. For example:
 
             >>> activation_min_max_mapping = {'softmax': (0, 1)}
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, activation_min_max_mapping, {})
+            >>> FrameworkInfo(kernel_channels_mapping, activation_min_max_mapping, {})
 
             If a layer's activations should be quantized and we know it's min/max outputs range in advanced, we can add it to layer_min_max_mapping for saving the statistics collection time. For example:
 
             >>> layer_min_max_mapping = {tf.keras.layers.Softmax: (0, 1)}
-            >>> FrameworkInfo(kernel_ops, activation_ops, no_quantization_ops, kernel_channels_mapping, activation_min_max_mapping, layer_min_max_mapping)
+            >>> FrameworkInfo(kernel_channels_mapping, activation_min_max_mapping, layer_min_max_mapping)
 
         """
 
-        self.kernel_ops = kernel_ops
-        self.activation_ops = activation_ops
-        self.no_quantization_ops = no_quantization_ops
         self.activation_quantizer_mapping = activation_quantizer_mapping
         self.weights_quantizer_mapping = weights_quantizer_mapping
         self.kernel_channels_mapping = kernel_channels_mapping
@@ -158,40 +137,3 @@ class FrameworkInfo(object):
         """
 
         return activation_name in self.activation_min_max_mapping
-
-    def in_kernel_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the kernel_ops group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the kernel_ops group or not.
-        """
-
-        return n.type in self.kernel_ops
-
-    def in_activation_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the activation group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the activation group or not.
-        """
-        return n.type in self.activation_ops
-
-    def in_no_quantization_ops(self, n: BaseNode) -> bool:
-        """
-        Check whether a node is in the no quantization group or not.
-
-        Args:
-            n: A node to check.
-
-        Returns:
-            Whether the node is in the no quantization group or not.
-        """
-        return n.type in self.no_quantization_ops

--- a/model_compression_toolkit/common/graph/base_node.py
+++ b/model_compression_toolkit/common/graph/base_node.py
@@ -92,6 +92,10 @@ class BaseNode:
         Returns: Whether node activation quantization is enabled or not.
 
         """
+        if self.final_activation_quantization_cfg:
+            # if we have a final configuration, then we only care to check if it enables activation quantization
+            return self.final_activation_quantization_cfg.enable_activation_quantization
+
         for qc in self.candidates_quantization_cfg:
             assert self.candidates_quantization_cfg[0].activation_quantization_cfg.enable_activation_quantization == \
                    qc.activation_quantization_cfg.enable_activation_quantization
@@ -103,6 +107,10 @@ class BaseNode:
         Returns: Whether node weights quantization is enabled or not.
 
         """
+        if self.final_weights_quantization_cfg:
+            # if we have a final configuration, then we only care to check if it enables weights quantization
+            return self.final_weights_quantization_cfg.enable_weights_quantization
+
         for qc in self.candidates_quantization_cfg:
             assert self.candidates_quantization_cfg[0].weights_quantization_cfg.enable_weights_quantization == \
                    qc.weights_quantization_cfg.enable_weights_quantization

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -461,8 +461,7 @@ def _prepare_model_for_quantization(in_model: Any,
     ######################################
     # Shift Negative Activations
     ######################################
-    if quant_config.shift_negative_activation_correction and \
-            quant_config.enable_activation_quantization:
+    if quant_config.shift_negative_activation_correction:
         transformed_graph = fw_impl.shift_negative_correction(transformed_graph,
                                                               quant_config,
                                                               fw_info)

--- a/model_compression_toolkit/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/node_quantization_config.py
@@ -83,7 +83,7 @@ class NodeActivationQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.activation_quantization_method = op_cfg.activation_quantization_method
         self.activation_n_bits = op_cfg.activation_n_bits
         self.relu_bound_to_power_of_2 = qc.relu_bound_to_power_of_2
-        self.enable_activation_quantization = qc.enable_activation_quantization
+        self.enable_activation_quantization = op_cfg.enable_activation_quantization
         self.activation_channel_equalization = qc.activation_channel_equalization
         self.input_scaling = qc.input_scaling
         self.min_threshold = qc.min_threshold
@@ -217,7 +217,7 @@ class NodeWeightsQuantizationConfig(BaseNodeNodeQuantizationConfig):
         self.weights_n_bits = op_cfg.weights_n_bits
         self.weights_bias_correction = qc.weights_bias_correction
         self.weights_per_channel_threshold = qc.weights_per_channel_threshold
-        self.enable_weights_quantization = qc.enable_weights_quantization
+        self.enable_weights_quantization = op_cfg.enable_weights_quantization
         self.min_threshold = qc.min_threshold
         self.l_p_value = qc.l_p_value
 

--- a/model_compression_toolkit/common/quantization/quantization_analyzer.py
+++ b/model_compression_toolkit/common/quantization/quantization_analyzer.py
@@ -60,7 +60,7 @@ def analyzer_graph(node_analyze_func: Callable,
         # If we use bias correction, and the node has coefficients to quantize, we need to make sure
         # its previous nodes' tensors are consistent with this node.
         # TODO: factor tensor marking in case of bias correction.
-        if qc.weights_bias_correction and fw_info.in_kernel_ops(n):
+        if qc.weights_bias_correction and n.is_weights_quantization_enabled():
             for ie in graph.incoming_edges(n):
                 input_node = ie.source_node
                 create_tensor2node(graph,

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -53,8 +53,6 @@ class QuantizationConfig(object):
                  weights_bias_correction: bool = True,
                  weights_per_channel_threshold: bool = True,
                  input_scaling: bool = False,
-                 enable_weights_quantization: bool = True,
-                 enable_activation_quantization: bool = True,
                  shift_negative_activation_correction: bool = False,
                  activation_channel_equalization: bool = False,
                  z_threshold: float = math.inf,
@@ -72,8 +70,6 @@ class QuantizationConfig(object):
             weights_bias_correction (bool): Whether to use weights bias correction or not.
             weights_per_channel_threshold (bool): Whether to quantize the weights per-channel or not (per-tensor).
             input_scaling (bool): Whether to use input scaling or not.
-            enable_weights_quantization (bool): Whether to quantize the model weights or not.
-            enable_activation_quantization (bool): Whether to quantize the model activations or not.
             shift_negative_activation_correction (bool): Whether to use shifting negative activation correction or not.
             activation_channel_equalization (bool): Whether to use activation channel equalization correction or not.
             z_threshold (float): Value of z score for outliers removal.
@@ -89,7 +85,7 @@ class QuantizationConfig(object):
             enabling relu_bound_to_power_of_2, weights_bias_correction, and quantizing the weights per-channel,
             one can instantiate a quantization configuration:
 
-            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,activation_quantization_method=QuantizationMethod.POWER_OF_TWO,weights_quantization_method=QuantizationMethod.POWER_OF_TWO,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
+            >>> qc = QuantizationConfig(activation_error_method=QuantizationErrorMethod.NOCLIPPING,weights_error_method=QuantizationErrorMethod.MSE,relu_bound_to_power_of_2=True,weights_bias_correction=True,weights_per_channel_threshold=True)
 
 
             The QuantizationConfig instanse can then be passed to
@@ -102,8 +98,6 @@ class QuantizationConfig(object):
         self.relu_bound_to_power_of_2 = relu_bound_to_power_of_2
         self.weights_bias_correction = weights_bias_correction
         self.weights_per_channel_threshold = weights_per_channel_threshold
-        self.enable_weights_quantization = enable_weights_quantization
-        self.enable_activation_quantization = enable_activation_quantization
         self.activation_channel_equalization = activation_channel_equalization
         self.input_scaling = input_scaling
         self.min_threshold = min_threshold

--- a/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
+++ b/model_compression_toolkit/common/quantization/quantization_params_generation/qparams_computation.py
@@ -51,40 +51,20 @@ def calculate_quantization_params(graph: Graph,
     nodes_list: List[BaseNode] = nodes if specific_nodes else graph.nodes()
 
     for n in nodes_list:  # iterate only nodes that we should compute their thresholds
-
-        weights_params, activation_params, activation_is_signed, output_channels_axis, \
-        input_channels_axis, activation_threshold_float = {}, {}, None, None, None, None
-
         for candidate_qc in n.candidates_quantization_cfg:
-            if fw_info.in_kernel_ops(n):  # If the node has a kernel to quantize
-                if n.is_weights_quantization_enabled():
-                    output_channels_axis, _ = get_channels_axis(candidate_qc.weights_quantization_cfg, fw_info, n.type)
-                    weights_params = get_weights_qparams(n.get_weights_by_keys(fw_impl.constants.KERNEL),
-                                                         candidate_qc.weights_quantization_cfg,
-                                                         output_channels_axis)
-
-                    candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
-                    candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
-
-                if n.is_activation_quantization_enabled():
-                    # If node's activations should be quantized as well, we compute its activation threshold
-                    activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
-                                                                nodes_prior_info=n.prior_info,
-                                                                out_stats_container=graph.get_out_stats_collector(n))
-
-            elif fw_info.in_activation_ops(n):  # If node has no kernel, but its activations should be quantized
-                if n.is_activation_quantization_enabled():
-                    activation_params = get_activations_qparams(activation_quant_cfg=candidate_qc.activation_quantization_cfg,
-                                                                nodes_prior_info=n.prior_info,
-                                                                out_stats_container=graph.get_out_stats_collector(n))
-            # If node should not be quantized at all
-            elif fw_info.in_no_quantization_ops(n):
-                pass  # pragma: no cover
-
-            # Create a NodeQuantizationConfig containing all quantization params and attach it to the node
+            if n.is_weights_quantization_enabled():
+                # If node's weights should be quantized, we compute its weights' quantization parameters
+                output_channels_axis, _ = get_channels_axis(candidate_qc.weights_quantization_cfg, fw_info, n.type)
+                weights_params = get_weights_qparams(n.get_weights_by_keys(fw_impl.constants.KERNEL),
+                                                     candidate_qc.weights_quantization_cfg,
+                                                     output_channels_axis)
+                candidate_qc.weights_quantization_cfg.set_weights_quantization_param(weights_params)
+                candidate_qc.weights_quantization_cfg.weights_channels_axis = output_channels_axis
             if n.is_activation_quantization_enabled():
+                # If node's activations should be quantized as well, we compute its activation quantization parameters
+                activation_params = get_activations_qparams(
+                    activation_quant_cfg=candidate_qc.activation_quantization_cfg,
+                    nodes_prior_info=n.prior_info,
+                    out_stats_container=graph.get_out_stats_collector(n))
+                # Create a NodeQuantizationConfig containing all quantization params and attach it to the node
                 candidate_qc.activation_quantization_cfg.set_activation_quantization_param(activation_params)
-
-        # If layer type is not in framework info, log a warning.
-        if not fw_info.in_no_quantization_ops(n) and not fw_info.in_activation_ops(n) and not fw_info.in_kernel_ops(n):
-            Logger.warning(f"Warning: unknown layer: {n.type.__name__}")

--- a/model_compression_toolkit/common/quantization/quantize_graph_weights.py
+++ b/model_compression_toolkit/common/quantization/quantize_graph_weights.py
@@ -42,7 +42,7 @@ def quantize_graph_weights(graph_to_quantize: Graph,
     # (according to operators groups in framework info).
     for n in graph.nodes():
 
-        if fw_info.in_kernel_ops(n) and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.enable_weights_quantization:
             quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
                                                                                     n,
                                                                                     n.final_weights_quantization_cfg,

--- a/model_compression_toolkit/common/quantization/quantize_graph_weights.py
+++ b/model_compression_toolkit/common/quantization/quantize_graph_weights.py
@@ -42,7 +42,7 @@ def quantize_graph_weights(graph_to_quantize: Graph,
     # (according to operators groups in framework info).
     for n in graph.nodes():
 
-        if n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.enable_weights_quantization:
+        if n.is_weights_quantization_enabled():
             quantized_kernel, io_channels_axes = get_quantized_kernel_by_weights_qc(fw_info,
                                                                                     n,
                                                                                     n.final_weights_quantization_cfg,

--- a/model_compression_toolkit/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/set_node_quantization_config.py
@@ -78,15 +78,11 @@ def set_quantization_configs_to_node(node: BaseNode,
                                                                   weight_channel_axis,
                                                                   node_qc_options)
 
-    enable_activation_quantization = quant_config.enable_activation_quantization \
-                                     and (fw_info.in_activation_ops(node) or fw_info.in_kernel_ops(node)) \
-                                     and node.get_has_activation()
-    enable_weights_quantization = quant_config.enable_weights_quantization \
-                                  and fw_info.in_kernel_ops(node) \
-                                  and node.has_weights_to_quantize(fw_info)
     for candidate_qc in node.candidates_quantization_cfg:
-        candidate_qc.weights_quantization_cfg.enable_weights_quantization = enable_weights_quantization
-        candidate_qc.activation_quantization_cfg.enable_activation_quantization = enable_activation_quantization
+        candidate_qc.weights_quantization_cfg.enable_weights_quantization = \
+            candidate_qc.weights_quantization_cfg.enable_weights_quantization and node.has_weights_to_quantize(fw_info)
+        candidate_qc.activation_quantization_cfg.enable_activation_quantization = \
+            candidate_qc.activation_quantization_cfg.enable_activation_quantization and node.get_has_activation()
 
 
 def create_node_activation_qc(qc: QuantizationConfig,

--- a/model_compression_toolkit/keras/default_framework_info.py
+++ b/model_compression_toolkit/keras/default_framework_info.py
@@ -17,13 +17,9 @@
 import tensorflow as tf
 
 if tf.__version__ < "2.6":
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, Dropout, \
-        MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, InputLayer, \
-        Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute, LayerNormalization
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 else:
-    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
-    Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, UpSampling2D, \
-    InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute, LayerNormalization
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -35,75 +31,6 @@ from model_compression_toolkit.common.quantization.quantizers.uniform_quantizers
 from model_compression_toolkit.keras.constants import SOFTMAX, LINEAR, RELU, SWISH, SIGMOID, IDENTITY, TANH, SELU, \
     KERNEL, DEPTHWISE_KERNEL
 from model_compression_toolkit.keras.quantizer.fake_quant_builder import power_of_two_quantization, symmetric_quantization, uniform_quantization
-
-"""
-Division of Keras layers by how they should be quantized.
-KERNEL_OPS: Layers that their coefficients should be quantized.
-ACTIVATION: Layers that their activation should be quantized.
-NO_QUANTIZATION: Layers that should not be quantized.
-"""
-
-KERNEL_OPS = [Conv2D,
-              DepthwiseConv2D,
-              Dense,
-              Conv2DTranspose]
-
-NO_QUANTIZATION = [Reshape,
-                   tf.reshape,
-                   Flatten,
-                   Permute,
-                   Cropping2D,
-                   ZeroPadding2D,
-                   Dropout,
-                   MaxPooling2D,
-                   tf.reshape,
-                   tf.split,
-                   tf.quantization.fake_quant_with_min_max_vars]  # TODO:  replace with marking
-
-ACTIVATION = [Activation,
-              ReLU,
-              tf.nn.relu,
-              tf.nn.relu6,
-              tf.nn.leaky_relu,
-              Softmax,
-              GlobalAveragePooling2D,
-              Add,
-              Multiply,
-              AveragePooling2D,
-              UpSampling2D,
-              InputLayer,
-              Concatenate,
-              PReLU,
-              ELU,
-              tf.nn.silu,
-              tf.nn.swish,
-              tf.nn.sigmoid,
-              tf.nn.tanh,
-              tf.nn.relu,
-              tf.nn.relu6,
-              tf.nn.leaky_relu,
-              LeakyReLU,
-              tf.nn.softsign,
-              tf.nn.gelu,
-              tf.nn.elu,
-              tf.nn.selu,
-              tf.nn.softplus,
-              tf.nn.softmax,
-              Dot,
-              LayerNormalization,
-              tf.add,
-              tf.multiply,
-              tf.reduce_mean,
-              tf.reduce_min,
-              tf.reduce_sum,
-              tf.reduce_max,
-              tf.image.resize,
-              tf.image.crop_and_resize,
-              tf.concat,
-              ]
-
-
-
 
 """
 Map each layer to a list of its' weights attributes that should get quantized.
@@ -178,10 +105,7 @@ Output channel index of the model's layers
 """
 OUTPUT_CHANNEL_INDEX = ChannelAxis.NHWC
 
-DEFAULT_KERAS_INFO = FrameworkInfo(KERNEL_OPS,
-                                   ACTIVATION,
-                                   NO_QUANTIZATION,
-                                   ACTIVATION_QUANTIZER_MAPPING,
+DEFAULT_KERAS_INFO = FrameworkInfo(ACTIVATION_QUANTIZER_MAPPING,
                                    WEIGHTS_QUANTIZER_MAPPING,
                                    DEFAULT_CHANNEL_AXIS_DICT,
                                    ACTIVATION2MINMAX,

--- a/model_compression_toolkit/keras/gradient_ptq/graph_info.py
+++ b/model_compression_toolkit/keras/gradient_ptq/graph_info.py
@@ -75,7 +75,9 @@ def get_trainable_parameters(fxp_model: Model,
             # collect trainable weights per layer
             layer_trainable_weights = layer.quantize_config.get_trainable_quantizer_parameters()
             if add_bias:
-                use_bias = isinstance(layer.layer, tuple(fw_info.kernel_ops)) and layer.layer.get_config().get(USE_BIAS)
+                kernel_ops_attrs = fw_info.kernel_ops_attributes_mapping.get(type(layer.layer))
+                use_bias = kernel_ops_attrs is not None and kernel_ops_attrs[0] is not None \
+                           and layer.layer.get_config().get(USE_BIAS)
                 if use_bias is not None and use_bias:
                     layer_trainable_weights.append(layer.layer.bias)
             trainable_weights.append(layer_trainable_weights)

--- a/model_compression_toolkit/pytorch/default_framework_info.py
+++ b/model_compression_toolkit/pytorch/default_framework_info.py
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import torch
-from torch.nn import Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, \
-    Sigmoid, Softplus, Softsign, Tanh
-from torch.nn.functional import hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, \
-    softplus, softsign
-from torch.nn import UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d
-from torch.nn.functional import upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d
-from torch.nn import Conv2d, ConvTranspose2d, Linear, BatchNorm2d
-from torch.nn import Dropout, Flatten
-from torch import add, multiply, mul, sub, flatten, reshape, split, unsqueeze, concat, cat,\
-    mean, dropout, sigmoid, tanh
-import operator
+from torch.nn import Hardsigmoid, ReLU, ReLU6, Softmax, Sigmoid
+from torch.nn.functional import hardsigmoid, relu, relu6, softmax
+from torch.nn import Conv2d, ConvTranspose2d, Linear
+from torch import sigmoid
 
 from model_compression_toolkit.common.defaultdict import DefaultDict
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -35,30 +27,6 @@ from model_compression_toolkit.common.quantization.quantizers.uniform_quantizers
 from model_compression_toolkit.pytorch.constants import KERNEL
 from model_compression_toolkit.pytorch.quantizer.fake_quant_builder import power_of_two_quantization, \
     symmetric_quantization, uniform_quantization
-from model_compression_toolkit.pytorch.quantizer.fake_quant_builder import power_of_two_quantization
-from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder, ConstantHolder
-
-"""
-Division of Pytorch modules by how they should be quantized.
-KERNEL_OPS: Layers that their coefficients should be quantized.
-ACTIVATION: Layers that their activation should be quantized.
-NO_QUANTIZATION: Layers that should not be quantized.
-"""
-
-KERNEL_OPS = [Conv2d, Linear, ConvTranspose2d]
-
-NO_QUANTIZATION = [Dropout, Flatten, ConstantHolder] + \
-                  [dropout, flatten, split, operator.getitem, reshape, unsqueeze]
-
-ACTIVATION = [DummyPlaceHolder] + \
-    [Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, Sigmoid, Softplus, Softsign, Tanh] + \
-    [hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, sigmoid, softplus, softsign, tanh] + \
-    [torch.relu] + \
-    [UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d] + \
-    [upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d] + \
-    [add, sub, mul, multiply] + \
-    [operator.add, operator.sub, operator.mul] + \
-    [BatchNorm2d, concat, cat, mean]
 
 """
 Map each layer to a list of its' weights attributes that should get quantized.
@@ -121,10 +89,7 @@ Output channel index of the model's layers
 """
 OUTPUT_CHANNEL_INDEX = ChannelAxis.NCHW
 
-DEFAULT_PYTORCH_INFO = FrameworkInfo(KERNEL_OPS,
-                                     ACTIVATION,
-                                     NO_QUANTIZATION,
-                                     ACTIVATION_QUANTIZER_MAPPING,
+DEFAULT_PYTORCH_INFO = FrameworkInfo(ACTIVATION_QUANTIZER_MAPPING,
                                      WEIGHTS_QUANTIZER_MAPPING,
                                      DEFAULT_CHANNEL_AXIS_DICT,
                                      ACTIVATION2MINMAX,

--- a/tests/common_tests/helpers/generate_test_hw_model.py
+++ b/tests/common_tests/helpers/generate_test_hw_model.py
@@ -40,3 +40,9 @@ def get_16bit_fw_hw_model(name):
     hw_model = generate_test_hw_model({'weights_n_bits': 16,
                                        'activation_n_bits': 16})
     return generate_fhw_model_keras(name=name, hardware_model=hw_model)
+
+
+def get_quantization_disabled_keras_hw_model(name):
+    hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                  'enable_activation_quantization': False})
+    return generate_fhw_model_keras(name=name, hardware_model=hwm)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 import numpy as np
 
 from model_compression_toolkit.keras.constants import ACTIVATION, LINEAR
+from tests.common_tests.helpers.generate_test_hw_model import get_quantization_disabled_keras_hw_model
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as mct
@@ -31,8 +32,11 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
         self.activation_function = activation_function
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        return get_quantization_disabled_keras_hw_model("activation_decomp_test")
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -35,9 +35,6 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
     def get_fw_hw_model(self):
         return get_quantization_disabled_keras_hw_model("activation_decomp_test")
 
-    def get_quantization_config(self):
-        return mct.QuantizationConfig()
-
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
         outputs = layers.Conv2D(3, 4, activation=self.activation_function)(inputs)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -38,12 +38,15 @@ class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
         super(BaseBatchNormalizationFolding, self).__init__(unit_test=unit_test)
 
     def get_fw_hw_model(self):
-        return get_16bit_fw_hw_model("kmean_quantizer_test")
+        hwm = generate_test_hw_model({'weights_n_bits': 16,
+                                      'activation_n_bits': 16,
+                                      'enable_weights_quantization': False,
+                                      'enable_activation_quantization': False})
+        return generate_fhw_model_keras(name="bn_folding_test", hardware_model=hwm)
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING, mct.QuantizationErrorMethod.NOCLIPPING,
-                                      False, False, True, enable_weights_quantization=False,
-                                      enable_activation_quantization=False)
+                                      False, False, True)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         y = float_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/conv_bn_relu_residual_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/conv_bn_relu_residual_test.py
@@ -38,6 +38,6 @@ class ConvBnReluResidualTest(BaseKerasFeatureNetworkTest):
         self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
         self.unit_test.assertTrue(quantized_model.layers[3].function == tf.quantization.fake_quant_with_min_max_vars)
         self.unit_test.assertTrue(quantized_model.layers[3].input.ref() == quantized_model.layers[2].output.ref())
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[7], layers.Add))
-        self.unit_test.assertTrue(quantized_model.layers[3].output.ref() in [t.ref() for t in quantized_model.layers[7].input])
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[8], layers.Add))
+        self.unit_test.assertTrue(quantized_model.layers[3].output.ref() in [t.ref() for t in quantized_model.layers[8].input])
         self.unit_test.assertTrue(isinstance(quantized_model.layers[4], layers.BatchNormalization)) # assert not folding

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -46,9 +46,6 @@ class MultiHeadAttentionTest(BaseKerasFeatureNetworkTest):
     def get_fw_hw_model(self):
         return get_quantization_disabled_keras_hw_model("multi_head_attention_test")
 
-    def get_quantization_config(self):
-        return QuantizationConfig()
-
     def get_input_shapes(self):
         if self.separate_key_value:
             return [[self.val_batch_size] + list(self.query_input_shape),

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
+from tests.common_tests.helpers.generate_test_hw_model import get_quantization_disabled_keras_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
 import model_compression_toolkit as mct
@@ -44,9 +43,11 @@ class MultiHeadAttentionTest(BaseKerasFeatureNetworkTest):
         self.separate_key_value = separate_key_value
         self.output_dim = output_dim
 
+    def get_fw_hw_model(self):
+        return get_quantization_disabled_keras_hw_model("multi_head_attention_test")
+
     def get_quantization_config(self):
-        return QuantizationConfig(enable_weights_quantization=False,
-                                  enable_activation_quantization=False)
+        return QuantizationConfig()
 
     def get_input_shapes(self):
         if self.separate_key_value:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
@@ -34,6 +34,9 @@ class MultipleOutputsNodeTests(BaseKerasFeatureNetworkTest):
     def get_fw_hw_model(self):
         return get_quantization_disabled_keras_hw_model("multiple_outputs_test")
 
+    def get_quantization_config(self):
+        return mct.QuantizationConfig()
+
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
         x = layers.Dense(20)(inputs)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
@@ -34,9 +34,6 @@ class MultipleOutputsNodeTests(BaseKerasFeatureNetworkTest):
     def get_fw_hw_model(self):
         return get_quantization_disabled_keras_hw_model("multiple_outputs_test")
 
-    def get_quantization_config(self):
-        return mct.QuantizationConfig()
-
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
         x = layers.Dense(20)(inputs)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
@@ -17,6 +17,8 @@
 from tests.common_tests.base_feature_test import BaseFeatureNetworkTest
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import get_quantization_disabled_keras_hw_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -29,9 +31,11 @@ class MultipleOutputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
+    def get_fw_hw_model(self):
+        return get_quantization_disabled_keras_hw_model("multiple_outputs_test")
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_activation_quantization=False,
-                                      enable_weights_quantization=False)
+        return mct.QuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -42,9 +42,6 @@ class NestedModelUnusedInputsOutputsTest(BaseKerasFeatureNetworkTest):
     def get_fw_hw_model(self):
         return get_quantization_disabled_keras_hw_model("nested_model_unused_inputs_test")
 
-    def get_quantization_config(self):
-        return mct.QuantizationConfig()
-
     def inner_functional_model(self, input_shape):
         inputs = layers.Input(shape=input_shape[1:])
         x = layers.Conv2D(3, 4)(inputs)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -15,6 +15,9 @@
 
 import model_compression_toolkit as mct
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import get_quantization_disabled_keras_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -36,8 +39,11 @@ class NestedModelUnusedInputsOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        return get_quantization_disabled_keras_hw_model("nested_model_unused_inputs_test")
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     def inner_functional_model(self, input_shape):
         inputs = layers.Input(shape=input_shape[1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 
 import tensorflow as tf
+
+from tests.common_tests.helpers.generate_test_hw_model import get_quantization_disabled_keras_hw_model
+
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.engine.functional import Functional
     from tensorflow.python.keras.engine.sequential import Sequential
@@ -37,8 +40,11 @@ class NestedTest(BaseKerasFeatureNetworkTest):
         super().__init__(unit_test,
                          input_shape=(16,16,3))
 
+    def get_fw_hw_model(self):
+        return get_quantization_disabled_keras_hw_model("nested_test")
+
     def get_quantization_config(self):
-        return mct.QuantizationConfig(enable_weights_quantization=False, enable_activation_quantization=False)
+        return mct.QuantizationConfig()
 
     # Dummy model to test reader's recursively model parsing
     def dummy_model(self, input_shape):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -43,9 +43,6 @@ class NestedTest(BaseKerasFeatureNetworkTest):
     def get_fw_hw_model(self):
         return get_quantization_disabled_keras_hw_model("nested_test")
 
-    def get_quantization_config(self):
-        return mct.QuantizationConfig()
-
     # Dummy model to test reader's recursively model parsing
     def dummy_model(self, input_shape):
         inputs = layers.Input(shape=input_shape[1:])

--- a/tests/keras_tests/feature_networks_tests/test_networks_runner_float.py
+++ b/tests/keras_tests/feature_networks_tests/test_networks_runner_float.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
+import copy
 
 import numpy as np
 import tensorflow as tf
@@ -62,7 +62,7 @@ class NetworkTest(object):
         graph.set_fw_info(DEFAULT_KERAS_INFO)
         graph.set_fw_hw_model(keras_default_hw_model)
         graph = set_quantization_configuration_to_graph(graph,
-                                                        DEFAULTCONFIG)
+                                                        copy.deepcopy(DEFAULTCONFIG))
         ptq_model, _ = model_builder(graph,
                                      mode=ModelBuilderMode.FLOAT)
         self.compare(inputs_list, ptq_model)
@@ -73,9 +73,9 @@ class NetworkTest(object):
                                                           fw_info=fw_info,
                                                           graph=graph)
         graph = substitute(graph,
-                           fw_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+                           fw_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         graph = set_quantization_configuration_to_graph(graph,
-                                                        DEFAULTCONFIG)
+                                                        copy.deepcopy(DEFAULTCONFIG))
 
         ptq_model, _ = model_builder(graph,
                                      mode=ModelBuilderMode.FLOAT)

--- a/tests/keras_tests/function_tests/test_bn_info_collection.py
+++ b/tests/keras_tests/function_tests/test_bn_info_collection.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import copy
+
 import keras
 import unittest
 from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, Input, SeparableConv2D, Reshape
@@ -135,7 +137,7 @@ def prepare_graph(in_model):
     for node in graph.nodes:
         node.prior_info = keras_impl.get_node_prior_info(node=node,
                                                          fw_info=fw_info, graph=graph)
-    transformed_graph = substitute(graph, keras_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+    transformed_graph = substitute(graph, keras_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
     return transformed_graph
 
 

--- a/tests/keras_tests/function_tests/test_bn_info_collection.py
+++ b/tests/keras_tests/function_tests/test_bn_info_collection.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import copy
-
 import keras
 import unittest
 from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, Input, SeparableConv2D, Reshape
@@ -137,7 +135,7 @@ def prepare_graph(in_model):
     for node in graph.nodes:
         node.prior_info = keras_impl.get_node_prior_info(node=node,
                                                          fw_info=fw_info, graph=graph)
-    transformed_graph = substitute(graph, keras_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+    transformed_graph = substitute(graph, keras_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
     return transformed_graph
 
 

--- a/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
@@ -80,13 +80,13 @@ class TestQuantizationConfigurations(unittest.TestCase):
             hwm = generate_test_hw_model({
                 'activation_quantization_method': quantize_method,
                 'weights_n_bits': 8,
-                'activation_n_bits': 8})
+                'activation_n_bits': 8,
+                'enable_weights_quantization': False})
             fw_hw_model = generate_fhw_model_keras(name="kl_quant_config_activation_test", hardware_model=hwm)
 
             qc = mct.QuantizationConfig(activation_error_method=error_method,
                                         relu_bound_to_power_of_2=relu_bound_to_power_of_2,
-                                        shift_negative_activation_correction=False,
-                                        enable_weights_quantization=False)
+                                        shift_negative_activation_correction=False)
 
             q_model, quantization_info = mct.keras_post_training_quantization(model,
                                                                               representative_data_gen,

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -4,15 +4,24 @@ import tensorflow as tf
 
 from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, \
+    get_quantization_disabled_keras_hw_model
 
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Input
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, \
+        UpSampling2D, InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute, \
+        LayerNormalization
 else:
     from keras.layers.core import TFOpLambda
     from keras import Input, Model
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, \
+        UpSampling2D, InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute, \
+        LayerNormalization
 
 from model_compression_toolkit import FrameworkInfo, keras_post_training_quantization, \
     keras_post_training_quantization_mixed_precision
@@ -22,6 +31,22 @@ from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode
 import numpy as np
+
+
+KERAS_LAYER_TEST_OPS = {
+    "kernel_ops": [Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose],
+
+    "no_quantization": [Reshape, tf.reshape, Flatten, Permute, Cropping2D, ZeroPadding2D, Dropout, MaxPooling2D,
+                        tf.reshape, tf.split, tf.quantization.fake_quant_with_min_max_vars],
+
+    "activation": [Activation, ReLU, tf.nn.relu, tf.nn.relu6, tf.nn.leaky_relu, Softmax, GlobalAveragePooling2D, Add,
+                   Multiply, AveragePooling2D, UpSampling2D, InputLayer, Concatenate, PReLU, ELU, tf.nn.silu,
+                   tf.nn.swish, tf.nn.sigmoid, tf.nn.tanh, tf.nn.relu, tf.nn.relu6, tf.nn.leaky_relu, LeakyReLU,
+                   tf.nn.softsign, tf.nn.gelu, tf.nn.elu, tf.nn.selu, tf.nn.softplus, tf.nn.softmax, Dot,
+                   LayerNormalization, tf.add, tf.multiply, tf.reduce_mean, tf.reduce_min, tf.reduce_sum, tf.reduce_max,
+                   tf.image.resize, tf.image.crop_and_resize, tf.concat,
+                   ]
+}
 
 
 class BaseKerasLayerTest(BaseLayerTest):
@@ -49,7 +74,7 @@ class BaseKerasLayerTest(BaseLayerTest):
     def get_fw_hw_model(self):
         if self.current_mode == LayerTestMode.FLOAT:
             # Disable all features that are enabled by default:
-            return generate_fhw_model_keras(name="float_layer_test", hardware_model=get_default_hardware_model())
+            get_quantization_disabled_keras_hw_model("float_layer_test")
         elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
             hwm = generate_test_hw_model({'weights_n_bits': 8,
                                           'activation_n_bits': 8})
@@ -115,18 +140,18 @@ class BaseKerasLayerTest(BaseLayerTest):
         fw_info = self.get_fw_info()
         for layer in quantized_model.layers:
             op = layer.function if isinstance(layer, TFOpLambda) else type(layer)
-            if op in fw_info.kernel_ops:
+            if op in KERAS_LAYER_TEST_OPS['kernel_ops']:
                 for attr in fw_info.get_kernel_op_attributes(type(layer)):
                     self.unit_test.assertTrue(np.sum(np.abs(
                         getattr(layer, attr) - getattr(float_model.get_layer(layer.name), attr))) > 0.0)
                 for next_layer in [node.layer for node in layer.outbound_nodes]:
                     self.unit_test.assertTrue(is_layer_fake_quant(next_layer))
 
-            elif op in fw_info.activation_ops:
+            elif op in KERAS_LAYER_TEST_OPS['activation']:
                 for next_layer in [node.layer for node in layer.outbound_nodes]:
                     self.unit_test.assertTrue(is_layer_fake_quant(next_layer))
 
-            elif op in fw_info.no_quantization_ops:
+            elif op in KERAS_LAYER_TEST_OPS['no_quantization']:
                 for next_layer in [node.layer for node in layer.outbound_nodes]:
                     self.unit_test.assertFalse(is_layer_fake_quant(next_layer))
 

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -74,7 +74,7 @@ class BaseKerasLayerTest(BaseLayerTest):
     def get_fw_hw_model(self):
         if self.current_mode == LayerTestMode.FLOAT:
             # Disable all features that are enabled by default:
-            get_quantization_disabled_keras_hw_model("float_layer_test")
+            return get_quantization_disabled_keras_hw_model("float_layer_test")
         elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
             hwm = generate_test_hw_model({'weights_n_bits': 8,
                                           'activation_n_bits': 8})

--- a/tests/pytorch_tests/function_tests/bn_info_collection_test.py
+++ b/tests/pytorch_tests/function_tests/bn_info_collection_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import copy
-
 import torch
 from torch.nn import Conv2d, BatchNorm2d, ReLU
 from model_compression_toolkit.pytorch.utils import to_torch_tensor
@@ -164,7 +162,7 @@ class BNInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
         return transformed_graph
 
     def run_test(self):
@@ -213,7 +211,7 @@ class Conv2D2BNInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
         return transformed_graph
 
     def run_test(self):
@@ -285,7 +283,7 @@ class Conv2DBNChainInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
         return transformed_graph
 
     def run_test(self):
@@ -345,7 +343,7 @@ class BNChainInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
         return transformed_graph
 
     def run_test(self):
@@ -417,7 +415,7 @@ class BNLayerInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
         return transformed_graph
 
     def run_test(self):
@@ -525,7 +523,7 @@ class INP2BNInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
         return transformed_graph
 
     def run_test(self):

--- a/tests/pytorch_tests/function_tests/bn_info_collection_test.py
+++ b/tests/pytorch_tests/function_tests/bn_info_collection_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import copy
+
 import torch
 from torch.nn import Conv2d, BatchNorm2d, ReLU
 from model_compression_toolkit.pytorch.utils import to_torch_tensor
@@ -162,7 +164,7 @@ class BNInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         return transformed_graph
 
     def run_test(self):
@@ -211,7 +213,7 @@ class Conv2D2BNInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         return transformed_graph
 
     def run_test(self):
@@ -283,7 +285,7 @@ class Conv2DBNChainInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         return transformed_graph
 
     def run_test(self):
@@ -343,7 +345,7 @@ class BNChainInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         return transformed_graph
 
     def run_test(self):
@@ -415,7 +417,7 @@ class BNLayerInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         return transformed_graph
 
     def run_test(self):
@@ -523,7 +525,7 @@ class INP2BNInfoCollectionTest(BasePytorchTest):
             node.prior_info = pytorch_impl.get_node_prior_info(node=node,
                                                                fw_info=fw_info,
                                                                graph=graph)
-        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(DEFAULTCONFIG))
+        transformed_graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(copy.deepcopy(DEFAULTCONFIG)))
         return transformed_graph
 
     def run_test(self):

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -16,6 +16,16 @@ import operator
 from typing import List, Any, Tuple
 import numpy as np
 import torch
+from torch.nn import Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax, \
+    Sigmoid, Softplus, Softsign, Tanh
+from torch.nn.functional import hardswish, hardsigmoid, relu, hardtanh, relu6, leaky_relu, prelu, silu, softmax, \
+    softplus, softsign
+from torch.nn import UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d
+from torch.nn.functional import upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d
+from torch.nn import Conv2d, ConvTranspose2d, Linear, BatchNorm2d
+from torch.nn import Dropout, Flatten
+from torch import add, multiply, mul, sub, flatten, reshape, split, unsqueeze, concat, cat,\
+    mean, dropout, sigmoid, tanh
 from torch.fx import symbolic_trace
 from torch.nn import Module
 
@@ -24,12 +34,31 @@ from model_compression_toolkit.common.framework_implementation import FrameworkI
 from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 from model_compression_toolkit.hardware_models.pytorch_hardware_model.pytorch_default import generate_fhw_model_pytorch
 from model_compression_toolkit.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
-from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder
+from model_compression_toolkit.pytorch.reader.graph_builders import DummyPlaceHolder, ConstantHolder
 from model_compression_toolkit.pytorch.utils import torch_tensor_to_numpy, to_torch_tensor
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode
 from model_compression_toolkit.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.pytorch.pytorch_implementation import PytorchImplementation
 from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+
+
+PYTORCH_LAYER_TEST_OPS = {
+    "kernel_ops": [Conv2d, Linear, ConvTranspose2d],
+
+    "no_quantization": [Dropout, Flatten, ConstantHolder, dropout, flatten, split, operator.getitem, reshape,
+                        unsqueeze],
+
+    "activation": [DummyPlaceHolder,
+                   Hardswish, Hardsigmoid, ReLU, Hardtanh, ReLU6, LeakyReLU, PReLU, SiLU, Softmax,
+                   Sigmoid, Softplus, Softsign, Tanh, hardswish, hardsigmoid, relu, hardtanh,
+                   relu6, leaky_relu, prelu,
+                   silu, softmax, sigmoid, softplus, softsign, tanh, torch.relu,
+                   UpsamplingBilinear2d, AdaptiveAvgPool2d, AvgPool2d, MaxPool2d,
+                   upsample_bilinear, adaptive_avg_pool2d, avg_pool2d, max_pool2d,
+                   add, sub, mul, multiply,
+                   operator.add, operator.sub, operator.mul,
+                   BatchNorm2d, concat, cat, mean]
+}
 
 
 class LayerTestModel(torch.nn.Module):
@@ -114,7 +143,9 @@ class BasePytorchLayerTest(BaseLayerTest):
     def get_fw_hw_model(self):
         if self.current_mode == LayerTestMode.FLOAT:
             # Disable all features that are enabled by default:
-            return generate_fhw_model_pytorch(name="float_layer_test", hardware_model=get_default_hardware_model())
+            hwm = generate_test_hw_model({'enable_weights_quantization': False,
+                                          'enable_activation_quantization': False})
+            return generate_fhw_model_pytorch(name="base_layer_test", hardware_model=hwm)
         elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
             hwm = generate_test_hw_model({'weights_n_bits': 8,
                                           'activation_n_bits': 8})
@@ -166,7 +197,7 @@ class BasePytorchLayerTest(BaseLayerTest):
             if op == OUTPUT or op == operator.getitem or is_node_fake_quant(node):
                 continue
             if hasattr(quantized_model, str(node.target)):
-                if type(op) in fw_info.kernel_ops:
+                if type(op) in PYTORCH_LAYER_TEST_OPS['kernel_ops']:
                     quantized_weights = get_layer_weights(getattr(quantized_model, node.target))
                     float_weights = get_layer_weights(getattr(float_model, node.target))
                     for k, v in quantized_weights.items():
@@ -179,13 +210,13 @@ class BasePytorchLayerTest(BaseLayerTest):
                         node_next = node_next.next
                     self.unit_test.assertTrue(is_node_fake_quant(node_next))
 
-            elif op in fw_info.activation_ops:
+            elif op in PYTORCH_LAYER_TEST_OPS['activation']:
                 node_next = node.next
                 while get_node_operation(node_next, quantized_model) == operator.getitem:
                     node_next = node_next.next
                 self.unit_test.assertTrue(is_node_fake_quant(node_next))
 
-            elif op in fw_info.no_quantization_ops:
+            elif op in PYTORCH_LAYER_TEST_OPS['no_quantization']:
                 node_next = node.next
                 while get_node_operation(node_next, quantized_model) == operator.getitem:
                     node_next = node_next.next

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -40,13 +40,22 @@ class BasePytorchTest(BaseFeatureNetworkTest):
         return {
             'no_quantization': generate_fhw_model_pytorch(name="no_quant_pytorch_test",
                                                           hardware_model=generate_test_hw_model({'weights_n_bits': 32,
-                                                                                                 'activation_n_bits': 32})),
+                                                                                                 'activation_n_bits': 32,
+                                                                                                 'enable_weights_quantization': False,
+                                                                                                 'enable_activation_quantization': False
+                                                                                                 })),
             'all_32bit': generate_fhw_model_pytorch(name="32_quant_pytorch_test",
                                                     hardware_model=generate_test_hw_model({'weights_n_bits': 32,
-                                                                                           'activation_n_bits': 32})),
+                                                                                           'activation_n_bits': 32,
+                                                                                           'enable_weights_quantization': True,
+                                                                                           'enable_activation_quantization': True
+                                                                                           })),
             'all_4bit': generate_fhw_model_pytorch(name="4_quant_pytorch_test",
                                                    hardware_model=generate_test_hw_model({'weights_n_bits': 4,
-                                                                                          'activation_n_bits': 4})),
+                                                                                          'activation_n_bits': 4,
+                                                                                          'enable_weights_quantization': True,
+                                                                                          'enable_activation_quantization': True
+                                                                                          })),
         }
 
     # TODO: We can remove this method and refactor Pytorch tests to run only over
@@ -55,19 +64,13 @@ class BasePytorchTest(BaseFeatureNetworkTest):
         return {
             'no_quantization': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                       mct.QuantizationErrorMethod.NOCLIPPING,
-                                                      False, True, True,
-                                                      enable_weights_quantization=False,
-                                                      enable_activation_quantization=False),
+                                                      False, True, True),
             'all_32bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                 mct.QuantizationErrorMethod.NOCLIPPING,
-                                                False, True, True,
-                                                enable_weights_quantization=True,
-                                                enable_activation_quantization=True),
+                                                False, True, True),
             'all_4bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               False, False, True,
-                                               enable_weights_quantization=True,
-                                               enable_activation_quantization=True),
+                                               False, False, True),
         }
 
     def create_inputs_shape(self):

--- a/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
@@ -145,7 +145,7 @@ class HardtanhBoundToPOTNetTest(BasePytorchTest):
                                                fhwm_name='relu_bound_pytorch_test')
 
     def get_quantization_configs(self):
-        quant_config = mct.DEFAULTCONFIG
+        quant_config = copy.deepcopy(mct.DEFAULTCONFIG)
         quant_config.relu_bound_to_power_of_2 = True
         return {"8bit_relu_bound": quant_config}
 

--- a/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import copy
+
 import torch
 
+from model_compression_toolkit import DEFAULTCONFIG
 from model_compression_toolkit.hardware_models.default_hwm import get_default_hardware_model
 from tests.pytorch_tests.layer_tests.base_pytorch_layer_test import get_layer_test_fw_hw_model_dict
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
@@ -101,7 +104,7 @@ class ReLUBoundToPOTNetTest(BasePytorchTest):
                                                fhwm_name='relu_bound_pytorch_test')
 
     def get_quantization_configs(self):
-        quant_config = super(ReLUBoundToPOTNetTest).get_quantization_config()
+        quant_config = copy.deepcopy(DEFAULTCONFIG)
         quant_config.relu_bound_to_power_of_2 = True
         return {"8bit_relu_bound": quant_config}
 

--- a/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/relu_bound_test.py
@@ -101,7 +101,7 @@ class ReLUBoundToPOTNetTest(BasePytorchTest):
                                                fhwm_name='relu_bound_pytorch_test')
 
     def get_quantization_configs(self):
-        quant_config = mct.DEFAULTCONFIG
+        quant_config = super(ReLUBoundToPOTNetTest).get_quantization_config()
         quant_config.relu_bound_to_power_of_2 = True
         return {"8bit_relu_bound": quant_config}
 

--- a/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/shift_negative_activation_test.py
@@ -62,8 +62,6 @@ class ShiftNegaviteActivationNetTest(BasePytorchTest):
         return {
             'all_8bit': mct.QuantizationConfig(mct.QuantizationErrorMethod.NOCLIPPING,
                                                mct.QuantizationErrorMethod.NOCLIPPING,
-                                               enable_weights_quantization=True,
-                                               enable_activation_quantization=True,
                                                shift_negative_activation_correction=True,
                                                shift_negative_ratio=np.inf),
         }


### PR DESCRIPTION
Refactor to allow getting is quantization enabled from hardware model instead of quantization config.
Main changes include:

- Remove enable_quantization for both weights and activation from QuantizationConfig (refactor entire lib accordingly).
- Removed operations lists from framework info - required modification in several conditions checks throughout the code.
- Large refactor in tests - to adjust setting test configuration with hw model