### PR TITLE
fix issue in model builder for mixed precision

### DIFF
--- a/model_compression_toolkit/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/set_node_quantization_config.py
@@ -17,12 +17,6 @@
 import copy
 from typing import List, Dict
 
-import tensorflow as tf
-if tf.__version__ < "2.6":
-    from tensorflow.python.keras.layers.core import TFOpLambda, SlicingOpLambda
-else:
-    from keras.layers.core import TFOpLambda, SlicingOpLambda
-
 from model_compression_toolkit.common import Logger, BaseNode
 from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.graph.base_graph import Graph
@@ -82,8 +76,7 @@ def set_quantization_configs_to_node(node: BaseNode,
     node.candidates_quantization_cfg = _create_node_candidates_qc(quant_config,
                                                                   fw_info,
                                                                   weight_channel_axis,
-                                                                  node_qc_options,
-                                                                  node.layer_class)
+                                                                  node_qc_options)
 
     for candidate_qc in node.candidates_quantization_cfg:
         candidate_qc.weights_quantization_cfg.enable_weights_quantization = \
@@ -170,8 +163,7 @@ def create_node_qc_candidate(qc: QuantizationConfig,
 def _create_node_candidates_qc(qc: QuantizationConfig,
                                fw_info: FrameworkInfo,
                                weight_channel_axis: int,
-                               node_qc_options: QuantizationConfigOptions,
-                               layer_class: type = None) -> List[CandidateNodeQuantizationConfig]:
+                               node_qc_options: QuantizationConfigOptions) -> List[CandidateNodeQuantizationConfig]:
     """
     Create a list of candidates of weights and activation quantization configurations for a node.
 
@@ -187,11 +179,6 @@ def _create_node_candidates_qc(qc: QuantizationConfig,
 
     candidates = []
     if isinstance(qc, MixedPrecisionQuantizationConfig):
-        if layer_class in [TFOpLambda, SlicingOpLambda] and len(node_qc_options.quantization_config_list) > 1:
-            raise Exception(f"Activation mixed-precision is not supported for layers of type {layer_class}."
-                            f"Please modify the TargetPlatformModel object, "
-                            f"such that layers of type {layer_class} won't have more than one quantization"
-                            f"configuration option.")
         for op_cfg in node_qc_options.quantization_config_list:
             candidate_nbits_qc = copy.deepcopy(qc)
             candidates.append(create_node_qc_candidate(candidate_nbits_qc,

--- a/model_compression_toolkit/keras/back2framework/model_builder.py
+++ b/model_compression_toolkit/keras/back2framework/model_builder.py
@@ -297,12 +297,14 @@ def model_builder(graph: common.Graph,
     # in a QuantizeWrapper containing QuantizeConfig that holds a quantizer that
     # stores the quantized weights using all possible bitwidths.
     elif mode == ModelBuilderMode.MIXEDPRECISION:
+        conf_nodes_names = graph.get_configurable_sorted_nodes_names()
+
         def _quantize_multiple_nbits(layer):
             nodes = graph.find_node_by_name(get_node_name_from_layer(layer))
             if len(nodes) == 1:
                 node = nodes[0]
                 # Wrap only if its weights should be quantized
-                if node.is_weights_quantization_enabled() or node.is_activation_quantization_enabled():
+                if node.name in conf_nodes_names:
                     return QuantizeWrapper(layer, quantization_config_builder_mixed_precision(node, fw_info))
                 return layer
 

--- a/model_compression_toolkit/keras/back2framework/model_builder.py
+++ b/model_compression_toolkit/keras/back2framework/model_builder.py
@@ -22,12 +22,12 @@ from model_compression_toolkit.keras.quantizer.mixed_precision.input_layer_quant
 # As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
 if tf.__version__ < "2.6":
     from tensorflow.keras.layers import Input
-    from tensorflow.python.keras.layers.core import TFOpLambda
+    from tensorflow.python.keras.layers.core import TFOpLambda, SlicingOpLambda
     from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
     from tensorflow.python.keras.layers import Layer
 else:
     from keras import Input
-    from keras.layers.core import TFOpLambda
+    from keras.layers.core import TFOpLambda, SlicingOpLambda
     from keras.engine.base_layer import TensorFlowOpLayer, Layer
 
 from model_compression_toolkit.common.model_builder_mode import ModelBuilderMode
@@ -305,6 +305,11 @@ def model_builder(graph: common.Graph,
                 node = nodes[0]
                 # Wrap only if its weights should be quantized
                 if node.name in conf_nodes_names:
+                    if node.layer_class in [TFOpLambda, SlicingOpLambda]:
+                        Logger.critical(f"Activation mixed-precision is not supported for layers of type "
+                                        f"{node.layer_class}. Please modify the TargetPlatformModel object, "
+                                        f"such that layers of type {node.layer_class} "
+                                        f"won't have more than one quantization configuration option.")
                     return QuantizeWrapper(layer, quantization_config_builder_mixed_precision(node, fw_info))
                 return layer
 


### PR DESCRIPTION
* TFOpLambda layers are not supported in activation mixed precision
* Use QuantizeWrapper in model builder only on configurable nodes