### PR TITLE
Add Technical Constrains to docs

### DIFF
--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -100,6 +100,11 @@ Please visit the MCT API documentation here
 
     API Documentation<../api/api_docs/index>
 
+Technical Constraints
+=========================
+
+* MCT doesn't keep the structure of the model's output. For example, if the output of a model is a list of lists of Tensors [[out1, out2], out3], the optimized model output will be [out1, out2, out3]
+
 References
 ====================================
 


### PR DESCRIPTION
Add Technical Constrains to docs: output structure may not be preserved after optimization (related to issue #114 )