### PR TITLE
Remove timeout in nightly TF testssuite

### DIFF
--- a/.github/workflows/run_tests_suite_tf25.yml
+++ b/.github/workflows/run_tests_suite_tf25.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/run_tests_suite_tf26.yml
+++ b/.github/workflows/run_tests_suite_tf26.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/run_tests_suite_tf27.yml
+++ b/.github/workflows/run_tests_suite_tf27.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     env:
       COVERAGE_THRESHOlD: 80
     steps:


### PR DESCRIPTION
In nightly tests for different Tensorflow versions
(2.5, 2.6, 2.7) there is a timeout. This is not needed
thus it's removed.