### PR TITLE
Remove get_model tests

### DIFF
--- a/tests/keras_tests/test_keras_hardware_model.py
+++ b/tests/keras_tests/test_keras_hardware_model.py
@@ -212,34 +212,27 @@ class TestKerasHWModel(unittest.TestCase):
         self.assertEqual(p1[1], LayerFilterParams(ReLU, Greater("max_value", 7), negative_slope=0))
 
 
-
 class TestGetKerasHardwareModelAPI(unittest.TestCase):
-
     def test_get_keras_hw_models(self):
-        keras_hw_models = [DEFAULT_HWM,
-                           QNNPACK_HWM,
-                           TFLITE_HWM]
+        fw_hw_model = mct.get_model(TENSORFLOW, DEFAULT_HWM)
+        model = MobileNetV2()
 
-        for hw_name in keras_hw_models:
-            fw_hw_model = mct.get_model(TENSORFLOW, hw_name)
-            model = MobileNetV2()
+        def rep_data():
+            return [np.random.randn(1, 224, 224, 3)]
 
-            def rep_data():
-                return [np.random.randn(1, 224, 224, 3)]
+        quantized_model, _ = mct.keras_post_training_quantization(model,
+                                                                  rep_data,
+                                                                  n_iter=1,
+                                                                  fw_hw_model=fw_hw_model)
 
-            quantized_model, _ = mct.keras_post_training_quantization(model,
-                                                                      rep_data,
-                                                                      n_iter=1,
-                                                                      fw_hw_model=fw_hw_model)
-
-            mp_qc = copy.deepcopy(DEFAULT_MIXEDPRECISION_CONFIG)
-            mp_qc.num_of_images = 1
-            quantized_model, _ = mct.keras_post_training_quantization_mixed_precision(model,
-                                                                                      rep_data,
-                                                                                      target_kpi=mct.KPI(np.inf),
-                                                                                      n_iter=1,
-                                                                                      quant_config=mp_qc,
-                                                                                      fw_hw_model=fw_hw_model)
+        mp_qc = copy.deepcopy(DEFAULT_MIXEDPRECISION_CONFIG)
+        mp_qc.num_of_images = 1
+        quantized_model, _ = mct.keras_post_training_quantization_mixed_precision(model,
+                                                                                  rep_data,
+                                                                                  target_kpi=mct.KPI(np.inf),
+                                                                                  n_iter=1,
+                                                                                  quant_config=mp_qc,
+                                                                                  fw_hw_model=fw_hw_model)
 
     def test_get_keras_not_supported_model(self):
         with self.assertRaises(Exception) as e:

--- a/tests/pytorch_tests/test_pytorch_hardware_model.py
+++ b/tests/pytorch_tests/test_pytorch_hardware_model.py
@@ -217,30 +217,25 @@ class TestPytorchHWModel(unittest.TestCase):
 class TestGetPytorchHardwareModelAPI(unittest.TestCase):
 
     def test_get_pytorch_models(self):
-        pytorch_hw_models = [DEFAULT_HWM,
-                             QNNPACK_HWM,
-                             TFLITE_HWM]
+        fw_hw_model = mct.get_model(PYTORCH, DEFAULT_HWM)
+        model = mobilenet_v2(pretrained=True)
 
-        for hw_name in pytorch_hw_models:
-            fw_hw_model = mct.get_model(PYTORCH, hw_name)
-            model = mobilenet_v2(pretrained=True)
+        def rep_data():
+            return [np.random.randn(1, 3, 224, 224)]
 
-            def rep_data():
-                return [np.random.randn(1, 3, 224, 224)]
+        quantized_model, _ = mct.pytorch_post_training_quantization(model,
+                                                                    rep_data,
+                                                                    n_iter=1,
+                                                                    fw_hw_model=fw_hw_model)
 
-            quantized_model, _ = mct.pytorch_post_training_quantization(model,
-                                                                        rep_data,
-                                                                        n_iter=1,
-                                                                        fw_hw_model=fw_hw_model)
-
-            mp_qc = copy.deepcopy(DEFAULT_MIXEDPRECISION_CONFIG)
-            mp_qc.num_of_images = 1
-            quantized_model, _ = mct.pytorch_post_training_quantization_mixed_precision(model,
-                                                                                        rep_data,
-                                                                                        target_kpi=mct.KPI(np.inf),
-                                                                                        n_iter=1,
-                                                                                        fw_hw_model=fw_hw_model,
-                                                                                        quant_config=mp_qc)
+        mp_qc = copy.deepcopy(DEFAULT_MIXEDPRECISION_CONFIG)
+        mp_qc.num_of_images = 1
+        quantized_model, _ = mct.pytorch_post_training_quantization_mixed_precision(model,
+                                                                                    rep_data,
+                                                                                    target_kpi=mct.KPI(np.inf),
+                                                                                    n_iter=1,
+                                                                                    fw_hw_model=fw_hw_model,
+                                                                                    quant_config=mp_qc)
 
     def test_get_pytorch_not_supported_model(self):
         with self.assertRaises(Exception) as e:


### PR DESCRIPTION
Removed get_model tests from Keras and Pytorch
as they take too much time due to long Symmetric and Uniform
thresholds search.