### PR TITLE
Fix index choosing in MP for PyTorch

### DIFF
--- a/model_compression_toolkit/pytorch/mixed_precision/mixed_precision_wrapper.py
+++ b/model_compression_toolkit/pytorch/mixed_precision/mixed_precision_wrapper.py
@@ -62,7 +62,7 @@ class PytorchMixedPrecisionWrapper(torch.nn.Module):
             self.node_q_cfg[0].activation_quantization_cfg.enable_activation_quantization and \
             not n.is_all_activation_candidates_equal()
 
-        max_cfg_candidates = n.find_min_candidates_indices()
+        max_cfg_candidates = n.find_max_candidates_indices()
         assert len(max_cfg_candidates) == 1, \
             f"A maximal config candidate must be defined, but some node have multiple potential maximal candidates"
         max_candidate_idx = max_cfg_candidates[0]


### PR DESCRIPTION
In MP wrapper for PyTorch, we search for the maximal candidate index
for initialization of the PyTch MP model. The issue was taking the minimal
index instead of maximal index. This commit fixes this.