### PR TITLE
Fixed minor bugs in MP metric calculation 

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation_manager.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation_manager.py
@@ -115,7 +115,7 @@ class SensitivityEvaluationManager:
                                                   compute_distance_fn=self.quant_config.compute_distance_fn)
             for j in range(num_samples):
                 distance_matrix[i, j] = \
-                    point_distance_fn(baseline_tensors[i][j].numpy(), mp_tensors[i][j].numpy(), i)
+                    point_distance_fn(baseline_tensors[i][j].numpy(), mp_tensors[i][j].numpy())
         return distance_matrix
 
     def build_distance_metrix(self):

--- a/model_compression_toolkit/core/common/similarity_analyzer.py
+++ b/model_compression_toolkit/core/common/similarity_analyzer.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import numpy as np
 
+from model_compression_toolkit.core.common.constants import EPS
 
 #########################
 #  Helpful functions
@@ -195,4 +196,6 @@ def compute_kl_divergence(float_tensor: np.ndarray, fxp_tensor: np.ndarray) -> f
     """
 
     validate_before_compute_similarity(float_tensor, fxp_tensor)
-    return np.sum(np.where(float_tensor != 0, float_tensor * np.log(float_tensor / fxp_tensor), 0))
+    non_zero_fxp_tensor = fxp_tensor.copy()
+    non_zero_fxp_tensor[non_zero_fxp_tensor == 0] = EPS
+    return np.sum(np.where(float_tensor != 0, float_tensor * np.log(float_tensor / non_zero_fxp_tensor), 0))

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -374,4 +374,4 @@ class KerasImplementation(FrameworkImplementation):
             return compute_kl_divergence
         elif layer_class == Dense:
             return compute_cs
-        return lambda x, y: compute_mse(x, y, norm=True, norm_eps=1e-8)
+        return lambda x, y: compute_mse(x, y, norm=False, norm_eps=1e-8)

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -343,4 +343,4 @@ class PytorchImplementation(FrameworkImplementation):
             return compute_kl_divergence
         elif layer_class == Linear:
             return compute_cs
-        return lambda x, y: compute_mse(x, y, norm=True, norm_eps=1e-8)
+        return lambda x, y: compute_mse(x, y, norm=False, norm_eps=1e-8)


### PR DESCRIPTION
Fixed minor bugs in MP metric calculation  - added epsilon to division in KL distance function, changed default to MSE (instead of NMSE) and removed unnecessary argument from call to distance computation