### PR TITLE
Fix issue: network editor doesnt affect final configs

### DIFF
--- a/model_compression_toolkit/common/network_editors/edit_network.py
+++ b/model_compression_toolkit/common/network_editors/edit_network.py
@@ -21,7 +21,7 @@ from model_compression_toolkit.common.network_editors import EditRule
 
 
 
-def edit_network_graph(graph_to_edit: Graph,
+def edit_network_graph(graph: Graph,
                        fw_info: FrameworkInfo,
                        network_editor: List[EditRule]):
     """
@@ -37,9 +37,9 @@ def edit_network_graph(graph_to_edit: Graph,
         The graph after it has been applied the edit rules from the network editor list.
 
     """
-    graph = copy.deepcopy(graph_to_edit)
+    # graph = copy.deepcopy(graph_to_edit)
     for edit_rule in network_editor:
         filtered_nodes = graph.filter(edit_rule.filter)
         for node in filtered_nodes:
             edit_rule.action.apply(node, graph, fw_info)
-    return graph
+    # return graph

--- a/model_compression_toolkit/common/network_editors/edit_network.py
+++ b/model_compression_toolkit/common/network_editors/edit_network.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
+import copy
 from typing import List
 
 from model_compression_toolkit.common.framework_info import FrameworkInfo
@@ -21,14 +21,14 @@ from model_compression_toolkit.common.network_editors import EditRule
 
 
 
-def edit_network_graph(graph: Graph,
+def edit_network_graph(graph_to_edit: Graph,
                        fw_info: FrameworkInfo,
                        network_editor: List[EditRule]):
     """
     Apply a list of edit rules on a graph.
 
     Args:
-        graph: A graph to edit.
+        graph_to_edit: The graph to edit.
         fw_info: Information needed for quantization about the specific framework (e.g., kernel channels indices,
         groups of layers by how they should be quantized, etc.)
         network_editor: List of edit rules to apply to the graph.
@@ -37,8 +37,9 @@ def edit_network_graph(graph: Graph,
         The graph after it has been applied the edit rules from the network editor list.
 
     """
-
+    graph = copy.deepcopy(graph_to_edit)
     for edit_rule in network_editor:
         filtered_nodes = graph.filter(edit_rule.filter)
         for node in filtered_nodes:
             edit_rule.action.apply(node, graph, fw_info)
+    return graph

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -146,9 +146,7 @@ def post_training_quantization(in_model: Any,
 
     # Edit the graph again after finalizing the configurations.
     # This is since some actions regard the final configuration and should be edited.
-    tg = edit_network_graph(tg,
-                            fw_info,
-                            core_config.debug_config.network_editor)
+    edit_network_graph(tg, fw_info, core_config.debug_config.network_editor)
 
     # Retrive lists of tuples (node, node's final weights/activation bitwidth)
     weights_conf_nodes_bitwidth = tg.get_final_weights_config()
@@ -537,7 +535,7 @@ def _prepare_model_for_quantization(graph: Graph,
     # Notice that not all actions affect at this stage (for example, actions that edit the final configuration as
     # there are no final configurations at this stage of the optimization). For this reason we edit the graph
     # again at the end of the optimization process.
-    transformed_graph = edit_network_graph(transformed_graph, fw_info, core_config.debug_config.network_editor)
+    edit_network_graph(transformed_graph, fw_info, core_config.debug_config.network_editor)
 
     ######################################
     # Calculate quantization params

--- a/model_compression_toolkit/common/post_training_quantization.py
+++ b/model_compression_toolkit/common/post_training_quantization.py
@@ -142,8 +142,13 @@ def post_training_quantization(in_model: Any,
 
     tg = set_bit_widths(core_config.mixed_precision_enable,
                         tg,
-                        fw_info,
                         bit_widths_config)
+
+    # Edit the graph again after finalizing the configurations.
+    # This is since some actions regard the final configuration and should be edited.
+    tg = edit_network_graph(tg,
+                            fw_info,
+                            core_config.debug_config.network_editor)
 
     # Retrive lists of tuples (node, node's final weights/activation bitwidth)
     weights_conf_nodes_bitwidth = tg.get_final_weights_config()
@@ -484,8 +489,7 @@ def _prepare_model_for_quantization(graph: Graph,
     Args:
         representative_data_gen (Callable): Dataset used for calibration.
         tpc (TargetPlatformCapabilities): TargetPlatformCapabilities object which holds target specific capabilities.
-        core_config (CoreConfig): CoreConfig containing parameters of how the model should be
-        quantized.
+        core_config (CoreConfig): CoreConfig containing parameters of how the model should be quantized.
         fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g.,
         kernel channels indices, groups of layers by how they should be quantized, etc.)
         tb_w (TensorboardWriter): TensorboardWriter object to use for logging events such as graphs, histograms, etc.
@@ -527,9 +531,13 @@ def _prepare_model_for_quantization(graph: Graph,
         mi.infer(representative_data_gen())
 
     ######################################
-    # Edit network according to user specific settings
+    # Edit network according to user
+    # specific settings
     ######################################
-    edit_network_graph(transformed_graph, fw_info, core_config.debug_config.network_editor)
+    # Notice that not all actions affect at this stage (for example, actions that edit the final configuration as
+    # there are no final configurations at this stage of the optimization). For this reason we edit the graph
+    # again at the end of the optimization process.
+    transformed_graph = edit_network_graph(transformed_graph, fw_info, core_config.debug_config.network_editor)
 
     ######################################
     # Calculate quantization params

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import numpy as np
+import tensorflow as tf
+from keras.engine.input_layer import InputLayer
+
+from model_compression_toolkit import QuantizationErrorMethod, QuantizationConfig
+from model_compression_toolkit.common.network_editors.actions import EditRule, ChangeFinalWeightsQuantConfigAttr, \
+    ChangeFinalActivationQuantConfigAttr, ChangeCandidatesActivationQuantConfigAttr
+from model_compression_toolkit.common.network_editors.node_filters import NodeTypeFilter
+from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+
+keras = tf.keras
+layers = keras.layers
+
+
+class ChangeFinalWeightQCAttrTest(BaseKerasFeatureNetworkTest):
+
+    def get_network_editor(self):
+        return [EditRule(filter=NodeTypeFilter(layers.Conv2D),
+                         action=ChangeFinalWeightsQuantConfigAttr(weights_bias_correction=False))]
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = layers.Conv2D(3, 4, use_bias=False)(inputs)
+        model = keras.Model(inputs=inputs, outputs=x)
+        return model
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
+        self.unit_test.assertTrue(quantized_model.layers[
+                                      2].bias is None)  # If bias correction is enabled, a bias should be added -
+        # This asserts the editing occured
+
+
+class ChangeFinalActivationQCAttrTest(BaseKerasFeatureNetworkTest):
+
+    def get_network_editor(self):
+        return [EditRule(filter=NodeTypeFilter(layers.Conv2D),
+                         action=ChangeFinalActivationQuantConfigAttr(activation_n_bits=7))]
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = layers.Conv2D(3, 4, use_bias=False)(inputs)
+        model = keras.Model(inputs=inputs, outputs=x)
+        return model
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
+        self.unit_test.assertTrue(quantized_model.layers[3].inbound_nodes[0].call_kwargs['num_bits'] == 7)

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -22,6 +22,8 @@ from tests.keras_tests.feature_networks_tests.feature_networks.bias_correction_d
     BiasCorrectionDepthwiseTest
 from tests.keras_tests.feature_networks_tests.feature_networks.network_editor.edit_error_method_test import \
     EditActivationErrorMethod
+from tests.keras_tests.feature_networks_tests.feature_networks.network_editor.change_qc_attr_test import \
+    ChangeFinalWeightQCAttrTest, ChangeFinalActivationQCAttrTest
 from tests.keras_tests.feature_networks_tests.feature_networks.softmax_shift_test import SoftmaxShiftTest
 from tests.keras_tests.feature_networks_tests.feature_networks.weights_mixed_precision_tests import MixedPercisionBaseTest, \
     MixedPercisionSearchTest, MixedPercisionManuallyConfiguredTest, MixedPercisionDepthwiseTest, \
@@ -95,6 +97,10 @@ class FeatureNetworkTest(unittest.TestCase):
 
     def test_edit_error_method(self):
         EditActivationErrorMethod(self).run_test()
+
+    def test_change_qc_attr(self):
+        ChangeFinalWeightQCAttrTest(self).run_test()
+        ChangeFinalActivationQCAttrTest(self).run_test()
 
     def test_bias_correction_dw(self):
         BiasCorrectionDepthwiseTest(self).run_test()

--- a/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_symmetric_threshold_selection_weights.py
@@ -129,7 +129,6 @@ class TestSymmetricThresholdSelectionWeights(unittest.TestCase):
                                               keras_impl)
         tg = set_bit_widths(core_config.mixed_precision_enable,
                             tg,
-                            fw_info,
                             None)
 
         quantized_model, user_info = _quantize_fixed_bit_widths_graph(False,

--- a/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
+++ b/tests/keras_tests/function_tests/test_uniform_range_selection_weights.py
@@ -132,7 +132,6 @@ class TestUniformRangeSelectionWeights(unittest.TestCase):
                                               keras_impl)
         tg = set_bit_widths(core_config.mixed_precision_enable,
                             tg,
-                            fw_info,
                             None)
 
         quantized_model, user_info = _quantize_fixed_bit_widths_graph(False,


### PR DESCRIPTION
Some actions regard the final quantization configuration do not
affect the network as the editing is done at the beggining of the
optimization process. This commits fix this by editing the network
one more time after finalizing the quantization configurations.