### PR TITLE
Api change

### DIFF
--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -19,6 +19,7 @@ from model_compression_toolkit.common.quantization import quantization_config
 from model_compression_toolkit.common.mixed_precision import mixed_precision_quantization_config
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig, \
     QuantizationErrorMethod, DEFAULTCONFIG
+from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common import target_platform
 from model_compression_toolkit.tpc_models.get_target_platform_capabilities import get_target_platform_capabilities
 from model_compression_toolkit.common.mixed_precision.kpi import KPI
@@ -31,11 +32,13 @@ from model_compression_toolkit.common import network_editors as network_editor
 
 from model_compression_toolkit.keras.quantization_facade import keras_post_training_quantization, \
     keras_post_training_quantization_mixed_precision
+from model_compression_toolkit.keras.quantization_facade import keras_post_training_quantization_experimental, \
+    keras_gradient_post_training_quantization_experimental
 from model_compression_toolkit.keras.quantization_facade import get_keras_gptq_config
 from model_compression_toolkit.pytorch.quantization_facade import pytorch_post_training_quantization, \
     pytorch_post_training_quantization_mixed_precision
 
-from model_compression_toolkit.keras.kpi_data_facade import keras_kpi_data
+from model_compression_toolkit.keras.kpi_data_facade import keras_kpi_data, keras_kpi_data_experimental
 from model_compression_toolkit.pytorch.kpi_data_facade import pytorch_kpi_data
 
 __version__ = "1.4.0"

--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -23,7 +23,7 @@ from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common import target_platform
 from model_compression_toolkit.tpc_models.get_target_platform_capabilities import get_target_platform_capabilities
 from model_compression_toolkit.common.mixed_precision.kpi import KPI
-from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig
+from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.common.logger import set_log_folder
 from model_compression_toolkit.common.data_loader import FolderImageLoader
 from model_compression_toolkit.common.framework_info import FrameworkInfo, ChannelAxis
@@ -37,8 +37,10 @@ from model_compression_toolkit.keras.quantization_facade import keras_post_train
 from model_compression_toolkit.keras.quantization_facade import get_keras_gptq_config
 from model_compression_toolkit.pytorch.quantization_facade import pytorch_post_training_quantization, \
     pytorch_post_training_quantization_mixed_precision
+from model_compression_toolkit.pytorch.quantization_facade import pytorch_post_training_quantization_experimental, \
+    pytorch_gradient_post_training_quantization_experimental
 
 from model_compression_toolkit.keras.kpi_data_facade import keras_kpi_data, keras_kpi_data_experimental
-from model_compression_toolkit.pytorch.kpi_data_facade import pytorch_kpi_data
+from model_compression_toolkit.pytorch.kpi_data_facade import pytorch_kpi_data, pytorch_kpi_data_experimental
 
 __version__ = "1.4.0"

--- a/model_compression_toolkit/common/framework_implementation.py
+++ b/model_compression_toolkit/common/framework_implementation.py
@@ -25,6 +25,7 @@ from model_compression_toolkit.common.graph.base_graph import Graph
 from model_compression_toolkit.common.model_builder_mode import ModelBuilderMode
 from model_compression_toolkit.common.node_prior_info import NodePriorInfo
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
+from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common.user_info import UserInformation
 
 
@@ -130,7 +131,7 @@ class FrameworkImplementation(ABC):
     @abstractmethod
     def shift_negative_correction(self,
                                   graph: Graph,
-                                  qc: QuantizationConfig,
+                                  core_config: CoreConfig,
                                   fw_info: FrameworkInfo) -> Graph:
         """
         Apply shift negative correction (SNC) on a graph.

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -17,15 +17,12 @@ import copy
 
 from typing import Any, List
 
-from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
 from model_compression_toolkit.common import Graph, BaseNode
 from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.logger import Logger
-from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
-    MixedPrecisionQuantizationConfig
 
 
-def set_bit_widths(quant_config: QuantizationConfig,
+def set_bit_widths(mixed_precision_enable,  # TODO: edit doc
                    graph_to_set_bit_widths: Graph,
                    fw_info: FrameworkInfo = None,
                    bit_widths_config: List[int] = None) -> Graph:
@@ -44,7 +41,7 @@ def set_bit_widths(quant_config: QuantizationConfig,
     """
     graph = copy.deepcopy(graph_to_set_bit_widths)
 
-    if isinstance(quant_config, MixedPrecisionQuantizationConfig):
+    if mixed_precision_enable:
         assert all([len(n.candidates_quantization_cfg) > 0 for n in graph.get_configurable_sorted_nodes()]), \
             "All configurable nodes in graph should have at least one candidate configuration in mixed precision mode"
 

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -22,7 +22,7 @@ from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.logger import Logger
 
 
-def set_bit_widths(mixed_precision_enable,
+def set_bit_widths(mixed_precision_enable: bool,
                    graph_to_set_bit_widths: Graph,
                    fw_info: FrameworkInfo = None,
                    bit_widths_config: List[int] = None) -> Graph:
@@ -31,7 +31,7 @@ def set_bit_widths(mixed_precision_enable,
     in bit_widths_config to finalize the node weights and activation quantization configuration.
 
     Args:
-        mixed_precision_enable: is mixed precision enabled.
+        mixed_precision_enable: Is mixed precision enabled.
         graph_to_set_bit_widths: A prepared for quantization graph to set its bit widths.
         fw_info: Information needed for quantization about the specific framework (e.g., kernel
         channels indices, groups of layers by how they should be quantized, etc.)

--- a/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
+++ b/model_compression_toolkit/common/mixed_precision/bit_width_setter.py
@@ -22,7 +22,7 @@ from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.logger import Logger
 
 
-def set_bit_widths(mixed_precision_enable,  # TODO: edit doc
+def set_bit_widths(mixed_precision_enable,
                    graph_to_set_bit_widths: Graph,
                    fw_info: FrameworkInfo = None,
                    bit_widths_config: List[int] = None) -> Graph:
@@ -31,7 +31,7 @@ def set_bit_widths(mixed_precision_enable,  # TODO: edit doc
     in bit_widths_config to finalize the node weights and activation quantization configuration.
 
     Args:
-        quant_config: MixedPrecisionQuantizationConfig the graph was computed according to.
+        mixed_precision_enable: is mixed precision enabled.
         graph_to_set_bit_widths: A prepared for quantization graph to set its bit widths.
         fw_info: Information needed for quantization about the specific framework (e.g., kernel
         channels indices, groups of layers by how they should be quantized, etc.)

--- a/model_compression_toolkit/common/mixed_precision/kpi.py
+++ b/model_compression_toolkit/common/mixed_precision/kpi.py
@@ -35,7 +35,7 @@ class KPITarget(Enum):
     ACTIVATION = 'activation'
 
 
-class KPI(object):
+class KPI:
     """
     Class to represent measurements of performance.
     """

--- a/model_compression_toolkit/common/mixed_precision/kpi_data.py
+++ b/model_compression_toolkit/common/mixed_precision/kpi_data.py
@@ -15,7 +15,7 @@
 from typing import Callable, Any
 import numpy as np
 
-from model_compression_toolkit import FrameworkInfo, KPI, MixedPrecisionQuantizationConfig, QuantizationConfig, CoreConfig
+from model_compression_toolkit import FrameworkInfo, KPI, MixedPrecisionQuantizationConfig, CoreConfig
 from model_compression_toolkit.common import Graph
 from model_compression_toolkit.common.framework_implementation import FrameworkImplementation
 from model_compression_toolkit.common.target_platform import TargetPlatformCapabilities
@@ -24,7 +24,7 @@ import model_compression_toolkit.common.post_training_quantization as ptq
 
 def compute_kpi_data(in_model: Any,
                      representative_data_gen: Callable,
-                     quant_config: MixedPrecisionQuantizationConfig,  # TODO: change to core_conffig
+                     quant_config: MixedPrecisionQuantizationConfig,
                      tpc: TargetPlatformCapabilities,
                      fw_info: FrameworkInfo,
                      fw_impl: FrameworkImplementation) -> KPI:
@@ -35,7 +35,7 @@ def compute_kpi_data(in_model: Any,
     Args:
         in_model:  Model to build graph from (the model that intended to be quantized).
         representative_data_gen: Dataset used for calibration.
-        quant_config: QuantizationConfig containing parameters of how the model should be quantized.
+        quant_config: MixedPrecisionQuantizationConfig containing parameters of how the model should be quantized.
         tpc: TargetPlatformCapabilities object that models the inference target platform and
                                               the attached framework operator's information.
         fw_info: Information needed for quantization about the specific framework.
@@ -71,7 +71,7 @@ def compute_kpi_data(in_model: Any,
 
 def compute_kpi_data_experimental(in_model: Any,
                                   representative_data_gen: Callable,
-                                  core_config: CoreConfig,  # TODO: change doc
+                                  core_config: CoreConfig,
                                   tpc: TargetPlatformCapabilities,
                                   fw_info: FrameworkInfo,
                                   fw_impl: FrameworkImplementation) -> KPI:
@@ -82,7 +82,7 @@ def compute_kpi_data_experimental(in_model: Any,
     Args:
         in_model:  Model to build graph from (the model that intended to be quantized).
         representative_data_gen: Dataset used for calibration.
-        quant_config: QuantizationConfig containing parameters of how the model should be quantized.
+        core_config: CoreConfig containing parameters of how the model should be quantized.
         tpc: TargetPlatformCapabilities object that models the inference target platform and
                                               the attached framework operator's information.
         fw_info: Information needed for quantization about the specific framework.

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -49,6 +49,27 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
         self.num_of_images = num_of_images
         self.configuration_overwrite = configuration_overwrite
 
+    def separate_configs(self):
+        _dummy_quant_config = QuantizationConfig()
+        _dummy_mp_config_experimental = MixedPrecisionQuantizationConfigV2()
+        qc_dict = {}
+        mp_dict = {}
+        for k, v in self.__dict__.items():
+            if hasattr(_dummy_quant_config, k):
+                qc_dict.update({k: v})
+            elif hasattr(_dummy_mp_config_experimental, k):
+                mp_dict.update({k: v})
+            else:
+                raise Exception(f'Attribute "{k}" mismatch: exists in MixedPrecisionQuantizationConfig but not in MixedPrecisionQuantizationConfigV2')
+
+        return QuantizationConfig(**qc_dict), MixedPrecisionQuantizationConfigV2(**mp_dict)
+
+
+# Default quantization configuration the library use.
+DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
+                                                                 compute_mse,
+                                                                 get_average_weights)
+
 
 class MixedPrecisionQuantizationConfigV2:
 
@@ -74,9 +95,3 @@ class MixedPrecisionQuantizationConfigV2:
         self.distance_weighting_method = distance_weighting_method
         self.num_of_images = num_of_images
         self.configuration_overwrite = configuration_overwrite
-
-
-# Default quantization configuration the library use.
-DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
-                                                                 compute_mse,
-                                                                 get_average_weights)

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -77,5 +77,6 @@ class MixedPrecisionQuantizationConfigV2:
 
 
 # Default quantization configuration the library use.
-DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(compute_mse,
+DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
+                                                                 compute_mse,
                                                                  get_average_weights)

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -21,6 +21,32 @@ from model_compression_toolkit.common.quantization.quantization_config import Qu
 from model_compression_toolkit.common.similarity_analyzer import compute_mse
 
 
+class MixedPrecisionQuantizationConfigV2:
+
+    def __init__(self,
+                 compute_distance_fn: Callable = compute_mse,
+                 distance_weighting_method: Callable = get_average_weights,
+                 num_of_images: int = 32,
+                 configuration_overwrite: List[int] = None):
+        """
+        Class with mixed precision parameters to quantize the input model.
+        Unlike QuantizationConfig, number of bits for quantization is a list of possible bit widths to
+        support mixed-precision model quantization.
+
+        Args:
+            compute_distance_fn (Callable): Function to compute a distance between two tensors.
+            distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
+            num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
+            configuration_overwrite (List[int]): A list of integers that enables overwrite of mixed precision with a predefined one.
+
+        """
+
+        self.compute_distance_fn = compute_distance_fn
+        self.distance_weighting_method = distance_weighting_method
+        self.num_of_images = num_of_images
+        self.configuration_overwrite = configuration_overwrite
+
+
 class MixedPrecisionQuantizationConfig(QuantizationConfig):
 
     def __init__(self,
@@ -49,7 +75,14 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
         self.num_of_images = num_of_images
         self.configuration_overwrite = configuration_overwrite
 
-    def separate_configs(self):
+    def separate_configs(self) -> Tuple[QuantizationConfig, MixedPrecisionQuantizationConfigV2]:
+        """
+        A function to separate the old MixedPrecisionQuantizationConfig into QuantizationConfig
+        and MixedPrecisionQuantizationConfigV2
+
+        Returns: QuantizationConfig, MixedPrecisionQuantizationConfigV2
+
+        """
         _dummy_quant_config = QuantizationConfig()
         _dummy_mp_config_experimental = MixedPrecisionQuantizationConfigV2()
         qc_dict = {}
@@ -69,29 +102,3 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
 DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
                                                                  compute_mse,
                                                                  get_average_weights)
-
-
-class MixedPrecisionQuantizationConfigV2:
-
-    def __init__(self,
-                 compute_distance_fn: Callable = compute_mse,
-                 distance_weighting_method: Callable = get_average_weights,
-                 num_of_images: int = 32,
-                 configuration_overwrite: List[int] = None):
-        """
-        Class with mixed precision parameters to quantize the input model.
-        Unlike QuantizationConfig, number of bits for quantization is a list of possible bit widths to
-        support mixed-precision model quantization.
-
-        Args:
-            compute_distance_fn (Callable): Function to compute a distance between two tensors.
-            distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
-            num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
-            configuration_overwrite (List[int]): A list of integers that enables overwrite of mixed precision with a predefined one.
-
-        """
-
-        self.compute_distance_fn = compute_distance_fn
-        self.distance_weighting_method = distance_weighting_method
-        self.num_of_images = num_of_images
-        self.configuration_overwrite = configuration_overwrite

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_quantization_config.py
@@ -50,7 +50,32 @@ class MixedPrecisionQuantizationConfig(QuantizationConfig):
         self.configuration_overwrite = configuration_overwrite
 
 
+class MixedPrecisionQuantizationConfigV2:
+
+    def __init__(self,
+                 compute_distance_fn: Callable = compute_mse,
+                 distance_weighting_method: Callable = get_average_weights,
+                 num_of_images: int = 32,
+                 configuration_overwrite: List[int] = None):
+        """
+        Class with mixed precision parameters to quantize the input model.
+        Unlike QuantizationConfig, number of bits for quantization is a list of possible bit widths to
+        support mixed-precision model quantization.
+
+        Args:
+            compute_distance_fn (Callable): Function to compute a distance between two tensors.
+            distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
+            num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
+            configuration_overwrite (List[int]): A list of integers that enables overwrite of mixed precision with a predefined one.
+
+        """
+
+        self.compute_distance_fn = compute_distance_fn
+        self.distance_weighting_method = distance_weighting_method
+        self.num_of_images = num_of_images
+        self.configuration_overwrite = configuration_overwrite
+
+
 # Default quantization configuration the library use.
-DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(DEFAULTCONFIG,
-                                                                 compute_mse,
+DEFAULT_MIXEDPRECISION_CONFIG = MixedPrecisionQuantizationConfig(compute_mse,
                                                                  get_average_weights)

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_search_facade.py
@@ -23,7 +23,7 @@ from model_compression_toolkit.common.mixed_precision.kpi import KPI, KPITarget
 from model_compression_toolkit.common.mixed_precision.kpi_aggregation_methods import MpKpiAggregation
 from model_compression_toolkit.common.mixed_precision.kpi_methods import MpKpiMetric
 from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
-    MixedPrecisionQuantizationConfig
+    MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.common.mixed_precision.mixed_precision_search_manager import MixedPrecisionSearchManager
 from model_compression_toolkit.common.mixed_precision.search_methods.linear_programming import \
     mp_integer_programming_search
@@ -46,7 +46,7 @@ kpi_functions_factory = {KPITarget.WEIGHTS: (MpKpiMetric.WEIGHTS_SIZE, MpKpiAggr
 
 
 def search_bit_width(graph_to_search_cfg: Graph,
-                     qc: MixedPrecisionQuantizationConfig,
+                     qc: MixedPrecisionQuantizationConfigV2,
                      fw_info: FrameworkInfo,
                      target_kpi: KPI,
                      get_sensitivity_evaluation: Callable = None,
@@ -61,7 +61,7 @@ def search_bit_width(graph_to_search_cfg: Graph,
 
     Args:
         graph_to_search_cfg: Graph to search a MP configuration for.
-        qc: MixedPrecisionQuantizationConfig the graph was prepared according to.
+        qc: MixedPrecisionQuantizationConfigV2 the graph was prepared according to.
         fw_info: FrameworkInfo object about the specific framework (e.g., attributes of different layers' weights to quantize).
         target_kpi: Target KPI to bound our feasible solution space s.t the configuration does not violates it.
         get_sensitivity_evaluation: Function specific to the model's framework, which builds and returns

--- a/model_compression_toolkit/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/common/mixed_precision/mixed_precision_search_facade.py
@@ -46,7 +46,7 @@ kpi_functions_factory = {KPITarget.WEIGHTS: (MpKpiMetric.WEIGHTS_SIZE, MpKpiAggr
 
 
 def search_bit_width(graph_to_search_cfg: Graph,
-                     qc: MixedPrecisionQuantizationConfigV2,
+                     mp_config: MixedPrecisionQuantizationConfigV2,
                      fw_info: FrameworkInfo,
                      target_kpi: KPI,
                      get_sensitivity_evaluation: Callable = None,
@@ -54,30 +54,30 @@ def search_bit_width(graph_to_search_cfg: Graph,
     """
     Search for a MP configuration for a given graph. Given a search_method method (by default, it's linear
     programming), we use the get_sensitivity_evaluation function to get a function to compute an
-    evaluation for the expected sensitivity for a bitwidth configuration.
-    Then, and after computing the KPI for each node in the graph for each bitwidth in the search space,
+    evaluation for the expected sensitivity for a bit-width configuration.
+    Then, and after computing the KPI for each node in the graph for each bit-width in the search space,
     we search for the optimal solution, given some target_kpi, the solution should fit.
     target_kpi have to be passed. If it was not passed, the facade is not supposed to get here by now.
 
     Args:
         graph_to_search_cfg: Graph to search a MP configuration for.
-        qc: MixedPrecisionQuantizationConfigV2 the graph was prepared according to.
+        mp_config: MixedPrecisionQuantizationConfigV2 the graph was prepared according to.
         fw_info: FrameworkInfo object about the specific framework (e.g., attributes of different layers' weights to quantize).
-        target_kpi: Target KPI to bound our feasible solution space s.t the configuration does not violates it.
+        target_kpi: Target KPI to bound our feasible solution space s.t the configuration does not violate it.
         get_sensitivity_evaluation: Function specific to the model's framework, which builds and returns
-        a function that evaluates the sensitivity of a bitwidth configuration for the MP model.
+        a function that evaluates the sensitivity of a bit-width configuration for the MP model.
         search_method: BitWidthSearchMethod to define which searching method to use.
 
     Returns:
         A MP configuration for the graph (list of integers, where the index in the list, is the node's
         index in the graph, when the graph is topology sorted, and the value in this index is the
-        bitwidth index on the node).
+        bit-width index on the node).
 
     """
 
     # target_kpi have to be passed. If it was not passed, the facade is not supposed to get here by now.
     if target_kpi is None:
-        Logger.critical('Target KPI have to be passed for search_methods bitwidth configuration')
+        Logger.critical('Target KPI have to be passed for search_methods bit-width configuration')
 
     graph = copy.deepcopy(graph_to_search_cfg)  # Copy graph before searching
 
@@ -87,7 +87,7 @@ def search_bit_width(graph_to_search_cfg: Graph,
 
     # Instantiate a manager object
     search_manager = MixedPrecisionSearchManager(graph,
-                                                 qc,
+                                                 mp_config,
                                                  fw_info,
                                                  get_sensitivity_evaluation,
                                                  kpi_functions)

--- a/model_compression_toolkit/common/network_editors/edit_network.py
+++ b/model_compression_toolkit/common/network_editors/edit_network.py
@@ -17,7 +17,8 @@ from typing import List
 
 from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.graph.base_graph import Graph
-from model_compression_toolkit.common.network_editors.actions import EditRule
+from model_compression_toolkit.common.network_editors import EditRule
+
 
 
 def edit_network_graph(graph: Graph,

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -44,6 +44,7 @@ from model_compression_toolkit.common.bias_correction.compute_bias_correction_of
 from model_compression_toolkit.common.quantization.quantization_analyzer import analyzer_graph
 from model_compression_toolkit.common.quantization.quantization_config import DEFAULTCONFIG
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
+from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common.quantization.quantization_params_generation.qparams_computation import \
     calculate_quantization_params
 
@@ -63,14 +64,14 @@ from model_compression_toolkit.common.target_platform.targetplatform2framework i
 def post_training_quantization(in_model: Any,
                                representative_data_gen: Callable,
                                n_iter: int,
-                               quant_config: QuantizationConfig,
+                               core_config: CoreConfig,
                                fw_info: FrameworkInfo,
                                fw_impl: FrameworkImplementation,
                                tpc: TargetPlatformCapabilities,
                                network_editor: List[EditRule] = [],
                                gptq_config: GradientPTQConfig = None,
                                analyze_similarity: bool = False,
-                               target_kpi: KPI = None, ):
+                               target_kpi: KPI = None):
     """
     Quantize a trained model using post-training quantization.
     First, the model graph is optimized using several transformations (e.g. folding BatchNormalization to preceding
@@ -120,7 +121,7 @@ def post_training_quantization(in_model: Any,
                                          representative_data_gen,
                                          network_editor,
                                          n_iter,
-                                         quant_config,
+                                         core_config,
                                          fw_info,
                                          tb_w,
                                          fw_impl)
@@ -128,11 +129,12 @@ def post_training_quantization(in_model: Any,
     ######################################
     # Finalize bit widths
     ######################################
+    # TODO: handle as core_config
     if target_kpi is not None:
-        assert isinstance(quant_config, MixedPrecisionQuantizationConfig)
-        if quant_config.configuration_overwrite is None:
+        assert core_config.mixed_precision_enable
+        if core_config.mixed_precision_config.configuration_overwrite is None:
             bit_widths_config = search_bit_width(tg,
-                                                 quant_config,
+                                                 core_config.mixed_precision_config,
                                                  fw_info,
                                                  target_kpi,
                                                  partial(fw_impl.get_sensitivity_evaluation_fn,
@@ -140,13 +142,13 @@ def post_training_quantization(in_model: Any,
                                                          fw_info=fw_info))
         else:
             Logger.warning(
-                f'Mixed Precision has overwrite bitwidth configuration{quant_config.configuration_overwrite}')
-            bit_widths_config = quant_config.configuration_overwrite
+                f'Mixed Precision has overwrite bitwidth configuration{core_config.mixed_precision_config.configuration_overwrite}')
+            bit_widths_config = core_config.mixed_precision_config.configuration_overwrite
 
     else:
         bit_widths_config = None
 
-    tg = set_bit_widths(quant_config,
+    tg = set_bit_widths(core_config.mixed_precision_enable,
                         tg,
                         fw_info,
                         bit_widths_config)
@@ -167,13 +169,14 @@ def post_training_quantization(in_model: Any,
 
 
 def get_finalized_graph(initial_graph: Graph,
-                        quant_config: QuantizationConfig = DEFAULTCONFIG,
+                        quant_config: QuantizationConfig = DEFAULTCONFIG,  # TODO: change doc
                         fw_info: FrameworkInfo = None,
                         tb_w: TensorboardWriter = None,
-                        fw_impl: FrameworkImplementation = None) -> Graph:
+                        fw_impl: FrameworkImplementation = None,
+                        mixed_precision_enable: bool = False) -> Graph:
     """
     Applies all edit operation (edit, substitutions, etc.) on the model's graph, to prepare it for the quantization
-    process. All future graph substitutions and operations that change the graph shold be added to this method.
+    process. All future graph substitutions and operations that change the graph should be added to this method.
 
     Args:
         initial_graph (Graph): Graph to apply the changes to.
@@ -215,7 +218,8 @@ def get_finalized_graph(initial_graph: Graph,
     # Add quantization configurations
     ######################################
     transformed_graph = set_quantization_configuration_to_graph(graph=transformed_graph,
-                                                                quant_config=quant_config)
+                                                                quant_config=quant_config,
+                                                                mixed_precision_enable=mixed_precision_enable)
 
     ######################################
     # Graph marking points
@@ -419,7 +423,6 @@ def _quantize_fixed_bit_widths_graph(analyze_similarity: bool,
     return quantized_model, user_info
 
 
-
 def read_model_to_graph(in_model: Any,
                         representative_data_gen: Callable,
                         tpc: TargetPlatformCapabilities,
@@ -450,7 +453,7 @@ def _prepare_model_for_quantization(graph: Graph,
                                     representative_data_gen: Callable,
                                     network_editor: List[EditRule] = [],
                                     n_iter: int = 500,
-                                    quant_config: QuantizationConfig = DEFAULTCONFIG,
+                                    core_config: CoreConfig = DEFAULTCONFIG,  # TODO: change to core_config
                                     fw_info: FrameworkInfo = None,
                                     tb_w: TensorboardWriter = None,
                                     fw_impl: FrameworkImplementation = None) -> Graph:
@@ -481,10 +484,11 @@ def _prepare_model_for_quantization(graph: Graph,
         tb_w.add_graph(graph, 'initial_graph')
 
     transformed_graph = get_finalized_graph(graph,
-                                            quant_config,
+                                            core_config.quantization_config,
                                             fw_info,
                                             tb_w,
-                                            fw_impl)
+                                            fw_impl,
+                                            mixed_precision_enable=core_config.mixed_precision_enable)
 
     ######################################
     # Graph analyzing (attaching statistics collectors)
@@ -492,7 +496,7 @@ def _prepare_model_for_quantization(graph: Graph,
     analyzer_graph(fw_impl.attach_sc_to_node,
                    transformed_graph,
                    fw_info,
-                   quant_config)  # Mark points for statistics collection
+                   core_config.quantization_config)  # Mark points for statistics collection
 
     if tb_w is not None:
         tb_w.add_graph(transformed_graph, 'after_analyzer_graph')
@@ -527,14 +531,14 @@ def _prepare_model_for_quantization(graph: Graph,
     # Graph substitution (post statistics collection)
     ######################################
     transformed_graph = substitute(transformed_graph,
-                                   fw_impl.get_substitutions_post_statistics_collection(quant_config))
+                                   fw_impl.get_substitutions_post_statistics_collection(core_config.quantization_config))
 
     ######################################
     # Shift Negative Activations
     ######################################
-    if quant_config.shift_negative_activation_correction:
+    if core_config.quantization_config.shift_negative_activation_correction:
         transformed_graph = fw_impl.shift_negative_correction(transformed_graph,
-                                                              quant_config,
+                                                              core_config,
                                                               fw_info)
         if tb_w is not None:
             tb_w.add_graph(transformed_graph, 'after_shift_negative_correction')

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -34,8 +34,6 @@ from model_compression_toolkit.common.mixed_precision.mixed_precision_search_fac
 from model_compression_toolkit.common.model_builder_mode import ModelBuilderMode
 from model_compression_toolkit.common.network_editors.actions import EditRule
 from model_compression_toolkit.common.network_editors.edit_network import edit_network_graph
-from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
-    MixedPrecisionQuantizationConfig
 from model_compression_toolkit.common.quantization.filter_nodes_candidates import filter_nodes_candidates
 from model_compression_toolkit.common.quantization.quantize_graph_weights import quantize_graph_weights
 from model_compression_toolkit.common.bias_correction.compute_bias_correction_of_graph import \
@@ -88,7 +86,7 @@ def post_training_quantization(in_model: Any,
         in_model: Model to quantize.
         representative_data_gen: Dataset used for calibration.
         n_iter: Number of calibration iterations to run.
-        quant_config: QuantizationConfig containing parameters of how the model should be quantized. `Default
+        core_config: CoreConfig containing parameters of how the model should be quantized. `Default
         configuration. <https://github.com/sony/model_optimization/blob/21e21c95ca25a31874a5be7af9dd2dd5da8f3a10
         /model_compression_toolkit/common/quantization/quantization_config.py#L163>`_
         fw_info: Information needed for quantization about the specific framework (e.g., kernel channels indices,
@@ -129,7 +127,6 @@ def post_training_quantization(in_model: Any,
     ######################################
     # Finalize bit widths
     ######################################
-    # TODO: handle as core_config
     if target_kpi is not None:
         assert core_config.mixed_precision_enable
         if core_config.mixed_precision_config.configuration_overwrite is None:
@@ -142,7 +139,7 @@ def post_training_quantization(in_model: Any,
                                                          fw_info=fw_info))
         else:
             Logger.warning(
-                f'Mixed Precision has overwrite bitwidth configuration{core_config.mixed_precision_config.configuration_overwrite}')
+                f'Mixed Precision has overwrite bit-width configuration{core_config.mixed_precision_config.configuration_overwrite}')
             bit_widths_config = core_config.mixed_precision_config.configuration_overwrite
 
     else:
@@ -169,7 +166,7 @@ def post_training_quantization(in_model: Any,
 
 
 def get_finalized_graph(initial_graph: Graph,
-                        quant_config: QuantizationConfig = DEFAULTCONFIG,  # TODO: change doc
+                        quant_config: QuantizationConfig = DEFAULTCONFIG,
                         fw_info: FrameworkInfo = None,
                         tb_w: TensorboardWriter = None,
                         fw_impl: FrameworkImplementation = None,
@@ -186,6 +183,7 @@ def get_finalized_graph(initial_graph: Graph,
         kernel channels indices, groups of layers by how they should be quantized, etc.)
         tb_w (TensorboardWriter): TensorboardWriter object to use for logging events such as graphs, histograms, etc.
         fw_impl (FrameworkImplementation): FrameworkImplementation object with a specific framework methods implementation.
+        mixed_precision_enable: is mixed precision enabled.
 
     Returns: Graph object that represents the model, after applying all required modifications to it.
 
@@ -453,7 +451,7 @@ def _prepare_model_for_quantization(graph: Graph,
                                     representative_data_gen: Callable,
                                     network_editor: List[EditRule] = [],
                                     n_iter: int = 500,
-                                    core_config: CoreConfig = DEFAULTCONFIG,  # TODO: change to core_config
+                                    core_config: CoreConfig = CoreConfig(),
                                     fw_info: FrameworkInfo = None,
                                     tb_w: TensorboardWriter = None,
                                     fw_impl: FrameworkImplementation = None) -> Graph:
@@ -470,7 +468,7 @@ def _prepare_model_for_quantization(graph: Graph,
         network_editor (List[EditRule]): List of EditRules. Each EditRule consists of a node filter and an action to
         change quantization settings of the filtered nodes.
         n_iter (int): Number of calibration iterations to run.
-        quant_config (QuantizationConfig): QuantizationConfig containing parameters of how the model should be
+        core_config (CoreConfig): CoreConfig containing parameters of how the model should be
         quantized.
         fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
         kernel channels indices, groups of layers by how they should be quantized, etc.)

--- a/model_compression_toolkit/common/quantization/core_config.py
+++ b/model_compression_toolkit/common/quantization/core_config.py
@@ -6,7 +6,7 @@ from model_compression_toolkit.common.mixed_precision.mixed_precision_quantizati
 
 class CoreConfig:
     """
-    A class to hold the configurations classes of the MCT-core
+    A class to hold the configurations classes of the MCT-core.
     """
     def __init__(self, n_iter: int = 500,
                  quantization_config: QuantizationConfig = QuantizationConfig(),
@@ -16,10 +16,11 @@ class CoreConfig:
         """
 
         Args:
-            n_iter (int): Number of calibration iterations to run
-            quantization_config: config for quantization
-            mixed_precision_config: config for mixed precision quantization (optional)
-            debug_config: config for debugging and editing the network quantization process
+            n_iter (int): Number of calibration iterations to run.
+            quantization_config (QuantizationConfig): Config for quantization.
+            mixed_precision_config (MixedPrecisionQuantizationConfigV2): Config for mixed precision quantization (optional,
+            default=None).
+            debug_config (DebugConfig): Config for debugging and editing the network quantization process.
         """
         self.n_iter = n_iter
         self.quantization_config = quantization_config

--- a/model_compression_toolkit/common/quantization/core_config.py
+++ b/model_compression_toolkit/common/quantization/core_config.py
@@ -1,26 +1,30 @@
 
-from typing import List
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
+from model_compression_toolkit.common.quantization.debug_config import DebugConfig
 from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfigV2
-from model_compression_toolkit.common.network_editors.edit_network import EditRule
 
 
 class CoreConfig:
+    """
+    A class to hold the configurations classes of the MCT-core
+    """
     def __init__(self, n_iter: int = 500,
                  quantization_config: QuantizationConfig = QuantizationConfig(),
                  mixed_precision_config: MixedPrecisionQuantizationConfigV2 = None,
-                 network_editor: List[EditRule] = []):
+                 debug_config: DebugConfig = DebugConfig()
+                 ):
         """
 
         Args:
             n_iter (int): Number of calibration iterations to run
-            quantization_config: quantization config
-            mixed_precision_config: mixed precision config (optional)
+            quantization_config: config for quantization
+            mixed_precision_config: config for mixed precision quantization (optional)
+            debug_config: config for debugging and editing the network quantization process
         """
         self.n_iter = n_iter
         self.quantization_config = quantization_config
         self.mixed_precision_config = mixed_precision_config
-        self.network_editor = network_editor
+        self.debug_config = debug_config
 
     @property
     def mixed_precision_enable(self):

--- a/model_compression_toolkit/common/quantization/core_config.py
+++ b/model_compression_toolkit/common/quantization/core_config.py
@@ -1,0 +1,28 @@
+
+from typing import List
+from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
+from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfigV2
+from model_compression_toolkit.common.network_editors.edit_network import EditRule
+
+
+class CoreConfig:
+    def __init__(self, n_iter: int = 500,
+                 quantization_config: QuantizationConfig = QuantizationConfig(),
+                 mixed_precision_config: MixedPrecisionQuantizationConfigV2 = None,
+                 network_editor: List[EditRule] = []):
+        """
+
+        Args:
+
+            kpi: Model maximal memory size (in bytes) for mixed precision optimization for weights & activations quantization
+            quantization_config: quantization config
+            mixed_precision_config: mixed precision config (optional)
+        """
+        self.n_iter = n_iter
+        self.quantization_config = quantization_config
+        self.mixed_precision_config = mixed_precision_config
+        self.network_editor = network_editor
+
+    @property
+    def mixed_precision_enable(self):
+        return self.mixed_precision_config is not None

--- a/model_compression_toolkit/common/quantization/core_config.py
+++ b/model_compression_toolkit/common/quantization/core_config.py
@@ -13,8 +13,7 @@ class CoreConfig:
         """
 
         Args:
-
-            kpi: Model maximal memory size (in bytes) for mixed precision optimization for weights & activations quantization
+            n_iter (int): Number of calibration iterations to run
             quantization_config: quantization config
             mixed_precision_config: mixed precision config (optional)
         """

--- a/model_compression_toolkit/common/quantization/debug_config.py
+++ b/model_compression_toolkit/common/quantization/debug_config.py
@@ -6,7 +6,7 @@ from model_compression_toolkit.common.network_editors.edit_network import EditRu
 
 class DebugConfig:
     """
-    A class for MCT core debug information
+    A class for MCT core debug information.
     """
     def __init__(self, analyze_similarity: bool = False,
                  network_editor: List[EditRule] = []):
@@ -14,9 +14,9 @@ class DebugConfig:
 
         Args:
 
-            analyze_similarity: Whether to plot similarity figures within TensorBoard (when logger is
-             enabled) or not. Can be used to pinpoint problematic layers in the quantization process
-            network_editor: A list of rules and actions to edit the network for quantization
+            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is
+             enabled) or not. Can be used to pinpoint problematic layers in the quantization process.
+            network_editor (List[EditRule]): A list of rules and actions to edit the network for quantization.
         """
         self.analyze_similarity = analyze_similarity
         self.network_editor = network_editor

--- a/model_compression_toolkit/common/quantization/debug_config.py
+++ b/model_compression_toolkit/common/quantization/debug_config.py
@@ -1,0 +1,22 @@
+
+from typing import List
+
+from model_compression_toolkit.common.network_editors.edit_network import EditRule
+
+
+class DebugConfig:
+    """
+    A class for MCT core debug information
+    """
+    def __init__(self, analyze_similarity: bool = False,
+                 network_editor: List[EditRule] = []):
+        """
+
+        Args:
+
+            analyze_similarity: Whether to plot similarity figures within TensorBoard (when logger is
+             enabled) or not. Can be used to pinpoint problematic layers in the quantization process
+            network_editor: A list of rules and actions to edit the network for quantization
+        """
+        self.analyze_similarity = analyze_similarity
+        self.network_editor = network_editor

--- a/model_compression_toolkit/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/common/quantization/quantization_config.py
@@ -43,8 +43,7 @@ class QuantizationErrorMethod(Enum):
     LP = 5
 
 
-
-class QuantizationConfig(object):
+class QuantizationConfig:
 
     def __init__(self,
                  activation_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
@@ -122,4 +121,3 @@ DEFAULTCONFIG = QuantizationConfig(QuantizationErrorMethod.MSE,
                                    weights_per_channel_threshold=True,
                                    input_scaling=False,
                                    softmax_shift=False)
-

--- a/model_compression_toolkit/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/set_node_quantization_config.py
@@ -34,7 +34,8 @@ from model_compression_toolkit.common.target_platform.op_quantization_config imp
 
 
 def set_quantization_configuration_to_graph(graph: Graph,
-                                            quant_config: QuantizationConfig) -> Graph:
+                                            quant_config: QuantizationConfig,
+                                            mixed_precision_enable: bool = False) -> Graph:  # TODO: edit doc
     """
     Add quantization configuration for each graph node.
 
@@ -51,14 +52,16 @@ def set_quantization_configuration_to_graph(graph: Graph,
         set_quantization_configs_to_node(node=n,
                                          quant_config=quant_config,
                                          fw_info=graph.fw_info,
-                                         tpc=graph.tpc)
+                                         tpc=graph.tpc,
+                                         mixed_precision_enable=mixed_precision_enable)
     return graph_with_qcs
 
 
 def set_quantization_configs_to_node(node: BaseNode,
                                      quant_config: QuantizationConfig,
                                      fw_info: FrameworkInfo,
-                                     tpc: TargetPlatformCapabilities):
+                                     tpc: TargetPlatformCapabilities,
+                                     mixed_precision_enable: bool = False):  # TODO: edit doc
     """
     Create and set quantization configurations to a node (for both weights and activation).
 
@@ -76,7 +79,8 @@ def set_quantization_configs_to_node(node: BaseNode,
     node.candidates_quantization_cfg = _create_node_candidates_qc(quant_config,
                                                                   fw_info,
                                                                   weight_channel_axis,
-                                                                  node_qc_options)
+                                                                  node_qc_options,
+                                                                  mixed_precision_enable=mixed_precision_enable)
 
     for candidate_qc in node.candidates_quantization_cfg:
         candidate_qc.weights_quantization_cfg.enable_weights_quantization = \
@@ -163,7 +167,8 @@ def create_node_qc_candidate(qc: QuantizationConfig,
 def _create_node_candidates_qc(qc: QuantizationConfig,
                                fw_info: FrameworkInfo,
                                weight_channel_axis: int,
-                               node_qc_options: QuantizationConfigOptions) -> List[CandidateNodeQuantizationConfig]:
+                               node_qc_options: QuantizationConfigOptions,
+                               mixed_precision_enable: bool = False) -> List[CandidateNodeQuantizationConfig]:  # TODO: edit doc
     """
     Create a list of candidates of weights and activation quantization configurations for a node.
 
@@ -178,7 +183,7 @@ def _create_node_candidates_qc(qc: QuantizationConfig,
     """
 
     candidates = []
-    if isinstance(qc, MixedPrecisionQuantizationConfig):
+    if mixed_precision_enable:
         for op_cfg in node_qc_options.quantization_config_list:
             candidate_nbits_qc = copy.deepcopy(qc)
             candidates.append(create_node_qc_candidate(candidate_nbits_qc,

--- a/model_compression_toolkit/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/common/quantization/set_node_quantization_config.py
@@ -35,13 +35,14 @@ from model_compression_toolkit.common.target_platform.op_quantization_config imp
 
 def set_quantization_configuration_to_graph(graph: Graph,
                                             quant_config: QuantizationConfig,
-                                            mixed_precision_enable: bool = False) -> Graph:  # TODO: edit doc
+                                            mixed_precision_enable: bool = False) -> Graph:
     """
     Add quantization configuration for each graph node.
 
     Args:
         graph: Graph for which to add quantization info to each node.
         quant_config: Quantization configuration containing parameters for how the graph should be quantized.
+        mixed_precision_enable: is mixed precision enabled
 
     Returns:
         The graph with quantization configurations attached to each node in it.
@@ -61,7 +62,7 @@ def set_quantization_configs_to_node(node: BaseNode,
                                      quant_config: QuantizationConfig,
                                      fw_info: FrameworkInfo,
                                      tpc: TargetPlatformCapabilities,
-                                     mixed_precision_enable: bool = False):  # TODO: edit doc
+                                     mixed_precision_enable: bool = False):
     """
     Create and set quantization configurations to a node (for both weights and activation).
 
@@ -70,7 +71,7 @@ def set_quantization_configs_to_node(node: BaseNode,
         quant_config: Quantization configuration to generate the node's configurations from.
         fw_info: Information needed for quantization about the specific framework.
         tpc: TargetPlatformCapabilities to get default OpQuantizationConfig.
-
+        mixed_precision_enable: is mixed precision enabled
     """
     node_qc_options = tpc.get_qco_by_node(node)
 
@@ -168,7 +169,7 @@ def _create_node_candidates_qc(qc: QuantizationConfig,
                                fw_info: FrameworkInfo,
                                weight_channel_axis: int,
                                node_qc_options: QuantizationConfigOptions,
-                               mixed_precision_enable: bool = False) -> List[CandidateNodeQuantizationConfig]:  # TODO: edit doc
+                               mixed_precision_enable: bool = False) -> List[CandidateNodeQuantizationConfig]:
     """
     Create a list of candidates of weights and activation quantization configurations for a node.
 
@@ -177,6 +178,7 @@ def _create_node_candidates_qc(qc: QuantizationConfig,
         fw_info: Framework information (e.g., which layers should have their kernels' quantized).
         weight_channel_axis: Output channel index of the node's kernel.
         node_qc_options: QuantizationConfigOptions for the node with quantization candidates information.
+        mixed_precision_enable: is mixed precision enabled
 
     Returns:
         List of candidates of weights quantization configurations to set for a node.

--- a/model_compression_toolkit/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/common/substitutions/shift_negative_activation.py
@@ -22,7 +22,7 @@ from model_compression_toolkit.common.graph.graph_matchers import NodeOperationM
 from model_compression_toolkit.common.target_platform import QuantizationMethod
 from model_compression_toolkit.common.quantization.set_node_quantization_config import create_node_activation_qc, \
     set_quantization_configs_to_node
-from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
+from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common.quantization.quantization_params_generation.qparams_activations_computation \
     import get_activations_qparams
 from model_compression_toolkit.keras.constants import PADDING
@@ -176,7 +176,7 @@ def remove_node_between_two_nodes(graph: Graph,
 
 
 def shift_negative_function(graph: Graph,
-                            qc: QuantizationConfig,
+                            core_config: CoreConfig,
                             non_linear_node: BaseNode,
                             op2d_node: BaseNode,
                             fw_info: FrameworkInfo,
@@ -291,8 +291,9 @@ def shift_negative_function(graph: Graph,
         # Set quantization configuration to node, even though we do not quantize it:
         set_quantization_configs_to_node(fw_info=fw_info,
                                          node=pad_node,
-                                         quant_config=qc,
-                                         tpc=graph.tpc)
+                                         quant_config=core_config.quantization_config,
+                                         tpc=graph.tpc,
+                                         mixed_precision_enable=core_config.mixed_precision_enable)
 
         for candidate_qc in pad_node.candidates_quantization_cfg:
             candidate_qc.weights_quantization_cfg.enable_weights_quantization = False
@@ -310,8 +311,9 @@ def shift_negative_function(graph: Graph,
 
     set_quantization_configs_to_node(fw_info=fw_info,
                                      node=add_node,
-                                     quant_config=qc,
-                                     tpc=graph.tpc)
+                                     quant_config=core_config.quantization_config,
+                                     tpc=graph.tpc,
+                                     mixed_precision_enable=core_config.mixed_precision_enable)
 
     original_non_linear_activation_nbits = non_linear_node_cfg_candidate.activation_n_bits
     # The non-linear node's output should be float, so we approximate it by using 16bits quantization.
@@ -330,7 +332,7 @@ def shift_negative_function(graph: Graph,
     for op_qc_idx, candidate_qc in enumerate(add_node.candidates_quantization_cfg):
         candidate_qc.weights_quantization_cfg.enable_weights_quantization = False
 
-        candidate_qc.activation_quantization_cfg = create_node_activation_qc(qc,
+        candidate_qc.activation_quantization_cfg = create_node_activation_qc(core_config.quantization_config,
                                                                              fw_info,
                                                                              add_node_qco[op_qc_idx])
 
@@ -424,7 +426,7 @@ def get_next_nodes_to_correct(n: BaseNode,
 
 
 def apply_shift_negative_correction(graph: Graph,
-                                    quant_config: QuantizationConfig,
+                                    core_config: CoreConfig,
                                     fw_info: FrameworkInfo,
                                     snc_node_types: NodeOperationMatcher,
                                     linear_node_types: NodeOperationMatcher,
@@ -480,7 +482,7 @@ def apply_shift_negative_correction(graph: Graph,
                                                                             )
             if linear_node is not None and n.is_activation_quantization_enabled():
                 graph = shift_negative_function(graph,
-                                                quant_config,
+                                                core_config,
                                                 n,
                                                 linear_node,
                                                 fw_info,

--- a/model_compression_toolkit/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/common/substitutions/shift_negative_activation.py
@@ -25,7 +25,7 @@ from model_compression_toolkit.common.quantization.set_node_quantization_config 
 from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common.quantization.quantization_params_generation.qparams_activations_computation \
     import get_activations_qparams
-from model_compression_toolkit.keras.constants import PADDING
+
 
 """
 This substitution aims to solve an issue of activation with negative outputs where
@@ -200,7 +200,7 @@ def shift_negative_function(graph: Graph,
 
     Args:
         graph: Graph to apply the shifting and correction.
-        qc: Quantization configuration to build the substitutions list according to.
+        core_config: Quantization configuration to build the substitutions list according to.
         non_linear_node: Non-linear node with negative values to shift.
         op2d_node: Linear node to correct its bias to overcome the expected error due to
         the shifting.
@@ -445,7 +445,7 @@ def apply_shift_negative_correction(graph: Graph,
 
     Args:
         graph: Graph to apply the substitution on.
-        quant_config: Quantization configuration to build the substitutions list according to.
+        core_config: Quantization configuration to build the substitutions list according to.
         fw_info: Information needed for quantization about the specific framework (e.g., kernel channels indices,
         groups of layers by how they should be quantized, etc.)
         snc_node_types: Types of activation nodes with negative outputs to consider.

--- a/model_compression_toolkit/common/target_platform/op_quantization_config.py
+++ b/model_compression_toolkit/common/target_platform/op_quantization_config.py
@@ -39,8 +39,6 @@ class QuantizationMethod(Enum):
     UNIFORM = 4
 
 
-
-
 class OpQuantizationConfig:
     """
     OpQuantizationConfig is a class to configure the quantization parameters of an operator.

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
@@ -415,7 +415,7 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
 
         mha_in_edges = graph.in_edges(mha_node)
 
-        # input permutation and reshape to standard shape: (batch, sequence, channels)
+        # input permutation and reshape to standard shape: (batch, iterations, sequence, channels)
         q_permute_node, k_permute_node, v_permute_node, \
         q_reshape_node, k_reshape_node, v_reshape_node = \
             self._standarize_input_shapes(graph, mha_node.name, len(mha_in_edges), params)

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
@@ -29,7 +29,7 @@ from tensorflow.keras.layers import Activation, Conv2D, Dense, DepthwiseConv2D, 
     GlobalAveragePooling2D, Dropout, ReLU, PReLU, ELU
 from typing import Tuple, Any
 
-from model_compression_toolkit import common, QuantizationConfig, FrameworkInfo
+from model_compression_toolkit import common, QuantizationConfig, CoreConfig, FrameworkInfo
 from model_compression_toolkit.common import BaseNode, Graph
 from model_compression_toolkit.common.constants import FLOAT_32, DATA_TYPE
 from model_compression_toolkit.keras.constants import NEGATIVE_SLOPE, PADDING, PAD_SAME, PAD_VALID, BIAS, USE_BIAS
@@ -271,7 +271,7 @@ def is_padding_node_and_node_has_padding(pad_node_to_consider: BaseNode,
 
 
 def keras_apply_shift_negative_correction(graph: Graph,
-                                          quant_config: QuantizationConfig,
+                                          core_config: CoreConfig,
                                           fw_info: FrameworkInfo) -> Graph:
     """
     Apply shift negative correction (SNC) on a graph built from a Keras model.
@@ -287,7 +287,7 @@ def keras_apply_shift_negative_correction(graph: Graph,
     snc_node, linear_node, bypass_node, pad_node = shift_negative_activation_node_matchers()
 
     return apply_shift_negative_correction(graph,
-                                           quant_config,
+                                           core_config,
                                            fw_info,
                                            snc_node,
                                            linear_node,

--- a/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/keras/graph_substitutions/substitutions/shift_negative_activation.py
@@ -29,7 +29,7 @@ from tensorflow.keras.layers import Activation, Conv2D, Dense, DepthwiseConv2D, 
     GlobalAveragePooling2D, Dropout, ReLU, PReLU, ELU
 from typing import Tuple, Any
 
-from model_compression_toolkit import common, QuantizationConfig, CoreConfig, FrameworkInfo
+from model_compression_toolkit import common, CoreConfig, FrameworkInfo
 from model_compression_toolkit.common import BaseNode, Graph
 from model_compression_toolkit.common.constants import FLOAT_32, DATA_TYPE
 from model_compression_toolkit.keras.constants import NEGATIVE_SLOPE, PADDING, PAD_SAME, PAD_VALID, BIAS, USE_BIAS
@@ -278,7 +278,7 @@ def keras_apply_shift_negative_correction(graph: Graph,
 
     Args:
         graph: Graph to apply SNC on.
-        quant_config: Quantization configuration.
+        core_config: Quantization configuration.
         fw_info: FrameworkInfo object with information about the specific framework's module.
 
     Returns:

--- a/model_compression_toolkit/keras/keras_implementation.py
+++ b/model_compression_toolkit/keras/keras_implementation.py
@@ -148,7 +148,7 @@ class KerasImplementation(FrameworkImplementation):
 
         Args:
             graph: Graph to apply SNC on.
-            qc: Quantization configuration.
+            core_config: Quantization configuration.
             fw_info: FrameworkInfo object with information about the specific framework's model.
 
         Returns:

--- a/model_compression_toolkit/keras/keras_implementation.py
+++ b/model_compression_toolkit/keras/keras_implementation.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from tensorflow.keras.models import Model
 
 from model_compression_toolkit import QuantizationConfig, FrameworkInfo, common, GradientPTQConfig, \
-    MixedPrecisionQuantizationConfig
+    MixedPrecisionQuantizationConfig, CoreConfig
 from model_compression_toolkit.common import Graph, BaseNode
 from model_compression_toolkit.common.collectors.statistics_collector import BaseStatsCollector
 from model_compression_toolkit.common.framework_implementation import FrameworkImplementation
@@ -141,7 +141,7 @@ class KerasImplementation(FrameworkImplementation):
 
     def shift_negative_correction(self,
                                   graph: Graph,
-                                  qc: QuantizationConfig,
+                                  core_config: CoreConfig,
                                   fw_info: FrameworkInfo) -> Graph:
         """
         Apply shift negative correction (SNC) on a graph.
@@ -155,7 +155,7 @@ class KerasImplementation(FrameworkImplementation):
             Graph after SNC.
         """
         return keras_apply_shift_negative_correction(graph,
-                                                     qc,
+                                                     core_config,
                                                      fw_info)
 
     def attach_sc_to_node(self,

--- a/model_compression_toolkit/keras/kpi_data_facade.py
+++ b/model_compression_toolkit/keras/kpi_data_facade.py
@@ -15,11 +15,11 @@
 
 from typing import Callable
 
-from model_compression_toolkit import KPI, MixedPrecisionQuantizationConfig
+from model_compression_toolkit import KPI, MixedPrecisionQuantizationConfig, CoreConfig
 from model_compression_toolkit.common import Logger
 from model_compression_toolkit.common.constants import TENSORFLOW
 from model_compression_toolkit.common.target_platform import TargetPlatformCapabilities
-from model_compression_toolkit.common.mixed_precision.kpi_data import compute_kpi_data
+from model_compression_toolkit.common.mixed_precision.kpi_data import compute_kpi_data, compute_kpi_data_experimental
 from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
     DEFAULT_MIXEDPRECISION_CONFIG
@@ -88,6 +88,63 @@ if importlib.util.find_spec("tensorflow") is not None\
                                 target_platform_capabilities,
                                 fw_info,
                                 fw_impl)
+
+
+    def keras_kpi_data_experimental(in_model: Model,
+                                    representative_data_gen: Callable,
+                                    core_config: CoreConfig,  # TODO: edit doc
+                                    fw_info: FrameworkInfo = DEFAULT_KERAS_INFO,
+                                    target_platform_capabilities: TargetPlatformCapabilities = KERAS_DEFAULT_TPC) -> KPI:
+        """
+        Computes KPI data that can be used to calculate the desired target KPI for mixed-precision quantization.
+        Builds the computation graph from the given model and hw modeling, and uses it to compute the KPI data.
+
+        Args:
+            in_model (Model): Keras model to quantize.
+            representative_data_gen (Callable): Dataset used for calibration.
+            quant_config (MixedPrecisionQuantizationConfig): MixedPrecisionQuantizationConfig containing parameters
+            of how the model should be quantized.
+            fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
+            kernel channels indices, groups of layers by how they should be quantized, etc.). `Default Keras info
+            <https://github.com/sony/model_optimization/blob/21e21c95ca25a31874a5be7af9dd2dd5da8f3a10
+            /model_compression_toolkit/keras/default_framework_info.py#L113>`_
+            target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the
+            Keras model according to. `Default Keras info
+            <https://github.com/sony/model_optimization/blob/9513796726e72ebdb5b075f5014eb8feae47f3ae
+            /model_compression_toolkit/hardware_models/keras_hardware_model/keras_default.py#L39>`_
+
+        Returns:
+            A KPI object with total weights parameters sum and max activation tensor.
+
+        Examples:
+            Import a Keras model:
+
+            >>> from tensorflow.keras.applications.mobilenet import MobileNet
+            >>> model = MobileNet()
+
+            Create a random dataset generator:
+
+            >>> import numpy as np
+            >>> def repr_datagen(): return [np.random.random((1,224,224,3))]
+
+            Import mct and call for KPI data calculation:
+            >>> import model_compression_toolkit as mct
+            >>> kpi_data = keras_kpi_data(model, repr_datagen)
+
+        """
+
+        if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):  # TODO: edit doc and comment
+            Logger.error("KPI data computation can be executed without MixedPrecisionQuantizationConfig object."
+                         "Given quant_config is not of type MixedPrecisionQuantizationConfig.")
+
+        fw_impl = KerasImplementation()
+
+        return compute_kpi_data_experimental(in_model,
+                                             representative_data_gen,
+                                             core_config,
+                                             target_platform_capabilities,
+                                             fw_info,
+                                             fw_impl)
 
 else:
     # If tensorflow or tensorflow_model_optimization are not installed,

--- a/model_compression_toolkit/keras/kpi_data_facade.py
+++ b/model_compression_toolkit/keras/kpi_data_facade.py
@@ -153,3 +153,9 @@ else:
         Logger.critical('Installing tensorflow and tensorflow_model_optimization is mandatory '
                         'when using keras_kpi_data. '
                         'Could not find Tensorflow package.')
+
+
+    def keras_kpi_data_experimental(*args, **kwargs):
+        Logger.critical('Installing tensorflow and tensorflow_model_optimization is mandatory '
+                        'when using keras_kpi_data. '
+                        'Could not find Tensorflow package.')

--- a/model_compression_toolkit/keras/kpi_data_facade.py
+++ b/model_compression_toolkit/keras/kpi_data_facade.py
@@ -77,7 +77,7 @@ if importlib.util.find_spec("tensorflow") is not None\
         """
 
         if not isinstance(quant_config, MixedPrecisionQuantizationConfig):
-            Logger.error("KPI data computation can be executed without MixedPrecisionQuantizationConfig object."
+            Logger.error("KPI data computation can't be executed without MixedPrecisionQuantizationConfig object."
                          "Given quant_config is not of type MixedPrecisionQuantizationConfig.")
 
         fw_impl = KerasImplementation()
@@ -92,7 +92,7 @@ if importlib.util.find_spec("tensorflow") is not None\
 
     def keras_kpi_data_experimental(in_model: Model,
                                     representative_data_gen: Callable,
-                                    core_config: CoreConfig,  # TODO: edit doc
+                                    core_config: CoreConfig,
                                     fw_info: FrameworkInfo = DEFAULT_KERAS_INFO,
                                     target_platform_capabilities: TargetPlatformCapabilities = KERAS_DEFAULT_TPC) -> KPI:
         """
@@ -102,7 +102,7 @@ if importlib.util.find_spec("tensorflow") is not None\
         Args:
             in_model (Model): Keras model to quantize.
             representative_data_gen (Callable): Dataset used for calibration.
-            quant_config (MixedPrecisionQuantizationConfig): MixedPrecisionQuantizationConfig containing parameters
+            core_config (CoreConfig): CoreConfig containing parameters for quantization and mixed precision
             of how the model should be quantized.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
             kernel channels indices, groups of layers by how they should be quantized, etc.). `Default Keras info
@@ -133,9 +133,9 @@ if importlib.util.find_spec("tensorflow") is not None\
 
         """
 
-        if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):  # TODO: edit doc and comment
-            Logger.error("KPI data computation can be executed without MixedPrecisionQuantizationConfig object."
-                         "Given quant_config is not of type MixedPrecisionQuantizationConfig.")
+        if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):
+            Logger.error("KPI data computation can't be executed without MixedPrecisionQuantizationConfigV2 object."
+                         "Given quant_config is not of type MixedPrecisionQuantizationConfigV2.")
 
         fw_impl = KerasImplementation()
 

--- a/model_compression_toolkit/keras/kpi_data_facade.py
+++ b/model_compression_toolkit/keras/kpi_data_facade.py
@@ -15,7 +15,7 @@
 
 from typing import Callable
 
-from model_compression_toolkit import KPI, MixedPrecisionQuantizationConfig, CoreConfig
+from model_compression_toolkit import KPI, MixedPrecisionQuantizationConfig, CoreConfig, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.common import Logger
 from model_compression_toolkit.common.constants import TENSORFLOW
 from model_compression_toolkit.common.target_platform import TargetPlatformCapabilities
@@ -133,7 +133,7 @@ if importlib.util.find_spec("tensorflow") is not None\
 
         """
 
-        if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):  # TODO: edit doc and comment
+        if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):  # TODO: edit doc and comment
             Logger.error("KPI data computation can be executed without MixedPrecisionQuantizationConfig object."
                          "Given quant_config is not of type MixedPrecisionQuantizationConfig.")
 

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -27,6 +27,7 @@ from model_compression_toolkit.common.mixed_precision.mixed_precision_quantizati
 from model_compression_toolkit.common.post_training_quantization import post_training_quantization
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
 from model_compression_toolkit.common.quantization.core_config import CoreConfig
+from model_compression_toolkit.common.quantization.debug_config import DebugConfig
 from model_compression_toolkit.common.quantization.quantization_config import DEFAULTCONFIG
 
 import importlib
@@ -144,10 +145,17 @@ if importlib.util.find_spec("tensorflow") is not None\
         """
         KerasModelValidation(model=in_model,
                              fw_info=fw_info).validate()
+
+        core_config = CoreConfig(n_iter,
+                                 quantization_config=quant_config,
+                                 debug_config=DebugConfig(analyze_similarity=analyze_similarity,
+                                                          network_editor=network_editor)
+                                 )
+
         return post_training_quantization(in_model,
                                           representative_data_gen,
                                           n_iter,
-                                          CoreConfig(n_iter, quant_config, network_editor=network_editor),
+                                          core_config,
                                           fw_info,
                                           KerasImplementation(),
                                           target_platform_capabilities,
@@ -250,7 +258,9 @@ if importlib.util.find_spec("tensorflow") is not None\
         core_config = CoreConfig(n_iter,
                                  quantization_config=quantization_config,
                                  mixed_precision_config=mp_config,
-                                 network_editor=network_editor)
+                                 debug_config=DebugConfig(analyze_similarity=analyze_similarity,
+                                                          network_editor=network_editor)
+                                 )
 
         return post_training_quantization(in_model,
                                           representative_data_gen,
@@ -271,7 +281,6 @@ if importlib.util.find_spec("tensorflow") is not None\
                                                                target_kpi: KPI = None,
                                                                core_config: CoreConfig = CoreConfig(),
                                                                fw_info: FrameworkInfo = DEFAULT_KERAS_INFO,
-                                                               analyze_similarity: bool = False,
                                                                target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_KERAS_TPC):
         """
         Quantize a trained Keras model using post-training quantization. The model is quantized using a
@@ -298,8 +307,6 @@ if importlib.util.find_spec("tensorflow") is not None\
             quantized, including mixed precision parameters. `Default configuration.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
             kernel channels indices, groups of layers by how they should be quantized, etc.). `Default Keras info
-            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is enabled)
-            or not.
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the
             Keras model according to.
 
@@ -367,9 +374,9 @@ if importlib.util.find_spec("tensorflow") is not None\
                                           fw_info=fw_info,
                                           fw_impl=KerasImplementation(),
                                           tpc=target_platform_capabilities,
-                                          network_editor=core_config.network_editor,
+                                          network_editor=core_config.debug_config.network_editor,
                                           gptq_config=gptq_config,
-                                          analyze_similarity=analyze_similarity,
+                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 
@@ -378,7 +385,6 @@ if importlib.util.find_spec("tensorflow") is not None\
                                                       target_kpi: KPI = None,
                                                       core_config: CoreConfig = CoreConfig(),
                                                       fw_info: FrameworkInfo = DEFAULT_KERAS_INFO,
-                                                      analyze_similarity: bool = False,  # move to debug_config inside core_config (put model_editor there too)
                                                       target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_KERAS_TPC):
         """
          Quantize a trained Keras model using post-training quantization. The model is quantized using a
@@ -403,8 +409,6 @@ if importlib.util.find_spec("tensorflow") is not None\
              kernel channels indices, groups of layers by how they should be quantized, etc.). `Default Keras info
              <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/keras
              /default_framework_info.py#L100>`_
-             analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is
-             enabled) or not.
              target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the
              Keras model according to.
 
@@ -473,8 +477,8 @@ if importlib.util.find_spec("tensorflow") is not None\
                                           fw_info=fw_info,
                                           fw_impl=KerasImplementation(),
                                           tpc=target_platform_capabilities,
-                                          network_editor=core_config.network_editor,
-                                          analyze_similarity=analyze_similarity,
+                                          network_editor=core_config.debug_config.network_editor,
+                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 else:

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -303,8 +303,8 @@ if importlib.util.find_spec("tensorflow") is not None\
             representative_data_gen (Callable): Dataset used for calibration.
             gptq_config (GradientPTQConfig): Configuration for using gptq (e.g. optimizer).
             target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
-            core_config (CoreConfig): configuration object containing parameters of how the model should be
-            quantized, including mixed precision parameters. `Default configuration.
+            core_config (CoreConfig): Configuration object containing parameters of how the model should be
+            quantized, including mixed precision parameters.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
             kernel channels indices, groups of layers by how they should be quantized, etc.). `Default Keras info
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the
@@ -359,9 +359,9 @@ if importlib.util.find_spec("tensorflow") is not None\
                              fw_info=fw_info).validate()
 
         if core_config.mixed_precision_enable:
-            if core_config.mixed_precision_config is None:
+            if isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):
                 common.Logger.error("Given quantization config to mixed-precision facade is not of type "
-                                    "MixedPrecisionQuantizationConfig. Please use keras_post_training_quantization API,"
+                                    "MixedPrecisionQuantizationConfigV2. Please use keras_post_training_quantization API,"
                                     "or pass a valid mixed precision configuration.")
 
             common.Logger.info("Using experimental mixed-precision quantization. "
@@ -403,7 +403,7 @@ if importlib.util.find_spec("tensorflow") is not None\
              in_model (Model): Keras model to quantize.
              representative_data_gen (Callable): Dataset used for calibration.
              target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
-             core_config (CoreConfig): configuration object containing parameters of how the model should be
+             core_config (CoreConfig): Configuration object containing parameters of how the model should be
              quantized, including mixed precision parameters.
              fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
              kernel channels indices, groups of layers by how they should be quantized, etc.). `Default Keras info
@@ -462,9 +462,9 @@ if importlib.util.find_spec("tensorflow") is not None\
                              fw_info=fw_info).validate()
 
         if core_config.mixed_precision_enable:
-            if core_config.mixed_precision_config is None:
+            if isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):
                 common.Logger.error("Given quantization config to mixed-precision facade is not of type "
-                                    "MixedPrecisionQuantizationConfig. Please use keras_post_training_quantization API,"
+                                    "MixedPrecisionQuantizationConfigV2. Please use keras_post_training_quantization API,"
                                     "or pass a valid mixed precision configuration.")
 
             common.Logger.info("Using experimental mixed-precision quantization. "

--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -246,6 +246,7 @@ if importlib.util.find_spec("tensorflow") is not None\
         common.Logger.info("Using experimental mixed-precision quantization. "
                            "If you encounter an issue please file a bug.")
 
+        # TODO: move to MixedPrecisionQuantizationConfig as a function to that returns the QuantizationConfig & MixedPrecisionQuantizationConfigV2
         _dummy_quant_config = QuantizationConfig()
         _dummy_mp_config = MixedPrecisionQuantizationConfig()
         _dummy_mp_config_experimental = MixedPrecisionQuantizationConfigV2()

--- a/model_compression_toolkit/pytorch/graph_substitutions/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/pytorch/graph_substitutions/substitutions/shift_negative_activation.py
@@ -21,7 +21,7 @@ from torch import reshape
 from torch.nn.functional import hardswish, silu, prelu, elu
 from torch.nn.functional import avg_pool2d
 
-from model_compression_toolkit import common, QuantizationConfig, FrameworkInfo
+from model_compression_toolkit import common, CoreConfig, FrameworkInfo
 from model_compression_toolkit.common import BaseNode, Graph
 from model_compression_toolkit.common.graph.graph_matchers import EdgeMatcher
 from model_compression_toolkit.common.graph.graph_matchers import NodeOperationMatcher
@@ -191,14 +191,14 @@ def is_padding_node_and_node_has_padding(pad_node_to_consider: BaseNode,
 
 
 def pytorch_apply_shift_negative_correction(graph: Graph,
-                                            quant_config: QuantizationConfig,
+                                            core_config: CoreConfig,
                                             fw_info: FrameworkInfo) -> Graph:
     """
     Apply shift negative correction (SNC) on a graph built from a Pytorch model.
 
     Args:
         graph: Graph to apply SNC on.
-        quant_config: Quantization configuration.
+        core_config: Quantization configuration.
         fw_info: FrameworkInfo object with information about the specific framework's module.
 
     Returns:
@@ -206,7 +206,7 @@ def pytorch_apply_shift_negative_correction(graph: Graph,
     """
     snc_node, linear_node, bypass_node, pad_node = shift_negative_activation_node_matchers()
     return apply_shift_negative_correction(graph,
-                                           quant_config,
+                                           core_config,
                                            fw_info,
                                            snc_node,
                                            linear_node,

--- a/model_compression_toolkit/pytorch/kpi_data_facade.py
+++ b/model_compression_toolkit/pytorch/kpi_data_facade.py
@@ -76,7 +76,7 @@ if importlib.util.find_spec("torch") is not None:
         """
 
         if not isinstance(quant_config, MixedPrecisionQuantizationConfig):
-            Logger.error("KPI data computation can be executed without MixedPrecisionQuantizationConfig object."
+            Logger.error("KPI data computation can't be executed without MixedPrecisionQuantizationConfig object."
                          "Given quant_config is not of type MixedPrecisionQuantizationConfig.")
 
         fw_impl = PytorchImplementation()
@@ -95,14 +95,13 @@ if importlib.util.find_spec("torch") is not None:
                                       fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
                                       target_platform_capabilities: TargetPlatformCapabilities = PYTORCH_DEFAULT_TPC) -> KPI:
         """
-        TODO: edit doc
         Computes KPI data that can be used to calculate the desired target KPI for mixed-precision quantization.
         Builds the computation graph from the given model and target platform capabilities, and uses it to compute the KPI data.
 
         Args:
             in_model (Model): Keras model to quantize.
             representative_data_gen (Callable): Dataset used for calibration.
-            quant_config (MixedPrecisionQuantizationConfig): MixedPrecisionQuantizationConfig containing parameters of how the model should be quantized.
+            core_config (CoreConfig): CoreConfig containing parameters for quantization and mixed precision
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to. `Default Keras TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py>`_
 
@@ -129,8 +128,8 @@ if importlib.util.find_spec("torch") is not None:
         """
 
         if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):
-            Logger.error("KPI data computation can be executed without MixedPrecisionQuantizationConfig object."
-                         "Given quant_config is not of type MixedPrecisionQuantizationConfig.")
+            Logger.error("KPI data computation can't be executed without MixedPrecisionQuantizationConfigV2 object."
+                         "Given quant_config is not of type MixedPrecisionQuantizationConfigV2.")
 
         fw_impl = PytorchImplementation()
 

--- a/model_compression_toolkit/pytorch/kpi_data_facade.py
+++ b/model_compression_toolkit/pytorch/kpi_data_facade.py
@@ -146,3 +146,8 @@ else:
     def pytorch_kpi_data(*args, **kwargs):
         Logger.critical('Installing torch is mandatory when using pytorch_kpi_data. '
                         'Could not find Tensorflow package.')
+
+
+    def pytorch_kpi_data_experimental(*args, **kwargs):
+        Logger.critical('Installing torch is mandatory when using pytorch_kpi_data. '
+                        'Could not find Tensorflow package.')

--- a/model_compression_toolkit/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/pytorch/pytorch_implementation.py
@@ -144,13 +144,13 @@ class PytorchImplementation(FrameworkImplementation):
         Apply shift negative correction (SNC) on a graph.
         Args:
             graph: Graph to apply SNC on.
-            qc: Quantization configuration.
+            core_config: Quantization configuration.
             fw_info: FrameworkInfo object with information about the specific framework's module.
         Returns:
             Graph after SNC.
         """
         return pytorch_apply_shift_negative_correction(graph,
-                                                       qc,
+                                                       core_config,
                                                        fw_info)
 
     def attach_sc_to_node(self,

--- a/model_compression_toolkit/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/pytorch/pytorch_implementation.py
@@ -18,7 +18,7 @@ import torch
 from torch.nn import Module
 
 from model_compression_toolkit import QuantizationConfig, FrameworkInfo, common, GradientPTQConfig, \
-    MixedPrecisionQuantizationConfig
+    MixedPrecisionQuantizationConfig, CoreConfig
 from model_compression_toolkit.common import Graph, BaseNode
 from model_compression_toolkit.common.collectors.statistics_collector import BaseStatsCollector
 from model_compression_toolkit.common.collectors.statistics_collector_generator import create_stats_collector_for_node
@@ -138,7 +138,7 @@ class PytorchImplementation(FrameworkImplementation):
 
     def shift_negative_correction(self,
                                   graph: Graph,
-                                  qc: QuantizationConfig,
+                                  core_config: CoreConfig,
                                   fw_info: FrameworkInfo) -> Graph:
         """
         Apply shift negative correction (SNC) on a graph.

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -23,6 +23,7 @@ from model_compression_toolkit.common.mixed_precision.kpi import KPI
 from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.network_editors.actions import EditRule
 from model_compression_toolkit.common.quantization.core_config import CoreConfig
+from model_compression_toolkit.common.quantization.debug_config import DebugConfig
 from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
     MixedPrecisionQuantizationConfig, DEFAULT_MIXEDPRECISION_CONFIG, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.common.post_training_quantization import post_training_quantization
@@ -99,7 +100,9 @@ if importlib.util.find_spec("torch") is not None:
         return post_training_quantization(in_module,
                                           representative_data_gen,
                                           n_iter,
-                                          CoreConfig(n_iter, quant_config, network_editor=network_editor),
+                                          CoreConfig(n_iter, quant_config,
+                                                     debug_config=DebugConfig(analyze_similarity=analyze_similarity,
+                                                                              network_editor=network_editor)),
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
@@ -199,7 +202,8 @@ if importlib.util.find_spec("torch") is not None:
         core_config = CoreConfig(n_iter,
                                  quantization_config=quantization_config,
                                  mixed_precision_config=mp_config,
-                                 network_editor=network_editor)
+                                 debug_config=DebugConfig(analyze_similarity=analyze_similarity,
+                                                          network_editor=network_editor))
 
         return post_training_quantization(in_model,
                                           representative_data_gen,
@@ -219,7 +223,6 @@ if importlib.util.find_spec("torch") is not None:
                                                         target_kpi: KPI = None,
                                                         core_config: CoreConfig = CoreConfig(),
                                                         fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
-                                                        analyze_similarity: bool = False,  # TODO: move to debug config
                                                         target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_PYTORCH_TPC):
         """
         Quantize a trained Pytorch module using post-training quantization.
@@ -241,7 +244,6 @@ if importlib.util.find_spec("torch") is not None:
             core_config (CoreConfig): configuration object containing parameters of how the model should be
             quantized, including mixed precision parameters.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
-            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is enabled) or not.
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to. `Default Keras TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py>`_
 
 
@@ -283,8 +285,8 @@ if importlib.util.find_spec("torch") is not None:
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
-                                          core_config.network_editor,
-                                          analyze_similarity=analyze_similarity,
+                                          core_config.debug_config.network_editor,
+                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 
@@ -294,7 +296,6 @@ if importlib.util.find_spec("torch") is not None:
                                                                  core_config: CoreConfig = CoreConfig(),
                                                                  fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
                                                                  gptq_config: GradientPTQConfig = None,
-                                                                 analyze_similarity: bool = False,  # TODO: move to debug config
                                                                  target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_PYTORCH_TPC):
         """
         Quantize a trained Pytorch module using post-training quantization.
@@ -317,7 +318,6 @@ if importlib.util.find_spec("torch") is not None:
             quantized, including mixed precision parameters.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
             gptq_config (GradientPTQConfig): Configuration for using gptq (e.g. optimizer).
-            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is enabled) or not.
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to. `Default Keras TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py>`_
 
 
@@ -359,9 +359,9 @@ if importlib.util.find_spec("torch") is not None:
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
-                                          core_config.network_editor,
+                                          core_config.debug_config.network_editor,
                                           gptq_config,
-                                          analyze_similarity=analyze_similarity,
+                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -22,8 +22,9 @@ from model_compression_toolkit.common.target_platform import TargetPlatformCapab
 from model_compression_toolkit.common.mixed_precision.kpi import KPI
 from model_compression_toolkit.common.framework_info import FrameworkInfo
 from model_compression_toolkit.common.network_editors.actions import EditRule
+from model_compression_toolkit.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.common.mixed_precision.mixed_precision_quantization_config import \
-    MixedPrecisionQuantizationConfig, DEFAULT_MIXEDPRECISION_CONFIG
+    MixedPrecisionQuantizationConfig, DEFAULT_MIXEDPRECISION_CONFIG, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.common.post_training_quantization import post_training_quantization
 from model_compression_toolkit.common.quantization.quantization_config import QuantizationConfig
 from model_compression_toolkit.common.quantization.quantization_config import DEFAULTCONFIG
@@ -98,7 +99,7 @@ if importlib.util.find_spec("torch") is not None:
         return post_training_quantization(in_module,
                                           representative_data_gen,
                                           n_iter,
-                                          quant_config,
+                                          CoreConfig(n_iter, quant_config, network_editor=network_editor),
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
@@ -194,10 +195,28 @@ if importlib.util.find_spec("torch") is not None:
         common.Logger.info("Using experimental mixed-precision quantization. "
                            "If you encounter an issue please file a bug.")
 
+        _dummy_quant_config = QuantizationConfig()
+        _dummy_mp_config = MixedPrecisionQuantizationConfig()
+        _dummy_mp_config_experimental = MixedPrecisionQuantizationConfigV2()
+        qc_dict = {}
+        mp_dict = {}
+        for k, v in quant_config.__dict__.items():
+            if hasattr(_dummy_quant_config, k):
+                qc_dict.update({k: v})
+            elif hasattr(_dummy_mp_config_experimental, k):
+                mp_dict.update({k: v})
+            else:
+                raise Exception(f'Attribute "{k}" mismatch: exists in MixedPrecisionQuantizationConfig but not in MixedPrecisionQuantizationConfigV2')
+
+        core_config = CoreConfig(n_iter,
+                                 quantization_config=QuantizationConfig(**qc_dict),
+                                 mixed_precision_config=MixedPrecisionQuantizationConfigV2(**mp_dict),
+                                 network_editor=network_editor)
+
         return post_training_quantization(in_model,
                                           representative_data_gen,
                                           n_iter,
-                                          quant_config,
+                                          core_config,
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
@@ -205,6 +224,161 @@ if importlib.util.find_spec("torch") is not None:
                                           gptq_config,
                                           analyze_similarity,
                                           target_kpi)
+
+
+    def pytorch_post_training_quantization_experimental(in_module: Module,
+                                                        representative_data_gen: Callable,
+                                                        target_kpi: KPI,
+                                                        core_config: CoreConfig = CoreConfig(),
+                                                        fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
+                                                        # gptq_config: GradientPTQConfig = None,
+                                                        analyze_similarity: bool = False,  # TODO: move to debug config
+                                                        target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_PYTORCH_TPC):
+        """
+        Quantize a trained Pytorch module using post-training quantization.
+        By default, the module is quantized using a symmetric constraint quantization thresholds
+        (power of two) as defined in the default TargetPlatformCapabilities.
+        The module is first optimized using several transformations (e.g. BatchNormalization folding to
+        preceding layers). Then, using a given dataset, statistics (e.g. min/max, histogram, etc.) are
+        being collected for each layer's output (and input, depends on the quantization configuration).
+        Thresholds are then being calculated using the collected statistics and the module is quantized
+        (both coefficients and activations by default).
+        If gptq_config is passed, the quantized weights are optimized using gradient based post
+        training quantization by comparing points between the float and quantized modules, and minimizing the
+        observed loss.
+
+        Args:
+            in_module (Module): Pytorch module to quantize.
+            representative_data_gen (Callable): Dataset used for calibration.
+            n_iter (int): Number of calibration iterations to run.
+            quant_config (QuantizationConfig): QuantizationConfig containing parameters of how the module should be quantized. `Default configuration. <https://github.com/sony/model_optimization/blob/21e21c95ca25a31874a5be7af9dd2dd5da8f3a10/model_compression_toolkit/common/quantization/quantization_config.py#L154>`_
+            fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
+            network_editor (List[EditRule]): List of EditRules. Each EditRule consists of a node filter and an action to change quantization settings of the filtered nodes.
+            gptq_config (GradientPTQConfig): Configuration for using gptq (e.g. optimizer).
+            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is enabled) or not.
+            target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to. `Default Keras TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py>`_
+
+
+        Returns:
+            A quantized module and information the user may need to handle the quantized module.
+
+        Examples:
+
+            Import a Pytorch module:
+
+            >>> import torchvision.models.mobilenet_v2 as models
+            >>> module = models.mobilenet_v2()
+
+            Create a random dataset generator:
+
+            >>> import numpy as np
+            >>> def repr_datagen(): return [np.random.random((1,224,224,3))]
+
+            Import mct and pass the module with the representative dataset generator to get a quantized module:
+
+            >>> import model_compression_toolkit as mct
+            >>> quantized_module, quantization_info = mct.pytorch_post_training_quantization(module, repr_datagen)
+
+        """
+
+        if core_config.mixed_precision_enable:
+            if core_config.mixed_precision_config is None:  # TODO: edit comment
+                common.Logger.error("Given quantization config to mixed-precision facade is not of type "
+                                    "MixedPrecisionQuantizationConfig. Please use pytorch_post_training_quantization API,"
+                                    "or pass a valid mixed precision configuration.")
+
+            common.Logger.info("Using experimental mixed-precision quantization. "
+                               "If you encounter an issue please file a bug.")
+
+        return post_training_quantization(in_module,
+                                          representative_data_gen,
+                                          core_config.n_iter,
+                                          core_config,
+                                          fw_info,
+                                          PytorchImplementation(),
+                                          target_platform_capabilities,
+                                          core_config.network_editor,
+                                          # gptq_config,
+                                          analyze_similarity=analyze_similarity,
+                                          target_kpi=target_kpi)
+
+
+    def pytorch_gradient_post_training_quantization_experimental(in_module: Module,
+                                                                 representative_data_gen: Callable,
+                                                                 target_kpi: KPI,
+                                                                 core_config: CoreConfig = CoreConfig(),
+                                                                 fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
+                                                                 gptq_config: GradientPTQConfig = None,
+                                                                 analyze_similarity: bool = False,  # TODO: move to debug config
+                                                                 target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_PYTORCH_TPC):
+        """
+        Quantize a trained Pytorch module using post-training quantization.
+        By default, the module is quantized using a symmetric constraint quantization thresholds
+        (power of two) as defined in the default TargetPlatformCapabilities.
+        The module is first optimized using several transformations (e.g. BatchNormalization folding to
+        preceding layers). Then, using a given dataset, statistics (e.g. min/max, histogram, etc.) are
+        being collected for each layer's output (and input, depends on the quantization configuration).
+        Thresholds are then being calculated using the collected statistics and the module is quantized
+        (both coefficients and activations by default).
+        If gptq_config is passed, the quantized weights are optimized using gradient based post
+        training quantization by comparing points between the float and quantized modules, and minimizing the
+        observed loss.
+
+        Args:
+            in_module (Module): Pytorch module to quantize.
+            representative_data_gen (Callable): Dataset used for calibration.
+            n_iter (int): Number of calibration iterations to run.
+            quant_config (QuantizationConfig): QuantizationConfig containing parameters of how the module should be quantized. `Default configuration. <https://github.com/sony/model_optimization/blob/21e21c95ca25a31874a5be7af9dd2dd5da8f3a10/model_compression_toolkit/common/quantization/quantization_config.py#L154>`_
+            fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
+            network_editor (List[EditRule]): List of EditRules. Each EditRule consists of a node filter and an action to change quantization settings of the filtered nodes.
+            gptq_config (GradientPTQConfig): Configuration for using gptq (e.g. optimizer).
+            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is enabled) or not.
+            target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to. `Default Keras TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py>`_
+
+
+        Returns:
+            A quantized module and information the user may need to handle the quantized module.
+
+        Examples:
+
+            Import a Pytorch module:
+
+            >>> import torchvision.models.mobilenet_v2 as models
+            >>> module = models.mobilenet_v2()
+
+            Create a random dataset generator:
+
+            >>> import numpy as np
+            >>> def repr_datagen(): return [np.random.random((1,224,224,3))]
+
+            Import mct and pass the module with the representative dataset generator to get a quantized module:
+
+            >>> import model_compression_toolkit as mct
+            >>> quantized_module, quantization_info = mct.pytorch_post_training_quantization(module, repr_datagen)
+
+        """
+
+        if core_config.mixed_precision_enable:
+            if core_config.mixed_precision_config is None:  # TODO: edit comment
+                common.Logger.error("Given quantization config to mixed-precision facade is not of type "
+                                    "MixedPrecisionQuantizationConfig. Please use pytorch_post_training_quantization API,"
+                                    "or pass a valid mixed precision configuration.")
+
+            common.Logger.info("Using experimental mixed-precision quantization. "
+                               "If you encounter an issue please file a bug.")
+
+        return post_training_quantization(in_module,
+                                          representative_data_gen,
+                                          core_config.n_iter,
+                                          core_config,
+                                          fw_info,
+                                          PytorchImplementation(),
+                                          target_platform_capabilities,
+                                          core_config.network_editor,
+                                          gptq_config,
+                                          analyze_similarity=analyze_similarity,
+                                          target_kpi=target_kpi)
+
 
 else:
     # If torch is not installed,
@@ -218,3 +392,14 @@ else:
         Logger.critical('Installing tensorflow and tensorflow_model_optimization is mandatory '
                         'when using pytorch_post_training_quantization_mixed_precision. '
                         'Could not find Tensorflow package.')
+
+    def pytorch_post_training_quantization_experimental(*args, **kwargs):
+        Logger.critical('Installing Pytorch is mandatory '
+                        'when using pytorch_post_training_quantization_experimental. '
+                        'Could not find the torch package.')
+
+    def pytorch_gradient_post_training_quantization_experimental(*args, **kwargs):
+        Logger.critical('Installing Pytorch is mandatory '
+                        'when using pytorch_gradient_post_training_quantization_experimental. '
+                        'Could not find the torch package.')
+

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -241,7 +241,7 @@ if importlib.util.find_spec("torch") is not None:
             in_module (Module): Pytorch module to quantize.
             representative_data_gen (Callable): Dataset used for calibration.
             target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
-            core_config (CoreConfig): configuration object containing parameters of how the model should be
+            core_config (CoreConfig): Configuration object containing parameters of how the model should be
             quantized, including mixed precision parameters.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to. `Default Keras TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py>`_
@@ -314,7 +314,7 @@ if importlib.util.find_spec("torch") is not None:
             in_module (Module): Pytorch module to quantize.
             representative_data_gen (Callable): Dataset used for calibration.
             target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
-            core_config (CoreConfig): configuration object containing parameters of how the model should be
+            core_config (CoreConfig): Configuration object containing parameters of how the model should be
             quantized, including mixed precision parameters.
             fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.). `Default PyTorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/pytorch/default_framework_info.py>`_
             gptq_config (GradientPTQConfig): Configuration for using gptq (e.g. optimizer).

--- a/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
+++ b/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
@@ -48,7 +48,7 @@ def generate_keras_default_tpc(name: str, tp_model: TargetPlatformModel):
     """
 
     keras_tpc = tpc.TargetPlatformCapabilities(tp_model,
-                                                name=name)
+                                               name=name)
     with keras_tpc:
         tpc.OperationsSetToLayers("NoQuantization", [Reshape,
                                                      tf.reshape,

--- a/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
@@ -20,6 +20,7 @@ from keras.layers import Conv2D, Conv2DTranspose
 
 import model_compression_toolkit as mct
 from model_compression_toolkit import QuantizationConfig, QuantizationErrorMethod
+from model_compression_toolkit import CoreConfig
 from model_compression_toolkit.common.bias_correction.compute_bias_correction_of_graph import \
     compute_bias_correction_of_graph
 from model_compression_toolkit.common.constants import RANGE_MIN, RANGE_MAX
@@ -92,6 +93,7 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
     def run_test_for_threshold_method(self, threshold_method, per_channel=True):
         qc = QuantizationConfig(weights_error_method=threshold_method,
                                 weights_per_channel_threshold=per_channel)
+        core_config = CoreConfig(n_iter=1, quantization_config=qc)
 
         tp = generate_test_tp_model({
             'weights_quantization_method': mct.target_platform.QuantizationMethod.UNIFORM})
@@ -104,7 +106,8 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
         graph.set_tpc(tpc)
         graph.set_fw_info(fw_info)
         graph = set_quantization_configuration_to_graph(graph=graph,
-                                                        quant_config=qc)
+                                                        quant_config=core_config.quantization_config,
+                                                        mixed_precision_enable=core_config.mixed_precision_enable)
         for node in graph.nodes:
             node.prior_info = keras_impl.get_node_prior_info(node=node,
                                                              fw_info=fw_info,
@@ -127,7 +130,7 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
         tg = compute_bias_correction_of_graph(graph,
                                               fw_info,
                                               keras_impl)
-        tg = set_bit_widths(qc,
+        tg = set_bit_widths(core_config.mixed_precision_enable,
                             tg,
                             fw_info,
                             None)


### PR DESCRIPTION
**Add a new API, currently dubbed "experimental":**
separate QuantizationConfig & MixedPrecisionConfig and put both under CoreConfig.
put analyze_similarity and network_editor in DebugConfig, under CoreConfig too.

**new APIs:**
keras_post_training_quantization_experimental
keras_gradient_post_training_quantization_experimental
pytorch_post_training_quantization_experimental
pytorch_gradient_post_training_quantization_experimental

Old APIs are still supported and will be deprecated in future releases