### PR TITLE
Update requirements file to use networkx 2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx
+networkx==2.8.0
 tqdm
 Pillow
 numpy


### PR DESCRIPTION
An issue occurs when using networkx 2.8.1 during deepcopy
of the graph. This downgrade solve the issue.