### PR TITLE
Separate GPTQ from model builder

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -18,7 +18,7 @@ from typing import Callable, Any, List, Tuple, Type, Dict
 import numpy as np
 
 from model_compression_toolkit.core import common
-from model_compression_toolkit import GradientPTQConfig, MixedPrecisionQuantizationConfigV2
+from model_compression_toolkit import MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.core.common import BaseNode
 from model_compression_toolkit.core.common.collectors.statistics_collector import BaseStatsCollector
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo
@@ -94,7 +94,7 @@ class FrameworkImplementation(ABC):
                       mode: ModelBuilderMode,
                       append2output: List[Any],
                       fw_info: FrameworkInfo,
-                      gptq_config: GradientPTQConfig) -> Tuple[Any, UserInformation]:
+                      return_float_outputs: bool = False) -> Tuple[Any, UserInformation]:
         """
         Build a framework model from a graph.
         The mode determines how the model should be build. append2output is a list of Nodes
@@ -105,7 +105,7 @@ class FrameworkImplementation(ABC):
             mode: Mode for how to build the model.
             append2output: List of Nodes to set as the model's outputs.
             fw_info: FrameworkInfo object with information about the specific framework's model
-            gptq_config: GPTQ configuration class
+            return_float_outputs (bool): whether to return outputs before or after quantization nodes (default)
 
         Returns:
             A tuple of the model that was built and an UserInformation object.

--- a/model_compression_toolkit/core/common/model_builder_mode.py
+++ b/model_compression_toolkit/core/common/model_builder_mode.py
@@ -23,12 +23,9 @@ class ModelBuilderMode(Enum):
     in the graph.
     QUANTIZED - Build a quantized model using the nodes' quantization attributes for adding
     quantization nodes to the model.
-    GPTQ - Build a quantized model using the nodes' quantization attributes for wrapping
-    layers with QuantizeWrapper and output comparing points.
     MIXEDPRECISION - Build a quantized model where the layers that their weights should be quantized
     can use different quantized weights according to the possible bitwidths of each layer.
     """
     FLOAT = 0
     QUANTIZED = 1
-    GPTQ = 2
-    MIXEDPRECISION = 3
+    MIXEDPRECISION = 2

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -16,8 +16,7 @@ if tf.__version__ < "2.6":
 else:
     from keras.layers import Dense, Activation, Conv2D, DepthwiseConv2D, Conv2DTranspose, Concatenate, Add
 
-from model_compression_toolkit import QuantizationConfig, FrameworkInfo, GradientPTQConfig, \
-    CoreConfig, MixedPrecisionQuantizationConfigV2
+from model_compression_toolkit import QuantizationConfig, FrameworkInfo, CoreConfig, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common import Graph, BaseNode
 from model_compression_toolkit.core.common.collectors.statistics_collector import BaseStatsCollector
@@ -118,7 +117,7 @@ class KerasImplementation(FrameworkImplementation):
                       mode: ModelBuilderMode,
                       append2output: List[Any] = None,
                       fw_info: FrameworkInfo = DEFAULT_KERAS_INFO,
-                      gptq_config: GradientPTQConfig = None) -> Tuple[Model, UserInformation]:
+                      return_float_outputs: bool = False) -> Tuple[Model, UserInformation]:
         """
         Build a Keras model from a graph.
         The mode determines how the model should be build. append2output is a list of Nodes
@@ -129,7 +128,7 @@ class KerasImplementation(FrameworkImplementation):
             mode: Mode for how to build the model.
             append2output: List of Nodes to set as the model's outputs.
             fw_info: FrameworkInfo object with information about the specific framework's model
-            gptq_config: GPTQ configuration class
+            return_float_outputs (bool): whether to return outputs before or after quantization nodes (default)
         Returns:
             A tuple of the Keras model that was built and an UserInformation object.
         """
@@ -137,7 +136,7 @@ class KerasImplementation(FrameworkImplementation):
                              mode,
                              append2output,
                              fw_info,
-                             gptq_config)
+                             return_float_outputs=return_float_outputs)
 
     def run_model_inference(self,
                             model: Any,

--- a/model_compression_toolkit/core/keras/quantization_facade.py
+++ b/model_compression_toolkit/core/keras/quantization_facade.py
@@ -24,7 +24,6 @@ from model_compression_toolkit.core.common.framework_info import FrameworkInfo
 from model_compression_toolkit.core.common.network_editors.actions import EditRule
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
     MixedPrecisionQuantizationConfig, DEFAULT_MIXEDPRECISION_CONFIG
-from model_compression_toolkit.core.common.post_training_quantization import post_training_quantization
 from model_compression_toolkit.core.common.quantization.quantization_config import QuantizationConfig
 from model_compression_toolkit.core.common.quantization.core_config import CoreConfig
 from model_compression_toolkit.core.common.quantization.debug_config import DebugConfig
@@ -42,6 +41,7 @@ if importlib.util.find_spec("tensorflow") is not None\
     from model_compression_toolkit.core.keras.keras_model_validation import KerasModelValidation
     from tensorflow.keras.models import Model
     from model_compression_toolkit.core.keras.constants import DEFAULT_TP_MODEL
+    from model_compression_toolkit.core.common.post_training_quantization import post_training_quantization
 
     from model_compression_toolkit import get_target_platform_capabilities
     DEFAULT_KERAS_TPC = get_target_platform_capabilities(TENSORFLOW, DEFAULT_TP_MODEL)

--- a/model_compression_toolkit/core/pytorch/back2framework/model_builder.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/model_builder.py
@@ -209,7 +209,7 @@ def model_builder(graph: common.Graph,
                   mode: ModelBuilderMode = ModelBuilderMode.QUANTIZED,
                   append2output: List[Any] = None,
                   fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
-                  gptq_config: GradientPTQConfig = None) -> Tuple[torch.nn.Module, Any]:
+                  return_float_outputs: bool = False) -> Tuple[torch.nn.Module, Any]:
     """
     Build a Pytorch model from a graph representing the model.
     The model is built by converting the graph nodes to torch modules and initializing a PytorchModelBuilder class.
@@ -220,10 +220,13 @@ def model_builder(graph: common.Graph,
         append2output: List of nodes or OutTensor objects. In float building mode,
         when the list contains nodes, all output tensors of all nodes are set as the model outputs.
         fw_info: Framework information (e.g., mapping from layers to their attributes to quantize).
-        gptq_config: GPTQ Configuration class.
+        return_float_outputs (bool): whether to return outputs before or after quantization nodes (default)
     Returns:
         A tuple of the model, and an UserInformation object.
     """
+
+    if return_float_outputs:
+        raise Exception("Running PyTorch model builder with return_float_outputs=True isn't supported yet")
 
     model = PytorchModelBuilder(graph, mode, append2output, fw_info)
 

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -114,7 +114,7 @@ class PytorchImplementation(FrameworkImplementation):
                       mode: ModelBuilderMode,
                       append2output: List[Any] = None,
                       fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
-                      gptq_config: GradientPTQConfig = None) -> Tuple[Module, UserInformation]:
+                      return_float_outputs: bool = False) -> Tuple[Module, UserInformation]:
         """
         Build a Pytorch module from a graph.
         The mode determines how the module should be build. append2output is a list of Nodes
@@ -124,7 +124,7 @@ class PytorchImplementation(FrameworkImplementation):
             mode: Mode for how to build the module.
             append2output: List of Nodes to set as the module's outputs.
             fw_info: FrameworkInfo object with information about the specific framework's module
-            gptq_config: GPTQ configuration class
+            return_float_outputs (bool): whether to return outputs before or after quantization nodes (default)
         Returns:
             A tuple of the Pytorch module that was built and an UserInformation object.
         """
@@ -132,7 +132,7 @@ class PytorchImplementation(FrameworkImplementation):
                              mode,
                              append2output,
                              fw_info,
-                             gptq_config)
+                             return_float_outputs)
 
     def run_model_inference(self,
                             model: Any,

--- a/model_compression_toolkit/gptq/common/gptq_training.py
+++ b/model_compression_toolkit/gptq/common/gptq_training.py
@@ -20,7 +20,6 @@ from model_compression_toolkit.core.common.framework_info import FrameworkInfo
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
 from model_compression_toolkit.gptq.common.gptq_graph import get_compare_points
 from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
-from model_compression_toolkit.gptq.keras.model_builder import model_builder as gptq_model_builder
 
 
 class GPTQTrainer(ABC):
@@ -60,13 +59,19 @@ class GPTQTrainer(ABC):
         self.float_model, self.float_user_info = fw_impl.model_builder(self.graph_float,
                                                                        mode=ModelBuilderMode.FLOAT,
                                                                        append2output=self.compare_points,
-                                                                       fw_info=fw_info)
+                                                                       fw_info=self.fw_info)
 
-        self.fxp_model, self.gptq_user_info = gptq_model_builder(self.graph_quant,
-                                                                 gptq_config,
-                                                                 mode=ModelBuilderMode.QUANTIZED,
-                                                                 append2output=self.compare_points,
-                                                                 fw_info=fw_info)
+        self.fxp_model, self.gptq_user_info = self.build_gptq_model()
+
+    @abstractmethod
+    def build_gptq_model(self):
+        """
+        Build the GPTQ model with QuantizationWrappers
+        Returns:
+            Quantized graph for GPTQ fine-tuning, GPTQ graph user info
+        """
+        raise NotImplemented(f'{self.__class__.__name__} have to implement the '
+                             f'framework\'s GPTQ model builder method.')
 
     @abstractmethod
     def train(self, representative_data_gen: Callable):

--- a/model_compression_toolkit/gptq/common/gptq_training.py
+++ b/model_compression_toolkit/gptq/common/gptq_training.py
@@ -20,6 +20,7 @@ from model_compression_toolkit.core.common.framework_info import FrameworkInfo
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
 from model_compression_toolkit.gptq.common.gptq_graph import get_compare_points
 from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
+from model_compression_toolkit.gptq.keras.model_builder import model_builder as gptq_model_builder
 
 
 class GPTQTrainer(ABC):
@@ -61,11 +62,11 @@ class GPTQTrainer(ABC):
                                                                        append2output=self.compare_points,
                                                                        fw_info=fw_info)
 
-        self.fxp_model, self.gptq_user_info = fw_impl.model_builder(self.graph_quant,
-                                                                    mode=ModelBuilderMode.GPTQ,
-                                                                    append2output=self.compare_points,
-                                                                    fw_info=fw_info,
-                                                                    gptq_config=gptq_config)
+        self.fxp_model, self.gptq_user_info = gptq_model_builder(self.graph_quant,
+                                                                 gptq_config,
+                                                                 mode=ModelBuilderMode.QUANTIZED,
+                                                                 append2output=self.compare_points,
+                                                                 fw_info=fw_info)
 
     @abstractmethod
     def train(self, representative_data_gen: Callable):
@@ -104,6 +105,10 @@ def gptq_training(graph_float: Graph,
         representative_data_gen: Dataset to use for inputs of the models.
         fw_impl: Framework implementation
         fw_info: Framework information
+
+    Returns:
+        Quantized graph for export
+
     """
     # Get GPTQ object and initialize it
     gptq_trainer_obj = fw_impl.get_gptq_trainer_obj()

--- a/model_compression_toolkit/gptq/keras/gptq_training.py
+++ b/model_compression_toolkit/gptq/keras/gptq_training.py
@@ -34,6 +34,8 @@ import numpy as np
 import copy
 from model_compression_toolkit.core.keras.constants import BIAS, USE_BIAS
 from model_compression_toolkit.gptq.keras.quantizer import WeightQuantizeConfig
+from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
+from model_compression_toolkit.gptq.keras.model_builder import model_builder as gptq_model_builder
 
 
 class KerasGPTQTrainer(GPTQTrainer):
@@ -77,6 +79,18 @@ class KerasGPTQTrainer(GPTQTrainer):
             common.Logger.error("Input scale mismatch between float and GPTQ networks")  # pragma: no cover
         else:
             self.input_scale = self.gptq_user_info.input_scale
+
+    def build_gptq_model(self):
+        """
+        Build the GPTQ model with QuantizationWrappers
+        Returns:
+            Quantized graph for GPTQ fine-tuning, GPTQ graph user info
+        """
+        return gptq_model_builder(self.graph_quant,
+                                  self.gptq_config,
+                                  mode=ModelBuilderMode.QUANTIZED,
+                                  append2output=self.compare_points,
+                                  fw_info=self.fw_info)
 
     def train(self, representative_data_gen: Callable):
         """

--- a/model_compression_toolkit/gptq/keras/model_builder.py
+++ b/model_compression_toolkit/gptq/keras/model_builder.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import tensorflow as tf
+
+from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
+from tensorflow_model_optimization.python.core.quantization.keras.quantize_wrapper import QuantizeWrapper
+from typing import Tuple, Any
+from model_compression_toolkit.core.common.logger import Logger
+from model_compression_toolkit.core import common
+from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig
+from model_compression_toolkit.core.common.framework_info import FrameworkInfo
+from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
+from model_compression_toolkit.gptq.keras.quantizer.config_factory import quantization_config_builder_gptq
+from model_compression_toolkit.core.keras.back2framework.model_builder import get_node_name_from_layer, \
+    is_layer_fake_quant
+from model_compression_toolkit.core.keras.back2framework.model_builder import model_builder as core_model_builder
+
+
+def model_builder(graph: common.Graph,
+                  gptq_config: GradientPTQConfig,
+                  mode: ModelBuilderMode = ModelBuilderMode.QUANTIZED,
+                  append2output=None,
+                  fw_info: FrameworkInfo = DEFAULT_KERAS_INFO) -> Tuple[tf.keras.models.Model, Any]:
+    """
+    Build a Keras model for GPTQ from a graph representing the model.
+    The model is built by converting the graph nodes to Keras layers and applying them sequentially to get the model
+    output tensors. The output tensors list and an input tensors list, then use to build the model.
+    After the model is built in Keras, it is cloned to add quantization wrappers for GPTQ fine-tuning
+
+    Args:
+        graph: Graph to build its corresponding Keras model.
+        gptq_config: GPTQ Configuration class.
+        mode: Building mode. Read ModelBuilderMode description for more info.
+        append2output: List of nodes or OutTensor objects. In float building mode,
+        when the list contains nodes, all output tensors of all nodes are set as the model outputs.
+        fw_info: Framework information (e.g., mapping from layers to their attributes to quantize).
+        This is for passing the kernel attributes to the QuanteWrappers.
+
+    Returns:
+        A tuple of the model and an UserInformation object.
+    """
+    if gptq_config is None:
+        Logger.exception("Building a model in GPTQ requires a GPTQ configuration as input")
+
+    model, graph_user_info = core_model_builder(graph, mode, append2output, fw_info, return_float_outputs=True)
+
+    def _quantize(layer):
+        nodes = graph.find_node_by_name(get_node_name_from_layer(layer))
+        if len(nodes) == 1:
+            node = nodes[0]
+            return QuantizeWrapper(layer, quantization_config_builder_gptq(node, fw_info, gptq_config))
+        elif is_layer_fake_quant(layer):
+            return layer
+        else:
+            raise Exception(
+                f"Mismatch between keras model and graph can't find node named: {get_node_name_from_layer(layer)}")
+
+    # clone each layer in the model and apply _quantize to the layer.
+    model = tf.keras.models.clone_model(model, input_tensors=None, clone_function=_quantize)
+
+    return model, graph_user_info


### PR DESCRIPTION
Separate GPTQ code in model builder to s separate model builder in GPTQ. the GPTQ model builder first calls the core model builder, and then adds the GPTQ QuantizationWrappers