### PR TITLE
Fix pytorch builder for getattr and add unbind to non-quant list

### DIFF
--- a/model_compression_toolkit/core/pytorch/reader/graph_builders.py
+++ b/model_compression_toolkit/core/pytorch/reader/graph_builders.py
@@ -86,6 +86,11 @@ def nodes_builder(model: GraphModule,
                 framework_attr[BIAS] = False if node_module.bias is None else True
         elif node.op == CALL_FUNCTION:
             node_type = node.target
+            if node_type == getattr:
+                node_has_activation = False
+                common.Logger.warning(
+                    'Pytorch model has a parameter or constant Tensor value. This can cause unexpected behaviour when '
+                    'converting the model.')
         elif node.op == PLACEHOLDER:
             node_type = DummyPlaceHolder
         elif node.op == OUTPUT:

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3/tpc_pytorch.py
@@ -16,7 +16,7 @@
 import operator
 
 import torch
-from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk
+from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind
 from torch.nn import Conv2d, Linear, BatchNorm2d
 from torch.nn import Dropout, Flatten, Hardtanh
 from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh, Hardswish
@@ -60,6 +60,7 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     unsqueeze,
                                                     BatchNorm2d,
                                                     chunk,
+                                                    unbind,
                                                     torch.Tensor.size])
 
         tp.OperationsSetToLayers("Conv", [Conv2d])


### PR DESCRIPTION
1. Fix getattr operation in pytorch graph builder
2. Add unbind (pytorch) to non-quantization TPC list