### PR TITLE
Fix issue with MP interest-point filtering test

### DIFF
--- a/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
+++ b/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
@@ -54,7 +54,8 @@ def build_ip_list_for_test(in_model, num_interest_points_factor):
     tpc = generate_keras_default_tpc(name="sem_test", tp_model=tp_model)
     graph.set_tpc(tpc)
     graph = set_quantization_configuration_to_graph(graph=graph,
-                                                    quant_config=qc)
+                                                    quant_config=qc,
+                                                    mixed_precision_enable=True)
 
     ips = get_mp_interest_points(graph=graph,
                                  fw_info=fw_info,
@@ -63,7 +64,7 @@ def build_ip_list_for_test(in_model, num_interest_points_factor):
     return ips, graph, fw_info
 
 
-class TestSensitivityMetricInterestPOints(unittest.TestCase):
+class TestSensitivityMetricInterestPoints(unittest.TestCase):
 
     def test_filtered_interest_points_set(self):
         in_model = DenseNet121()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -25,7 +25,6 @@ from tests.common_tests.function_tests.test_threshold_selection import TestThres
 from tests.common_tests.function_tests.test_folder_image_loader import TestFolderLoader
 from tests.common_tests.test_tp_model import TargetPlatformModelingTest, OpsetTest, QCOptionsTest, FusingTest
 
-
 found_tf = importlib.util.find_spec("tensorflow") is not None and importlib.util.find_spec(
     "tensorflow_model_optimization") is not None
 found_pytorch = importlib.util.find_spec("torch") is not None and importlib.util.find_spec(
@@ -48,6 +47,8 @@ if found_tf:
     from tests.keras_tests.function_tests.test_uniform_quantize_tensor import TestUniformQuantizeTensor
     from tests.keras_tests.function_tests.test_uniform_range_selection_weights import TestUniformRangeSelectionWeights
     from tests.keras_tests.test_keras_tp_model import TestKerasTPModel
+    from tests.keras_tests.function_tests.test_sensitivity_metric_interest_points import \
+        TestSensitivityMetricInterestPoints
 
 
 if found_pytorch:
@@ -72,6 +73,7 @@ if __name__ == '__main__':
 
     # Add TF tests only if tensorflow is installed
     if found_tf:
+        suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestSensitivityMetricInterestPoints))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestQuantizationConfigurations))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(FeatureNetworkTest))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestLogger))


### PR DESCRIPTION
MP filterring interest-points tests did not pass the "mp enable"
flag during candidates creation to nodes.
The tests class was renamed as well due to a typo.