### PR TITLE
Add new fusions to default TPC and fix issue in fusion algorithm

### DIFF
--- a/model_compression_toolkit/common/fusion/layer_fusing.py
+++ b/model_compression_toolkit/common/fusion/layer_fusing.py
@@ -63,9 +63,9 @@ def is_valid_fusion(fusing_patterns: List[List[Any]], nodes: List[BaseNode]) -> 
     return False
 
 
-def mark_fusing_activation(nodes: List[BaseNode]):
+def disable_nodes_activation_quantization(nodes: List[BaseNode]):
     """
-    Mark activation for non-quantization needed due to fusion
+    Disable activation for non-quantization needed due to fusion
     Args:
         nodes: nodes to update their activation quantization
     """
@@ -121,7 +121,7 @@ def fusion(graph: Graph, tpc: TargetPlatformCapabilities) -> Graph:
         # New fusion: mark all nodes in the fusion except last one
         if is_valid_fusion(fusing_patterns, fusing_nodes):
             fused_nodes.extend(fusing_nodes)
-            mark_fusing_activation(fusing_nodes[:-1])
+            disable_nodes_activation_quantization(fusing_nodes[:-1])
             fused_graph.user_info.add_fusion(fusing_nodes)
 
     return fused_graph

--- a/model_compression_toolkit/common/fusion/layer_fusing.py
+++ b/model_compression_toolkit/common/fusion/layer_fusing.py
@@ -39,6 +39,30 @@ def filter_fusing_patterns(fusing_patterns: List[List[Any]], node: BaseNode, idx
     return valid_fusing_patterns
 
 
+def is_valid_fusion(fusing_patterns: List[List[Any]], nodes: List[BaseNode]) -> bool:
+    """
+    Check if the fusion is valid: exist in fusing_patterns
+    Args:
+        fusing_patterns: supported fusings
+        nodes: nodes which are participating in fusion
+    Returns:
+        whether the fusion in valid
+    """
+    fusion_depth = len(nodes)
+    if fusion_depth <= 1:
+        return False
+    for fusing_pattern in fusing_patterns:
+        if fusion_depth != len(fusing_pattern):
+            continue
+        counter = 0
+        for i,layer in enumerate(fusing_pattern):
+            if (type(layer) == LayerFilterParams and layer.match(nodes[i])) or layer == nodes[i].type:
+                counter += 1
+        if counter == fusion_depth:
+            return True
+    return False
+
+
 def mark_fusing_activation(nodes: List[BaseNode]):
     """
     Mark activation for non-quantization needed due to fusion
@@ -94,10 +118,9 @@ def fusion(graph: Graph, tpc: TargetPlatformCapabilities) -> Graph:
             if len(next_nodes) != 1:  # Give up if node has more than one connection (not supported for fusion)
                 break
 
-        fused_nodes.extend(fusing_nodes)
-
         # New fusion: mark all nodes in the fusion except last one
-        if len(fusing_nodes) > 1:
+        if is_valid_fusion(fusing_patterns, fusing_nodes):
+            fused_nodes.extend(fusing_nodes)
             mark_fusing_activation(fusing_nodes[:-1])
             fused_graph.user_info.add_fusion(fusing_nodes)
 

--- a/model_compression_toolkit/common/target_platform/targetplatform2framework/operations_to_layers.py
+++ b/model_compression_toolkit/common/target_platform/targetplatform2framework/operations_to_layers.py
@@ -72,7 +72,7 @@ class OperationsToLayers:
                          op: OperatorsSetBase) -> Any:
         """
         Get list of layers that are associated with an OperatorsSet object.
-        If op is not in OperationsToLayers - return None.
+        If op is not in OperationsToLayers - return an empty list.
 
         Args:
             op: OperatorsSetBase object to get its layers.
@@ -89,7 +89,7 @@ class OperationsToLayers:
                 layers.extend(self.get_layers_by_op(o))
             return layers
         Logger.warning(f'{op.name} is not in model.')
-        return None
+        return []
 
     def __add__(self,
                 op_set_to_layers: OperationsSetToLayers):

--- a/model_compression_toolkit/tpc_models/default_tp_model.py
+++ b/model_compression_toolkit/tpc_models/default_tp_model.py
@@ -136,12 +136,14 @@ def generate_tp_model(default_config: OpQuantizationConfig,
         swish = tpc.OperatorsSet("Swish")
         sigmoid = tpc.OperatorsSet("Sigmoid")
         tanh = tpc.OperatorsSet("Tanh")
+        hardswish = tpc.OperatorsSet("HardSwish")
+        hardsigmoid = tpc.OperatorsSet("HardSigmoid")
 
         # Combine multiple operators into a single operator to avoid quantization between
         # them. To do this we define fusing patterns using the OperatorsSets that were created.
         # To group multiple sets with regard to fusing, an OperatorSetConcat can be created
-        activations_after_conv_to_fuse = tpc.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh)
-        activations_after_fc_to_fuse = tpc.OperatorSetConcat(any_relu, swish, sigmoid)
+        activations_after_conv_to_fuse = tpc.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh, hardswish)
+        activations_after_fc_to_fuse = tpc.OperatorSetConcat(any_relu, swish, sigmoid, hardsigmoid)
 
         tpc.Fusing([conv, activations_after_conv_to_fuse])
         tpc.Fusing([fc, activations_after_fc_to_fuse])

--- a/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
+++ b/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
@@ -93,7 +93,6 @@ def generate_keras_default_tpc(name: str, tp_model: TargetPlatformModel):
         tpc.OperationsSetToLayers("Tanh", [tf.nn.tanh,
                                            tpc.LayerFilterParams(Activation, activation="tanh")])
 
-        tpc.OperationsSetToLayers("HardSwish", [])
 
         tpc.OperationsSetToLayers("HardSigmoid", [hard_sigmoid])
 

--- a/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
+++ b/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
@@ -92,4 +92,9 @@ def generate_keras_default_tpc(name: str, tp_model: TargetPlatformModel):
 
         tpc.OperationsSetToLayers("Tanh", [tf.nn.tanh,
                                            tpc.LayerFilterParams(Activation, activation="tanh")])
+
+        tpc.OperationsSetToLayers("HardSwish", [])
+
+        tpc.OperationsSetToLayers("HardSigmoid", [])
+
     return keras_tpc

--- a/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
+++ b/model_compression_toolkit/tpc_models/keras_tp_models/keras_default.py
@@ -25,7 +25,7 @@ else:
     Dropout, MaxPooling2D, Activation, ReLU, Add, PReLU, Flatten, Cropping2D
 
 from model_compression_toolkit.tpc_models.default_tp_model import get_default_tp_model
-
+from tensorflow.keras.activations import hard_sigmoid
 import model_compression_toolkit as mct
 tpc = mct.target_platform
 
@@ -95,6 +95,6 @@ def generate_keras_default_tpc(name: str, tp_model: TargetPlatformModel):
 
         tpc.OperationsSetToLayers("HardSwish", [])
 
-        tpc.OperationsSetToLayers("HardSigmoid", [])
+        tpc.OperationsSetToLayers("HardSigmoid", [hard_sigmoid])
 
     return keras_tpc

--- a/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py
+++ b/model_compression_toolkit/tpc_models/pytorch_tp_models/pytorch_default.py
@@ -19,8 +19,8 @@ import torch
 from torch import add, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk
 from torch.nn import Conv2d, ConvTranspose2d, Linear, BatchNorm2d
 from torch.nn import Dropout, Flatten, Hardtanh
-from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh
-from torch.nn.functional import relu, relu6, prelu, silu, hardtanh
+from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh, Hardswish, Hardsigmoid
+from torch.nn.functional import relu, relu6, prelu, silu, hardtanh, hardswish, hardsigmoid
 
 from model_compression_toolkit.common.target_platform import TargetPlatformModel
 from model_compression_toolkit.common.target_platform.targetplatform2framework import \
@@ -89,5 +89,11 @@ def generate_pytorch_tpc(name: str, tp_model: TargetPlatformModel):
 
         OperationsSetToLayers("Tanh", [Tanh,
                                        tanh])
+
+        OperationsSetToLayers("HardSwish", [Hardswish,
+                                            hardswish])
+
+        OperationsSetToLayers("HardSigmoid", [Hardsigmoid,
+                                              hardsigmoid])
 
     return pytorch_tpc

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -74,7 +74,7 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
             else:
                 self.unit_test.assertFalse(isinstance(l, Functional) or isinstance(l, Sequential))
         num_layers = 8
-        num_fq_layers = 5
+        num_fq_layers = 7
         self.unit_test.assertTrue(len(quantized_model.layers) == (num_layers+num_fq_layers))
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)


### PR DESCRIPTION
1. Adding some fusions to TPC, relevant to mobilenetv3, pytorch
2. There is a bug that we declare fusion when only some layers from fusion are found and not the whole pattern.
This fix checks the candidate fusion to see if the entire fusion is found.