### PR TITLE
Mha sub update

### DIFF
--- a/model_compression_toolkit/core/keras/constants.py
+++ b/model_compression_toolkit/core/keras/constants.py
@@ -47,13 +47,17 @@ CHANNELS_FORMAT = 'data_format'
 CHANNELS_FORMAT_FIRST = 'channels_first'
 CHANNELS_FORMAT_LAST = 'channels_last'
 AXES = 'axes'
+AXIS = 'axis'
 DIMS = 'dims'
 TARGET_SHAPE = 'target_shape'
+TRANSPOSE_A = 'transpose_a'
+TRANSPOSE_B = 'transpose_b'
 
 # functional nodes attributes
 FUNCTION = 'function'
 F_RESHAPE = 'reshape'
 F_STRIDED_SLICE = 'strided_slice'
+F_MATMUL = 'matmul'
 F_STACK = 'stack'
 
 # Layers variables names:

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
+import numpy as np
 import tensorflow as tf
 if tf.__version__ < "2.6":
     from tensorflow.python.keras.layers.core import TFOpLambda
 else:
     from keras.layers.core import TFOpLambda
-from tensorflow.keras.layers import MultiHeadAttention, Dense, Softmax, Concatenate, Dot, Reshape, Permute
+from tensorflow.keras.layers import MultiHeadAttention, Conv2D, Softmax, Concatenate, Dot, Reshape, Permute
 
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common.graph.base_graph import Graph, BaseNode, OutTensor
@@ -28,9 +27,9 @@ from model_compression_toolkit.core.common.graph.graph_matchers import NodeOpera
 from model_compression_toolkit.core.common.constants import REUSE, REUSE_GROUP
 from model_compression_toolkit.core.keras.reader.node_builder import REUSED_IDENTIFIER
 from model_compression_toolkit.core.keras.constants import KERNEL, BIAS, USE_BIAS, NUM_HEADS, KEY_DIM, VALUE_DIM, \
-    QUERY_SHAPE, KEY_SHAPE, VALUE_SHAPE, OUTPUT_SHAPE, ATTENTION_AXES, ACTIVATION, LINEAR, UNITS, AXES, \
+    QUERY_SHAPE, KEY_SHAPE, VALUE_SHAPE, OUTPUT_SHAPE, ATTENTION_AXES, ACTIVATION, LINEAR, FILTERS, AXES, \
     FUNCTION, DIMS, TARGET_SHAPE, F_STRIDED_SLICE, F_STACK, Q_KERNEL, Q_BIAS, K_KERNEL, K_BIAS, V_KERNEL, V_BIAS, \
-    OUTPUT_KERNEL, OUTPUT_BIAS
+    OUTPUT_KERNEL, OUTPUT_BIAS, F_MATMUL, TRANSPOSE_B, KERNEL_SIZE, AXIS
 
 
 class MHAParams:
@@ -71,25 +70,26 @@ class MHAParams:
         self.q_reshape_shape = tuple([self.query_shape[0], self.iter_axes_prod, self.q_att_axes_prod, self.query_shape[-1]])
         self.k_reshape_shape = tuple([self.key_shape[0], self.iter_axes_prod, kv_att_axes_prod, self.key_shape[-1]])
         self.v_reshape_shape = tuple([self.value_shape[0], self.iter_axes_prod, kv_att_axes_prod, self.value_shape[-1]])
-        self.q_slice_shape = tuple([self.query_shape[0], self.q_att_axes_prod, self.query_shape[-1]])
-        self.k_slice_shape = tuple([self.key_shape[0], kv_att_axes_prod, self.key_shape[-1]])
-        self.v_slice_shape = tuple([self.value_shape[0], kv_att_axes_prod, self.value_shape[-1]])
-        # projection after splitting the input tensors to number of iterations, so iters axis is removed
-        self.query_proj_shape = self.q_reshape_shape[:1] + self.q_reshape_shape[2:-1] + (self.query_key_dim,)
-        self.key_proj_shape = self.k_reshape_shape[:1] + self.k_reshape_shape[2:-1] + (self.query_key_dim,)
-        self.value_proj_shape = self.v_reshape_shape[:1] + self.v_reshape_shape[2:-1] + (self.value_dim,)
-        self.att_matrix_shape = (self.key_shape[0],) + (self.q_att_axes_prod, kv_att_axes_prod)
-        self.reuse_params = {REUSE: mha_node.reuse, REUSE_GROUP: mha_node.reuse_group}
-        self.concat_shape = (self.query_shape[0],) + (self.q_att_axes_prod, self.value_dim*self.num_heads)
+        self.query_proj_shape = self.q_reshape_shape[:-1] + (self.query_key_dim,)
+        self.key_proj_shape = self.k_reshape_shape[:-1] + (self.query_key_dim,)
+        self.value_proj_shape = self.v_reshape_shape[:-1] + (self.value_dim,)
+        self.q_slice_shape = self.query_proj_shape[0:1] + self.query_proj_shape[2:]
+        self.k_slice_shape = self.key_proj_shape[0:1] + self.key_proj_shape[2:]
+        self.v_slice_shape = self.value_proj_shape[0:1] + self.value_proj_shape[2:]
+        self.att_matrix_shape = self.q_slice_shape[:-1] + self.k_slice_shape[1:2]
+        self.att_output_shape = self.att_matrix_shape[:-1] + self.v_slice_shape[2:3]
+        self.stack_shape = self.att_output_shape[:1] + (self.iter_axes_prod,) + self.att_output_shape[1:]
+        self.concat_shape = self.stack_shape[:-1] + (self.value_dim*self.num_heads,)
         self.output_shape = self.concat_shape[:-1] + (self.d_model,)
-        self.stacked_output_shape = (self.output_shape[0], self.iter_axes_prod) + self.output_shape[1:]
+        # self.stacked_output_shape = (self.output_shape[0], self.iter_axes_prod) + self.output_shape[1:]
+        self.reuse_params = {REUSE: mha_node.reuse, REUSE_GROUP: mha_node.reuse_group}
 
 
 class MultiHeadAttentionDecomposition(common.BaseSubstitution):
     """
     Removes a MultiHeadAttention node from the graph,
-    and replaces it with a compatible graph that consists of Dense,
-     Dot, Softmax and Concatenate layers
+    and replaces it with a compatible graph that consists of Conv2D,
+     matmul, Softmax and Concatenate layers
     """
 
     def __init__(self):
@@ -181,7 +181,7 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
         return '' if reuse_index == 0 or reuse_index is None else f'{REUSED_IDENTIFIER}{reuse_index}'
 
     @staticmethod
-    def _slice_per_iteration(graph, name, i_iter, q_reshape_node, k_reshape_node, v_reshape_node, params):
+    def _slice_per_iteration(graph, name, head_index, i_iter, q_node, k_node, v_node, params):
         """
         Prepare MHA data for attention: Slice inputs on Iters axis.
          [B, Iters, Sequence, Channels] --> [B, Sequence, Channels]
@@ -189,39 +189,75 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
         Args:
             graph: input graph
             name: MHA node name
+            head_index: TODO: add doc
             i_iter: iteration index, from 0..Iters-1
-            q_reshape_node: query input after standardization
-            k_reshape_node: key input after standardization
-            v_reshape_node: value input after standardization
+            q_node: query input after standardization
+            k_node: key input after standardization
+            v_node: value input after standardization
             params: MHA params object
 
         Returns:
             inputs to MHA node, per iteration
         """
-        q_slice_node = FunctionalNode(f'{name}_q_slice{i_iter}', {FUNCTION: F_STRIDED_SLICE},
+        q_slice_node = FunctionalNode(f'{name}_q{head_index}_slice{i_iter}', {FUNCTION: F_STRIDED_SLICE},
                                       params.q_reshape_shape, params.q_slice_shape, {}, TFOpLambda,
                                       op_call_args=[[0, i_iter, 0, 0], [0, i_iter + 1, 0, 0]],
                                       op_call_kwargs={'begin_mask': 13, 'end_mask': 13, 'shrink_axis_mask': 2},
                                       functional_op=tf.strided_slice, **params.reuse_params)
-        graph.add_node_with_in_edges(q_slice_node, [q_reshape_node])
-        k_slice_node = FunctionalNode(f'{name}_k_slice{i_iter}', {FUNCTION: F_STRIDED_SLICE},
+        graph.add_node_with_in_edges(q_slice_node, [q_node])
+        k_slice_node = FunctionalNode(f'{name}_k{head_index}_slice{i_iter}', {FUNCTION: F_STRIDED_SLICE},
                                       params.k_reshape_shape, params.k_slice_shape, {}, TFOpLambda,
                                       op_call_args=[[0, i_iter, 0, 0], [0, i_iter + 1, 0, 0]],
                                       op_call_kwargs={'begin_mask': 13, 'end_mask': 13, 'shrink_axis_mask': 2},
                                       functional_op=tf.strided_slice, **params.reuse_params)
-        graph.add_node_with_in_edges(k_slice_node, [k_reshape_node])
-        v_slice_node = FunctionalNode(f'{name}_v_slice{i_iter}', {FUNCTION: F_STRIDED_SLICE},
+        graph.add_node_with_in_edges(k_slice_node, [k_node])
+        v_slice_node = FunctionalNode(f'{name}_v{head_index}_slice{i_iter}', {FUNCTION: F_STRIDED_SLICE},
                                       params.v_reshape_shape, params.v_slice_shape, {}, TFOpLambda,
                                       op_call_args=[[0, i_iter, 0, 0], [0, i_iter + 1, 0, 0]],
                                       op_call_kwargs={'begin_mask': 13, 'end_mask': 13, 'shrink_axis_mask': 2},
                                       functional_op=tf.strided_slice, **params.reuse_params)
-        graph.add_node_with_in_edges(v_slice_node, [v_reshape_node])
+        graph.add_node_with_in_edges(v_slice_node, [v_node])
 
         return q_slice_node, k_slice_node, v_slice_node
 
-    def _calc_attention_head(self, graph, q_in_node, k_in_node, v_in_node, mha_node,
+    def _project_inputs(self, graph, mha_node, head_index, q_reshape_node, k_reshape_node, v_reshape_node, params):
+        # TODO: add doc
+        # add norm factor to query kernel and bias
+        factor = (params.query_key_dim ** -0.5)
+        qk = mha_node.weights[self._get_weight_by_name(mha_node, Q_KERNEL)][:, head_index, :].copy() * factor
+        kk = mha_node.weights[self._get_weight_by_name(mha_node, K_KERNEL)][:, head_index, :].copy()
+        vk = mha_node.weights[self._get_weight_by_name(mha_node, V_KERNEL)][:, head_index, :].copy()
+        qb = mha_node.weights[self._get_weight_by_name(mha_node, Q_BIAS)][head_index, :].copy() * factor
+        kb = mha_node.weights[self._get_weight_by_name(mha_node, K_BIAS)][head_index, :].copy()
+        vb = mha_node.weights[self._get_weight_by_name(mha_node, V_BIAS)][head_index, :].copy()
+        qk = qk[np.newaxis, np.newaxis, ...]
+        kk = kk[np.newaxis, np.newaxis, ...]
+        vk = vk[np.newaxis, np.newaxis, ...]
+
+        # project query, key & value inputs to query_key_dim, query_key_dim & value_dim respectively
+        query_name = f'{mha_node.name}_query_{head_index}'
+        q_node = BaseNode(query_name, {FILTERS: params.query_key_dim, KERNEL_SIZE: 1, USE_BIAS: params.use_bias,
+                                       ACTIVATION: LINEAR},
+                          params.q_reshape_shape, params.query_proj_shape, {KERNEL: qk, BIAS: qb}, Conv2D,
+                          **params.reuse_params)
+        graph.add_node_with_in_edges(q_node, [q_reshape_node])
+        key_name = f'{mha_node.name}_key_{head_index}'
+        k_node = BaseNode(key_name, {FILTERS: params.query_key_dim, KERNEL_SIZE: 1, USE_BIAS: params.use_bias, ACTIVATION: LINEAR},
+                          params.k_reshape_shape, params.key_proj_shape, {KERNEL: kk, BIAS: kb}, Conv2D,
+                          **params.reuse_params)
+        graph.add_node_with_in_edges(k_node, [k_reshape_node])
+        value_name = f'{mha_node.name}_value_{head_index}'
+        v_node = BaseNode(value_name, {FILTERS: params.value_dim, KERNEL_SIZE: 1, USE_BIAS: params.use_bias, ACTIVATION: LINEAR},
+                          params.v_reshape_shape, params.value_proj_shape, {KERNEL: vk, BIAS: vb}, Conv2D,
+                          **params.reuse_params)
+        graph.add_node_with_in_edges(v_node, [v_reshape_node])
+        return q_node, k_node, v_node
+
+    @staticmethod
+    def _calc_attention_head(graph, q_slice_node, k_slice_node, v_slice_node, mha_node,
                              iter_index, head_index, params):
         """
+        TODO: fix doc
         Generate the attention head subgraph: Dot(softmax(Dot(proj(Q), proj(K))), proj(V))
 
         Args:
@@ -239,61 +275,40 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
 
         """
 
-        # add norm factor to query kernel and bias
-        factor = (params.query_key_dim ** -0.5)
-        qk = mha_node.weights[self._get_weight_by_name(mha_node, Q_KERNEL)][:, head_index, :].copy() * factor
-        kk = mha_node.weights[self._get_weight_by_name(mha_node, K_KERNEL)][:, head_index, :].copy()
-        vk = mha_node.weights[self._get_weight_by_name(mha_node, V_KERNEL)][:, head_index, :].copy()
-        qb = mha_node.weights[self._get_weight_by_name(mha_node, Q_BIAS)][head_index, :].copy() * factor
-        kb = mha_node.weights[self._get_weight_by_name(mha_node, K_BIAS)][head_index, :].copy()
-        vb = mha_node.weights[self._get_weight_by_name(mha_node, V_BIAS)][head_index, :].copy()
-
-        # create new nodes:
-        _reuse_suffix = self.get_reuse_suffix(iter_index)
-        _iter_suffix = f'_{iter_index}' if iter_index else ''
-        # project query, key & value inputs to query_key_dim, query_key_dim & value_dim respectively
-        query_name = f'{mha_node.name}_query_{head_index}' + _reuse_suffix
-        q_node = BaseNode(query_name, {UNITS: params.query_key_dim, USE_BIAS: params.use_bias,
-                                       ACTIVATION: LINEAR},
-                          params.q_slice_shape, params.query_proj_shape, {KERNEL: qk, BIAS: qb}, Dense,
-                          **self.gen_reuse_params(iter_index, query_name, params.reuse_params))
-        graph.add_node_with_in_edges(q_node, [q_in_node])
-        key_name = f'{mha_node.name}_key_{head_index}' + _reuse_suffix
-        k_node = BaseNode(key_name, {UNITS: params.query_key_dim, USE_BIAS: params.use_bias, ACTIVATION: LINEAR},
-                          params.k_slice_shape, params.key_proj_shape, {KERNEL: kk, BIAS: kb}, Dense,
-                          **self.gen_reuse_params(iter_index, key_name, params.reuse_params))
-        graph.add_node_with_in_edges(k_node, [k_in_node])
-        value_name = f'{mha_node.name}_value_{head_index}' + _reuse_suffix
-        v_node = BaseNode(value_name, {UNITS: params.value_dim, USE_BIAS: params.use_bias, ACTIVATION: LINEAR},
-                          params.v_slice_shape, params.value_proj_shape, {KERNEL: vk, BIAS: vb}, Dense,
-                          **self.gen_reuse_params(iter_index, value_name, params.reuse_params))
-        graph.add_node_with_in_edges(v_node, [v_in_node])
-
         # calculate attention matrix:
-        # apply tf.matmul(q, tf.transpose(k, perm=[0, 2, 1]) as layers.Dot(axes=2)([q, k])
-        dot_name = f'{mha_node.name}_dot_{head_index}' + _iter_suffix
-        dot_node = BaseNode(dot_name, {AXES: 2},
-                            (params.query_proj_shape, params.key_proj_shape), params.att_matrix_shape,
-                            {}, Dot, **params.reuse_params)
-        graph.add_node_with_in_edges(dot_node, [q_node, k_node])
+        matmul_node = FunctionalNode(f'{mha_node.name}_qk{head_index}_matmul{iter_index}', {FUNCTION: F_MATMUL},
+                                     (params.q_slice_shape, params.k_slice_shape), params.att_matrix_shape, {},
+                                     TFOpLambda, op_call_args=[], op_call_kwargs={TRANSPOSE_B: True},
+                                     functional_op=tf.matmul, **params.reuse_params)
+        graph.add_node_with_in_edges(matmul_node, [q_slice_node, k_slice_node])
 
         # apply softmax on attention matrix
-        softmax_name = f'{mha_node.name}_softmax_{head_index}' + _iter_suffix
+        softmax_name = f'{mha_node.name}_softmax{head_index}_{iter_index}'
         softmax_node = BaseNode(softmax_name, {},
                                 params.att_matrix_shape, params.att_matrix_shape,
                                 {}, Softmax, **params.reuse_params)
-        graph.add_node_with_in_edges(softmax_node, [dot_node])
+        graph.add_node_with_in_edges(softmax_node, [matmul_node])
 
-        dotv_name = f'{mha_node.name}_dotv_{head_index}' + _iter_suffix
-        dotv_node = BaseNode(dotv_name, {AXES: (2, 1)},
-                             (params.att_matrix_shape, params.value_proj_shape), params.value_proj_shape,
-                             {}, Dot, **params.reuse_params)
-        graph.add_node_with_in_edges(dotv_node, [softmax_node, v_node])
-
-        return dotv_node
+        # multiply attention matrix with projected values
+        matmulv_node = FunctionalNode(f'{mha_node.name}_v{head_index}_matmul{iter_index}', {FUNCTION: F_MATMUL},
+                                      (params.att_matrix_shape, params.v_slice_shape), params.att_output_shape,
+                                      {}, TFOpLambda, op_call_args=[], op_call_kwargs={},
+                                      functional_op=tf.matmul, **params.reuse_params)
+        graph.add_node_with_in_edges(matmulv_node, [softmax_node, v_slice_node])
+        return matmulv_node
 
     @staticmethod
-    def _concat_heads(graph, name, input_nodes, iter_index, params):
+    def _stack_iters(graph, name, input_nodes, head_index, params):
+        # TODO: acc doc
+        output_stacked = FunctionalNode(f'{name}_stack{head_index}', {FUNCTION: F_STACK},
+                                        tuple([n.output_shape for n in input_nodes]), params.stack_shape, {},
+                                        TFOpLambda, op_call_args=[], op_call_kwargs={AXIS: 1},
+                                        functional_op=tf.stack, inputs_as_list=True, **params.reuse_params)
+        graph.add_node_with_in_edges(output_stacked, input_nodes)
+        return output_stacked
+
+    @staticmethod
+    def _concat_heads(graph, name, input_nodes, params):
         """
         concatenate attention heads
         Args:
@@ -306,13 +321,14 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
         Returns: concat node
 
         """
-        concat_node = BaseNode(f'{name}_concat_{iter_index}', {},
-                               (params.value_proj_shape,)*params.num_heads, params.concat_shape, {}, Concatenate,
+        concat_node = BaseNode(f'{name}_concat_heads', {},
+                               tuple([n.output_shape for n in input_nodes]), params.concat_shape, {}, Concatenate,
                                **params.reuse_params)
         graph.add_node_with_in_edges(concat_node, input_nodes)
+
         return concat_node
 
-    def _project_output(self, graph, mha_node, input_node, iter_index, params):
+    def _project_output(self, graph, mha_node, input_node, params):
         """
         project all attention outputs (after concatenation)
         Args:
@@ -325,14 +341,14 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
         Returns:
             output node of the MHA node
         """
-        w_out = mha_node.weights[self._get_weight_by_name(mha_node, OUTPUT_KERNEL)].copy().reshape((-1, params.d_model))
+        w_out = mha_node.weights[self._get_weight_by_name(mha_node, OUTPUT_KERNEL)].copy().reshape((1, 1, -1, params.d_model))
         b_out = mha_node.weights[self._get_weight_by_name(mha_node, OUTPUT_BIAS)].copy()
-        proj_output_name = f'{mha_node.name}_output_dense' + self.get_reuse_suffix(iter_index)
-        output_dense = BaseNode(proj_output_name, {UNITS: params.d_model, USE_BIAS: params.use_bias, ACTIVATION: LINEAR},
-                                params.concat_shape, params.output_shape, {KERNEL: w_out, BIAS: b_out}, Dense,
-                                **self.gen_reuse_params(iter_index, proj_output_name, params.reuse_params))
-        graph.add_node_with_in_edges(output_dense, [input_node])
-        return output_dense
+        proj_output_name = f'{mha_node.name}_output_conv1x1'
+        output = BaseNode(proj_output_name, {FILTERS: params.d_model, KERNEL_SIZE: 1, USE_BIAS: params.use_bias, ACTIVATION: LINEAR},
+                                params.concat_shape, params.output_shape, {KERNEL: w_out, BIAS: b_out}, Conv2D,
+                                **params.reuse_params)
+        graph.add_node_with_in_edges(output, [input_node])
+        return output
 
     @staticmethod
     def _destandarize_output_shapes(graph, name, output_node, params):
@@ -349,7 +365,7 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
         """
 
         output_reshape_node = BaseNode(f'{name}_output_reshape', {TARGET_SHAPE: params.q_perm_shape[1:-1] + (params.d_model,)},
-                                       params.stacked_output_shape, params.q_perm_shape[:-1] + (params.d_model,), {},
+                                       params.output_shape, params.q_perm_shape[:-1] + (params.d_model,), {},
                                        Reshape, **params.reuse_params)
         graph.add_node_with_in_edges(output_reshape_node, [output_node])
         output_permute_node = BaseNode(f'{name}_output_permute', {DIMS: params.output_perm_dims[1:]},
@@ -420,33 +436,31 @@ class MultiHeadAttentionDecomposition(common.BaseSubstitution):
         q_reshape_node, k_reshape_node, v_reshape_node = \
             self._standarize_input_shapes(graph, mha_node.name, len(mha_in_edges), params)
 
-        # Generate nodes for attention heads:
-        proj_outputs = []
-        for i_iter in range(params.iter_axes_prod):
-            q_slice_node, k_slice_node, v_slice_node = self._slice_per_iteration(graph, mha_node.name, i_iter,
-                                                                                 q_reshape_node, k_reshape_node, v_reshape_node,
-                                                                                 params)
+        head_outputs = []
+        for head_index in range(params.num_heads):
+            q_node, k_node, v_node = self._project_inputs(graph, mha_node, head_index,
+                                                          q_reshape_node, k_reshape_node, v_reshape_node, params)
 
-            att_head_output_nodes = []
-            for head_index in range(params.num_heads):
-                iter_for_att = None if params.iter_axes_prod == 1 else i_iter
-                dotv_node = self._calc_attention_head(graph, q_slice_node, k_slice_node, v_slice_node,
-                                                      mha_node, iter_for_att, head_index, params)
-                att_head_output_nodes.append(dotv_node)
+            att_outputs = []
+            for i_iter in range(params.iter_axes_prod):
+                q_slice_node, k_slice_node, v_slice_node = self._slice_per_iteration(graph, mha_node.name, head_index, i_iter,
+                                                                                     q_node, k_node, v_node,
+                                                                                     params)
 
-            # concatenate all attention heads
-            concat_node = self._concat_heads(graph, mha_node.name, att_head_output_nodes, i_iter, params)
+                matmulv_node = self._calc_attention_head(graph, q_slice_node, k_slice_node, v_slice_node, mha_node,
+                                                         i_iter, head_index, params)
 
-            # project output
-            proj_outputs.append(self._project_output(graph, mha_node, concat_node, i_iter, params))
+                att_outputs.append(matmulv_node)
 
-        output_dense = FunctionalNode(f'{mha_node.name}_stack', {FUNCTION: F_STACK},
-                                      (params.output_shape,)*params.iter_axes_prod, params.stacked_output_shape, {},
-                                      TFOpLambda, op_call_args=[], op_call_kwargs={'axis': 1},
-                                      functional_op=tf.stack, inputs_as_list=True, **params.reuse_params)
-        graph.add_node_with_in_edges(output_dense, proj_outputs)
+            output_stacked = self._stack_iters(graph, mha_node.name, att_outputs, head_index, params)
+            head_outputs.append(output_stacked)
+
+        concat_node = self._concat_heads(graph, mha_node.name, head_outputs, params)
+
+        output = self._project_output(graph, mha_node, concat_node, params)
+
         # re-order output to match MHA node output (reshape+permute)
-        output_permute_node = self._destandarize_output_shapes(graph, mha_node.name, output_dense, params)
+        output_permute_node = self._destandarize_output_shapes(graph, mha_node.name, output, params)
 
         # connect edges to new nodes
         self._connect_to_graph(graph, mha_node, q_permute_node, k_permute_node, v_permute_node, output_permute_node)


### PR DESCRIPTION
Replace layers.Dot & layers.Dense with tf.matmul & layers.Conv2D (1x1) in MHA decomposition substitution
Removes the need to reuse Dense nodes when MHA iteration is required