### PR TITLE
remove duplicate arguments from post_training_quantization

### DIFF
--- a/model_compression_toolkit/keras/quantization_facade.py
+++ b/model_compression_toolkit/keras/quantization_facade.py
@@ -154,14 +154,11 @@ if importlib.util.find_spec("tensorflow") is not None\
 
         return post_training_quantization(in_model,
                                           representative_data_gen,
-                                          n_iter,
                                           core_config,
                                           fw_info,
                                           KerasImplementation(),
                                           target_platform_capabilities,
-                                          network_editor,
-                                          gptq_config,
-                                          analyze_similarity)
+                                          gptq_config)
 
 
     def keras_post_training_quantization_mixed_precision(in_model: Model,
@@ -264,14 +261,11 @@ if importlib.util.find_spec("tensorflow") is not None\
 
         return post_training_quantization(in_model,
                                           representative_data_gen,
-                                          n_iter,
                                           core_config,
                                           fw_info,
                                           KerasImplementation(),
                                           target_platform_capabilities,
-                                          network_editor,
                                           gptq_config,
-                                          analyze_similarity,
                                           target_kpi)
 
 
@@ -369,14 +363,11 @@ if importlib.util.find_spec("tensorflow") is not None\
 
         return post_training_quantization(in_model=in_model,
                                           representative_data_gen=representative_data_gen,
-                                          n_iter=core_config.n_iter,
                                           core_config=core_config,
                                           fw_info=fw_info,
                                           fw_impl=KerasImplementation(),
                                           tpc=target_platform_capabilities,
-                                          network_editor=core_config.debug_config.network_editor,
                                           gptq_config=gptq_config,
-                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 
@@ -472,13 +463,10 @@ if importlib.util.find_spec("tensorflow") is not None\
 
         return post_training_quantization(in_model=in_model,
                                           representative_data_gen=representative_data_gen,
-                                          n_iter=core_config.n_iter,
                                           core_config=core_config,
                                           fw_info=fw_info,
                                           fw_impl=KerasImplementation(),
                                           tpc=target_platform_capabilities,
-                                          network_editor=core_config.debug_config.network_editor,
-                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 else:

--- a/model_compression_toolkit/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/pytorch/quantization_facade.py
@@ -99,16 +99,13 @@ if importlib.util.find_spec("torch") is not None:
 
         return post_training_quantization(in_module,
                                           representative_data_gen,
-                                          n_iter,
                                           CoreConfig(n_iter, quant_config,
                                                      debug_config=DebugConfig(analyze_similarity=analyze_similarity,
                                                                               network_editor=network_editor)),
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
-                                          network_editor,
-                                          gptq_config,
-                                          analyze_similarity)
+                                          gptq_config)
 
 
     def pytorch_post_training_quantization_mixed_precision(in_model: Module,
@@ -207,14 +204,11 @@ if importlib.util.find_spec("torch") is not None:
 
         return post_training_quantization(in_model,
                                           representative_data_gen,
-                                          n_iter,
                                           core_config,
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
-                                          network_editor,
                                           gptq_config,
-                                          analyze_similarity,
                                           target_kpi)
 
 
@@ -280,13 +274,10 @@ if importlib.util.find_spec("torch") is not None:
 
         return post_training_quantization(in_module,
                                           representative_data_gen,
-                                          core_config.n_iter,
                                           core_config,
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
-                                          core_config.debug_config.network_editor,
-                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 
@@ -354,14 +345,11 @@ if importlib.util.find_spec("torch") is not None:
 
         return post_training_quantization(in_module,
                                           representative_data_gen,
-                                          core_config.n_iter,
                                           core_config,
                                           fw_info,
                                           PytorchImplementation(),
                                           target_platform_capabilities,
-                                          core_config.debug_config.network_editor,
                                           gptq_config,
-                                          analyze_similarity=core_config.debug_config.analyze_similarity,
                                           target_kpi=target_kpi)
 
 


### PR DESCRIPTION
remove duplicate arguments from common.post_training_quantization:
analyze_similarity, network_editor & n_iter (all moved to CoreConfig)