### PR TITLE
Fix issue in PyTorch visualization similarity analyzer

### DIFF
--- a/model_compression_toolkit/core/common/visualization/nn_visualizer.py
+++ b/model_compression_toolkit/core/common/visualization/nn_visualizer.py
@@ -113,12 +113,12 @@ class NNVisualizer:
             new_inputs.append(np.expand_dims(img, axis=0))
 
         # Get outputs
-        tensors_float = self.float_model(new_inputs)
-        tensors_fxp = self.quantized_model(new_inputs)
+        tensors_float = self.fw_impl.run_model_inference(self.float_model, new_inputs)
+        tensors_fxp = self.fw_impl.run_model_inference(self.quantized_model, new_inputs)
 
         # Compute distance between couples of outputs.
         distance_array = np.asarray(
-            [distance_fn(t_float.numpy(), t_fxp.numpy()) for t_float, t_fxp in zip(tensors_float, tensors_fxp)])
+            [distance_fn(self.fw_impl.to_numpy(t_float), self.fw_impl.to_numpy(t_fxp)) for t_float, t_fxp in zip(tensors_float, tensors_fxp)])
 
         distance_array = convert_to_range(distance_array)
 

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -130,7 +130,7 @@ class KerasImplementation(FrameworkImplementation):
 
     def run_model_inference(self,
                             model: Any,
-                            input_list: List[Any]) -> Tuple[Any]:
+                            input_list: List[Any]) -> Tuple[tf.Tensor]:
         """
         Run the model logic on the given the inputs.
 

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -131,16 +131,18 @@ class PytorchImplementation(FrameworkImplementation):
 
     def run_model_inference(self,
                             model: Any,
-                            input_list: List[Any]) -> Tuple[Any]:
+                            input_list: List[Any]) -> Tuple[torch.Tensor]:
         """
         Run the model logic on the given the inputs.
+
         Args:
             model: Pytorch model.
             input_list: List of inputs for the model.
+
         Returns:
-            The Pytorch model's output in numpy format.
+            The Pytorch model's output.
         """
-        return torch_tensor_to_numpy(model(*to_torch_tensor(input_list)))
+        return model(*to_torch_tensor(input_list))
 
     def shift_negative_correction(self,
                                   graph: Graph,
@@ -148,10 +150,12 @@ class PytorchImplementation(FrameworkImplementation):
                                   fw_info: FrameworkInfo) -> Graph:
         """
         Apply shift negative correction (SNC) on a graph.
+
         Args:
             graph: Graph to apply SNC on.
             core_config: Quantization configuration.
             fw_info: FrameworkInfo object with information about the specific framework's module.
+
         Returns:
             Graph after SNC.
         """


### PR DESCRIPTION
Issue of wrong inference in PyTorch models when analyzing similarity.
Inference should go through FrameworkImplementation method as infernce
are different between PyTorch and Tensorflow. This commit fixes this.