### PR TITLE
Fix irrelevant TPC logs

### DIFF
--- a/model_compression_toolkit/core/tpc_models/default_tpc/v2/tp_model.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v2/tp_model.py
@@ -119,12 +119,11 @@ def generate_tp_model(default_config: OpQuantizationConfig,
         swish = tp.OperatorsSet("Swish")
         sigmoid = tp.OperatorsSet("Sigmoid")
         tanh = tp.OperatorsSet("Tanh")
-        hardswish = tp.OperatorsSet("HardSwish")
 
         # Combine multiple operators into a single operator to avoid quantization between
         # them. To do this we define fusing patterns using the OperatorsSets that were created.
         # To group multiple sets with regard to fusing, an OperatorSetConcat can be created
-        activations_after_conv_to_fuse = tp.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh, hardswish)
+        activations_after_conv_to_fuse = tp.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh)
         activations_after_fc_to_fuse = tp.OperatorSetConcat(any_relu, tanh, sigmoid)
 
         # ------------------- #

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v2/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v2/tpc_pytorch.py
@@ -72,9 +72,8 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                              tp.LayerFilterParams(Hardtanh, min_val=0),
                                              tp.LayerFilterParams(hardtanh, min_val=0)])
         tp.OperationsSetToLayers("PReLU", [PReLU, prelu])
-        tp.OperationsSetToLayers("Swish", [SiLU, silu])
+        tp.OperationsSetToLayers("Swish", [SiLU, silu, Hardswish, hardswish])
         tp.OperationsSetToLayers("Sigmoid", [Sigmoid, sigmoid])
         tp.OperationsSetToLayers("Tanh", [Tanh, tanh])
-        tp.OperationsSetToLayers("HardSwish", [Hardswish, hardswish])
 
     return pytorch_tpc

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3/tp_model.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3/tp_model.py
@@ -138,12 +138,11 @@ def generate_tp_model(default_config: OpQuantizationConfig,
         swish = tp.OperatorsSet("Swish")
         sigmoid = tp.OperatorsSet("Sigmoid")
         tanh = tp.OperatorsSet("Tanh")
-        hardswish = tp.OperatorsSet("HardSwish")
 
         # Combine multiple operators into a single operator to avoid quantization between
         # them. To do this we define fusing patterns using the OperatorsSets that were created.
         # To group multiple sets with regard to fusing, an OperatorSetConcat can be created
-        activations_after_conv_to_fuse = tp.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh, hardswish)
+        activations_after_conv_to_fuse = tp.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh)
         activations_after_fc_to_fuse = tp.OperatorSetConcat(any_relu, swish, sigmoid)
         any_binary = tp.OperatorSetConcat(add, sub, mul, div)
 

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3/tpc_pytorch.py
@@ -78,9 +78,8 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
         tp.OperationsSetToLayers("Mul", [operator.mul, mul])
         tp.OperationsSetToLayers("Div", [operator.truediv, div])
         tp.OperationsSetToLayers("PReLU", [PReLU, prelu])
-        tp.OperationsSetToLayers("Swish", [SiLU, silu])
+        tp.OperationsSetToLayers("Swish", [SiLU, silu, Hardswish, hardswish])
         tp.OperationsSetToLayers("Sigmoid", [Sigmoid, sigmoid])
         tp.OperationsSetToLayers("Tanh", [Tanh, tanh])
-        tp.OperationsSetToLayers("HardSwish", [Hardswish, hardswish])
 
     return pytorch_tpc

--- a/model_compression_toolkit/core/tpc_models/tflite_tpc/v1/tp_model.py
+++ b/model_compression_toolkit/core/tpc_models/tflite_tpc/v1/tp_model.py
@@ -130,8 +130,7 @@ def generate_tp_model(default_config: OpQuantizationConfig,
                                   fixed_zero_point=-128, fixed_scale=1 / 256))
 
         conv2d = tp.OperatorsSet("Conv2d")
-        depthwise_conv2d = tp.OperatorsSet("DepthwiseConv2D")
-        kernel = tp.OperatorSetConcat(conv2d, fc, depthwise_conv2d)
+        kernel = tp.OperatorSetConcat(conv2d, fc)
 
         relu = tp.OperatorsSet("Relu")
         elu = tp.OperatorsSet("Elu")

--- a/model_compression_toolkit/core/tpc_models/tflite_tpc/v1/tpc_keras.py
+++ b/model_compression_toolkit/core/tpc_models/tflite_tpc/v1/tpc_keras.py
@@ -88,8 +88,7 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                              tp.LayerFilterParams(Activation, activation="softmax")])
         tp.OperationsSetToLayers("Logistic", [tf.sigmoid, tp.LayerFilterParams(Activation, activation="sigmoid")])
 
-        tp.OperationsSetToLayers("Conv2d", [Conv2D])
-        tp.OperationsSetToLayers("DepthwiseConv2D", [DepthwiseConv2D])
+        tp.OperationsSetToLayers("Conv2d", [Conv2D, DepthwiseConv2D])
         tp.OperationsSetToLayers("Relu", [tf.nn.relu,
                                           tf.nn.relu6,
                                           tp.LayerFilterParams(ReLU, Eq("max_value", None) | Eq("max_value", 6)),


### PR DESCRIPTION
Fix irrelevant TPC related logs by combining OperatorSets which are relevant only for specific framework (therefore, caused the warning about not being defined in a the other framework's TPC).

Merged: Haedswish into Swish OpratorSet and DepthwiseConv2D into Conv2d OperatorSet.