### PR TITLE
Change mixed-precision sensitivity metric interest points

### DIFF
--- a/model_compression_toolkit/common/mixed_precision/sensitivity_evaluation_manager.py
+++ b/model_compression_toolkit/common/mixed_precision/sensitivity_evaluation_manager.py
@@ -142,6 +142,10 @@ def get_mp_interest_points(graph: Graph, fw_info: FrameworkInfo):
 
     # We add the last configurable node to the list of interest points, since we need it to be able to include all
     # configurable nodes in the sensitivity metric computation
+
+    conf_nodes = graph.get_configurable_sorted_nodes()
+    if len(conf_nodes) == 0:
+        raise Exception("No configurable nodes in mixed precision search mode")
     last_conf_node = graph.get_configurable_sorted_nodes()[-1]
     interest_points_nodes = kernel_nodes if last_conf_node in kernel_nodes else kernel_nodes + [last_conf_node]
     return interest_points_nodes

--- a/model_compression_toolkit/keras/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/keras/mixed_precision/sensitivity_evaluation.py
@@ -111,10 +111,11 @@ def _configure_bitwidths_keras_model(model_mp: Model,
         node_idx: List of nodes' indices to configure (the rest layers are configured as the baseline model).
     """
     # Configure model
-    # Note: the last configurable layer must be included in the interest points for evaluating the metric,
-    # otherwise, it would not be considered throughout the mp optimization search (since it would not
-    # affect the metric value)
-    model_mp_layers_names = [l.name for l in model_mp.layers]
+    # Note: Not all nodes in the graph are included in the MP model that is returned by the model builder.
+    # Thus, the last configurable layer must be included in the interest points for evaluating the metric,
+    # otherwise, not all configurable nodes will be considered throughout the MP optimization search (since
+    # they will not affect the metric value).
+    model_mp_layers_names = [layer.name for layer in model_mp.layers]
     if node_idx is not None:  # configure specific layers in the mp model
         for node_idx_to_configure in node_idx:
             node_name = f'quant_{sorted_configurable_nodes_names[node_idx_to_configure]}'

--- a/model_compression_toolkit/keras/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/keras/mixed_precision/sensitivity_evaluation.py
@@ -111,17 +111,29 @@ def _configure_bitwidths_keras_model(model_mp: Model,
         node_idx: List of nodes' indices to configure (the rest layers are configured as the baseline model).
     """
     # Configure model
+    # Note: the last configurable layer must be included in the interest points for evaluating the metric,
+    # otherwise, it would not be considered throughout the mp optimization search (since it would not
+    # affect the metric value)
+    model_mp_layers_names = [l.name for l in model_mp.layers]
     if node_idx is not None:  # configure specific layers in the mp model
         for node_idx_to_configure in node_idx:
-            current_layer = model_mp.get_layer(
-                name=f'quant_{sorted_configurable_nodes_names[node_idx_to_configure]}')
-            _set_layer_to_bitwidth(current_layer, mp_model_configuration[node_idx_to_configure])
+            node_name = f'quant_{sorted_configurable_nodes_names[node_idx_to_configure]}'
+            if node_name in model_mp_layers_names:
+                current_layer = model_mp.get_layer(name=node_name)
+                _set_layer_to_bitwidth(current_layer, mp_model_configuration[node_idx_to_configure])
+            else:
+                raise Exception("The last configurable node is not included in the list of interest points for"
+                                "sensitivity evaluation metric for the mixed-precision search.")
 
     else:  # use the entire mp_model_configuration to configure the model
         for node_idx_to_configure, bitwidth_idx in enumerate(mp_model_configuration):
-            current_layer = model_mp.get_layer(
-                name=f'quant_{sorted_configurable_nodes_names[node_idx_to_configure]}')
-            _set_layer_to_bitwidth(current_layer, mp_model_configuration[node_idx_to_configure])
+            node_name = f'quant_{sorted_configurable_nodes_names[node_idx_to_configure]}'
+            if node_name in model_mp_layers_names:
+                current_layer = model_mp.get_layer(name=node_name)
+                _set_layer_to_bitwidth(current_layer, mp_model_configuration[node_idx_to_configure])
+            else:
+                raise Exception("The last configurable node is not included in the list of interest points for"
+                                "sensitivity evaluation metric for the mixed-precision search.")
 
 
 def _set_layer_to_bitwidth(wrapped_layer: Layer,

--- a/tests/keras_tests/function_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/function_tests/test_lp_search_bitwidth.py
@@ -33,10 +33,12 @@ from model_compression_toolkit.common.quantization.set_node_quantization_config 
 from model_compression_toolkit.common.model_collector import ModelCollector
 from model_compression_toolkit import DEFAULTCONFIG
 from model_compression_toolkit.common.similarity_analyzer import compute_mse
+from model_compression_toolkit.hardware_models.default_hwm import get_op_quantization_configs
 from model_compression_toolkit.hardware_models.keras_hardware_model.keras_default import generate_fhw_model_keras
 from model_compression_toolkit.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.keras.keras_implementation import KerasImplementation
-from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model
+from tests.common_tests.helpers.generate_test_hw_model import generate_test_hw_model, \
+    generate_mixed_precision_test_hw_model
 
 
 class TestLpSearchBitwidth(unittest.TestCase):
@@ -163,7 +165,12 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
                                               compute_mse,
                                               get_average_weights,
                                               num_of_images=1)
-        hw_model = generate_test_hw_model({'enable_activation_quantization': False})
+
+        base_config, mixed_precision_cfg_list = get_op_quantization_configs()
+        base_config = base_config.clone_and_edit(enable_activation_quantization=False)
+        hw_model = generate_mixed_precision_test_hw_model(
+            base_cfg=base_config,
+            mp_bitwidth_candidates_list=[(c.weights_n_bits, c.activation_n_bits) for c in mixed_precision_cfg_list])
         fw_hw_model = generate_fhw_model_keras(name="bitwidth_cfg_test", hardware_model=hw_model)
         fw_info = DEFAULT_KERAS_INFO
         in_model = MobileNetV2()


### PR DESCRIPTION
Reduce the number of interest points for mp metric evaluation from the entire set of configurable nodes to only the outputs of convolutional layers.