### PR TITLE
Pytorch remove asserts from graph

### DIFF
--- a/model_compression_toolkit/core/pytorch/reader/reader.py
+++ b/model_compression_toolkit/core/pytorch/reader/reader.py
@@ -99,7 +99,8 @@ def remove_broken_nodes_from_graph(graph):
         graph: Networkx MultiDiGraph representing the Pytorch model.
 
     Returns:
-        Networkx MultiDiGraph representing the Pytorch model after removing nodes without output (like assert).
+        Networkx MultiDiGraph representing the Pytorch model after removing nodes without an output
+        (for example: "assert").
 
     """
     output_nodes = [n.node for n in graph.output_nodes]
@@ -109,14 +110,14 @@ def remove_broken_nodes_from_graph(graph):
     for node in nodes_list:
         nodes_to_remove.append(node)
         # iterate over all the relevant nodes
-        while len(nodes_to_remove) >> 0:
+        while len(nodes_to_remove) != 0:
             for node_to_remove in nodes_to_remove:
                 parent_nodes = [edge.source_node for edge in graph.incoming_edges(node_to_remove)]
                 # check all the parent nodes
                 for parent_node in parent_nodes:
-                    # if the parent node connected only to the "broken" node, we'll add the parent node to
+                    # if the parent node is connected only to the "broken" node, we'll add the parent node to
                     # the relevant nodes list
-                    # if the parent node connected to other nodes, we'll only remove the edge
+                    # if the parent node is connected to other nodes, we'll only remove the edge
                     if graph.out_degree(parent_node) == 1:
                         nodes_to_remove.append(parent_node)
                     graph.remove_edge(parent_node, node_to_remove)
@@ -131,8 +132,8 @@ def model_reader(model: torch.nn.Module,
                  to_numpy: Callable,
                  to_tensor: Callable) -> Graph:
     """
-    Reads a Pytorch model, converts it to an FX Graph using the fx toolkit, then builds a base graph representing the
-    fx graph and filter "broken nodes" (like assert).
+    Reads a Pytorch model and converts it to an FX Graph using the fx toolkit. Then, builds a base graph representing
+    the fx graph. Finally, we filter "broken nodes" (nodes without outputs, for example: "assert").
     Args:
         model: Pytorch model to build its graph representation.
         representative_data_gen (Callable): Dataset used for calibration.

--- a/tests/pytorch_tests/model_tests/feature_models/add_net_assert_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/add_net_assert_test.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import torch
+from torch import _assert
+from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
+
+"""
+This tests checks that the assert operation is being removed from the graph during quantization.
+"""
+
+
+class AddAssertNet(torch.nn.Module):
+    def __init__(self):
+        super(AddAssertNet, self).__init__()
+        self.conv1 = torch.nn.Conv2d(3, 4, kernel_size=1, stride=1)
+        self.conv2 = torch.nn.Conv2d(3, 4, kernel_size=1, stride=1)
+
+    def forward(self, x, y):
+        _assert(x.shape == y.shape, "Inputs should have the same shape")
+        x1 = self.conv1(x)
+        assert(x.ndim == 4, f'expected 4D input (got {x.ndim}D input)')
+        x2 = x1 + 3
+        _assert(x2.shape == x1.shape, "Tensors should have the same shape")
+        y = self.conv2(y)
+        return x2 - y, y - x2, x2 + y
+
+
+class AddAssertNetTest(BasePytorchTest):
+    """
+    This tests checks that the assert operation is being removed from the graph during quantization.
+    """
+
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 3, 32, 32], [self.val_batch_size, 3, 32, 32]]
+
+    def create_feature_network(self, input_shape):
+        return AddAssertNet()

--- a/tests/pytorch_tests/model_tests/feature_models/remove_broken_node_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/remove_broken_node_test.py
@@ -1,0 +1,72 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+import torch
+from torch.fx import symbolic_trace
+
+from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
+from model_compression_toolkit.core.pytorch.utils import set_model
+from model_compression_toolkit.core.common.graph.functional_node import FunctionalNode
+
+
+"""
+This tests checks that the "broken" node (node without output) is being removed from the graph during quantization.
+"""
+
+
+class BrokenNet(torch.nn.Module):
+    def __init__(self, const):
+        super(BrokenNet, self).__init__()
+        self.const = const
+
+    def forward(self, x, y):
+        x1 = x + self.const
+        x2 = x + y
+        return x2
+
+
+class BrokenNetTest(BasePytorchTest):
+    """
+    This tests checks that the "broken" node (node without output) is being removed from the graph during quantization.
+    """
+
+    def __init__(self, unit_test, const=3):
+        super().__init__(unit_test)
+        self.const = const
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 3, 32, 32], [self.val_batch_size, 3, 32, 32]]
+
+    def create_feature_network(self, input_shape):
+        return BrokenNet(self.const)
+
+    def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
+        set_model(float_model)
+
+        float_fx_model = symbolic_trace(float_model)
+        float_node_list = list(float_fx_model.graph.nodes)
+
+        # check for the const of the "broken" node in nodes in the float model
+        self.unit_test.assertTrue(np.any([self.const in args for args in [node.args for node in float_node_list]]))
+
+        for model_name, quantized_model in quantized_models.items():
+            set_model(quantized_model)
+
+            quantized_node_list = list(quantized_model.graph.nodes)
+
+            # check for the const of the "broken" node in nodes in the quantized model
+            self.unit_test.assertFalse(np.any(
+                [self.const in args for args in [node.op_call_args for node in quantized_node_list
+                                                 if node.__class__ == FunctionalNode]]))

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -15,7 +15,8 @@
 import unittest
 
 from tests.pytorch_tests.model_tests.feature_models.add_net_test import AddNetTest
-from tests.pytorch_tests.model_tests.feature_models.add_net_assert_test import AddAssertNetTest
+from tests.pytorch_tests.model_tests.feature_models.remove_assert_test import AssertNetTest
+from tests.pytorch_tests.model_tests.feature_models.remove_broken_node_test import BrokenNetTest
 from tests.pytorch_tests.model_tests.feature_models.add_same_test import AddSameNetTest
 from tests.pytorch_tests.model_tests.feature_models.bn_folding_test import BNFoldingNetTest
 from tests.pytorch_tests.model_tests.feature_models.linear_collapsing_test import TwoConv2DCollapsingTest, \
@@ -60,12 +61,12 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         AddNetTest(self).run_test()
 
-    def test_add_assert_net(self):
+    def test_assert_net(self):
         """
         This tests check that the assert operation is being
         removed from the graph during quantization.
         """
-        AddAssertNetTest(self).run_test()
+        AssertNetTest(self).run_test()
 
     def test_add_same(self):
         """
@@ -78,6 +79,13 @@ class FeatureModelsTestRunner(unittest.TestCase):
         This test checks the BatchNorm folding feature, plus adding a residual connection.
         """
         BNFoldingNetTest(self).run_test()
+
+    def test_broken_net(self):
+        """
+        This tests checks that the "broken" node (node without output) is being
+        removed from the graph during quantization.
+        """
+        BrokenNetTest(self).run_test()
 
     def test_linear_collapsing(self):
         """

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -15,6 +15,7 @@
 import unittest
 
 from tests.pytorch_tests.model_tests.feature_models.add_net_test import AddNetTest
+from tests.pytorch_tests.model_tests.feature_models.add_net_assert_test import AddAssertNetTest
 from tests.pytorch_tests.model_tests.feature_models.add_same_test import AddSameNetTest
 from tests.pytorch_tests.model_tests.feature_models.bn_folding_test import BNFoldingNetTest
 from tests.pytorch_tests.model_tests.feature_models.linear_collapsing_test import TwoConv2DCollapsingTest, \
@@ -58,6 +59,13 @@ class FeatureModelsTestRunner(unittest.TestCase):
         Both with different layers and with constants.
         """
         AddNetTest(self).run_test()
+
+    def test_add_assert_net(self):
+        """
+        This tests check that the assert operation is being
+        removed from the graph during quantization.
+        """
+        AddAssertNetTest(self).run_test()
 
     def test_add_same(self):
         """


### PR DESCRIPTION
Remove from Pytorch graph reader nodes without output (like assert)