### PR TITLE
PyTorch support for gradient-based weights for mixed-precision metric

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -367,7 +367,7 @@ class FrameworkImplementation(ABC):
                    interest_points: List[BaseNode],
                    output_list: List[BaseNode],
                    all_outputs_indices: List[int],
-                   alpha: float = 0.1) -> List[float]:
+                   alpha: float = 0.3) -> List[float]:
         """
         Calls a framework specific model gradient calculation function, which computes the gradients of the model's
         outputs with respect to the feature maps of the set of given interest points.

--- a/model_compression_toolkit/core/keras/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/keras/back2framework/model_gradients.py
@@ -98,7 +98,7 @@ def keras_model_grad(graph_float: common.Graph,
                      interest_points: List[BaseNode],
                      output_list: List[BaseNode],
                      all_outputs_indices: List[int],
-                     alpha: float = 0.1) -> List[float]:
+                     alpha: float = 0.3) -> List[float]:
     """
     Computes the gradients of a Keras model's outputs with respect to the feature maps of the set of given
     interest points. It then uses the gradients to compute the hessian trace for each interest point and normalized the

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -415,7 +415,7 @@ class KerasImplementation(FrameworkImplementation):
                    interest_points: List[BaseNode],
                    output_list: List[BaseNode],
                    all_outputs_indices: List[int],
-                   alpha: float = 0.1) -> List[float]:
+                   alpha: float = 0.3) -> List[float]:
         """
         Calls a Keras model gradient calculation function, which computes the gradients of the model's
         outputs with respect to the feature maps of the set of given interest points.

--- a/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
@@ -65,7 +65,6 @@ def run_operation(n: BaseNode,
         n: The corresponding node of the layer it runs.
         input_tensors: List of Pytorch tensors that are the layer's inputs.
         op_func: Module/functional to apply to the input tensors.
-        mode: model quantiztion mode from ModelBuilderMode
     Returns:
         A list of Pytorch tensors. The Module/functional output tensors after applying the
         Module/functional to the input tensors.
@@ -150,12 +149,13 @@ class PytorchModelGradients(torch.nn.Module):
             if isinstance(out_tensors_of_n, list):
                 output_t = []
                 for t in out_tensors_of_n:
-                    t.retain_grad()
+                    if n in self.interest_points and t.requires_grad:
+                        t.retain_grad()
                     output_t.append(t)
                 node_to_output_tensors_dict.update({n: output_t})
             else:
                 assert isinstance(out_tensors_of_n, torch.Tensor)
-                if out_tensors_of_n.requires_grad:
+                if n in self.interest_points and out_tensors_of_n.requires_grad:
                     out_tensors_of_n.retain_grad()
                 node_to_output_tensors_dict.update({n: [out_tensors_of_n]})
 

--- a/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
@@ -1,0 +1,200 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Tuple, Any, Dict, List
+import numpy as np
+
+import torch
+from networkx import topological_sort
+
+from model_compression_toolkit import FrameworkInfo
+from model_compression_toolkit.core import common
+from model_compression_toolkit.core.common import BaseNode, Graph
+from model_compression_toolkit.core.common.graph.edge import EDGE_SINK_INDEX
+from model_compression_toolkit.core.common.graph.functional_node import FunctionalNode
+from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
+from model_compression_toolkit.core.pytorch.back2framework.instance_builder import node_builder
+from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
+from model_compression_toolkit.core.pytorch.reader.graph_builders import DummyPlaceHolder
+from model_compression_toolkit.core.pytorch.mixed_precision.mixed_precision_wrapper import PytorchMixedPrecisionWrapper
+from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig
+
+
+def build_input_tensors_list(node: BaseNode,
+                             graph: Graph,
+                             inputs: Tuple[Any],
+                             node_to_output_tensors_dict: Dict[BaseNode, List]) -> List[List]:
+    """
+    Given a node, build a list of input tensors the node gets. The list is built
+    based on the node's incoming edges and previous nodes' output tensors.
+    Args:
+        node: Node to build its input tensors list.
+        graph: Graph the node is in.
+        inputs: list of input tensors to model
+        node_to_output_tensors_dict: A dictionary from a node to its output tensors.
+    Returns:
+        A list of the node's input tensors.
+    """
+    if node.type == DummyPlaceHolder:
+        input_tensors = [inputs[graph.get_inputs().index(node)]]
+    else:
+        input_tensors = []
+        # Go over a sorted list of the node's incoming edges, and for each source node get its output tensors.
+        # Append them in a result list.
+        for ie in graph.incoming_edges(node, sort_by_attr=EDGE_SINK_INDEX):
+            _input_tensors = node_to_output_tensors_dict[ie.source_node]
+            input_tensors.append(_input_tensors)
+        input_tensors = [tensor for tensor_list in input_tensors for tensor in tensor_list]  # flat list of lists
+    return input_tensors
+
+
+def run_operation(n: BaseNode,
+                  input_tensors: List,
+                  op_func: Any) -> List[torch.Tensor]:
+    """
+    Applying the layer (op_func) to the input tensors (input_tensors).
+    If quantized is set to True, and the layer's corresponding node (n) has quantization
+    attributes, an additional fake-quantization node is built and appended to the layer.
+    Args:
+        n: The corresponding node of the layer it runs.
+        input_tensors: List of Pytorch tensors that are the layer's inputs.
+        op_func: Module/functional to apply to the input tensors.
+        mode: model quantiztion mode from ModelBuilderMode
+    Returns:
+        A list of Pytorch tensors. The Module/functional output tensors after applying the
+        Module/functional to the input tensors.
+    """
+
+    op_call_args = n.op_call_args if isinstance(n, FunctionalNode) else []
+    functional_kwargs = n.op_call_kwargs if isinstance(n, FunctionalNode) else {}
+    if isinstance(n, FunctionalNode) and n.inputs_as_list:
+        out_tensors_of_n = op_func(input_tensors, *op_call_args, **functional_kwargs)
+    else:
+        out_tensors_of_n = op_func(*input_tensors + op_call_args, **functional_kwargs)
+
+    return out_tensors_of_n
+
+
+def generate_outputs(
+        out_nodes: List[BaseNode],
+        node_to_output_tensors_dict: dict):
+    """
+    Args:
+        out_nodes: List of output nodes.
+        node_to_output_tensors_dict: A dictionary from a node to its output tensors.
+    Returns: List of output tensor/s for the model
+    """
+    output = []
+    for n in out_nodes:
+        out_tensors_of_n = node_to_output_tensors_dict.get(n)
+        if len(out_tensors_of_n) > 1:
+            output.append(out_tensors_of_n)
+        else:
+            output += out_tensors_of_n
+    return output
+
+
+class PytorchModelGradients(torch.nn.Module):
+    """
+    Class for reconstructing a Pytorch model from a graph
+    """
+    def __init__(self,
+                 graph_float: common.Graph,
+                 model_input_tensors: Dict[BaseNode, np.ndarray],
+                 interest_points: List[BaseNode],
+                 output_list: List[BaseNode],
+                 all_outputs_indices: List[int],
+                 alpha: float = 0.1):
+        """
+        Construct a Pytorch model.
+        Args:
+            graph: Graph to build its corresponding Pytorch model.
+            mode: Building mode. Read ModelBuilderMode description for more info.
+            append2output: List of nodes or OutTensor objects.
+            fw_info: Framework information (e.g., mapping from layers to their attributes to quantize).
+        """
+        super(PytorchModelGradients, self).__init__()
+        self.graph_float = graph_float
+        self.node_sort = list(topological_sort(graph_float))
+        self.nodes_dict = {}
+        self.interest_points = interest_points
+        self.alpha = alpha
+
+        self.out_tensors = []
+        self.grads = []
+
+        for n in self.node_sort:
+            if not isinstance(n, FunctionalNode):
+                self.add_module(n.name, node_builder(n))
+
+    def forward(self,
+                *args: Any) -> Any:
+        """
+        Args:
+            args: argument input tensors to model.
+        Returns:
+            torch Tensor/s which is/are the output of the model logic.
+        """
+        node_to_output_tensors_dict = dict()
+        for n in self.node_sort:
+            input_tensors = build_input_tensors_list(n,
+                                                     self.graph_float,
+                                                     args,
+                                                     node_to_output_tensors_dict)
+
+            op_func = self.get_op_func(n)
+            out_tensors_of_n = run_operation(n,  # Run node operation and fetch outputs
+                                             input_tensors,
+                                             op_func=op_func)
+            # for t in out_tensors_of_n:
+            #     t.retain_grad()
+
+            if n in self.interest_points:
+                # out_tensors_of_n[0].requires_grad = True
+                out_tensors_of_n[0].retain_grad()
+                # out_tensors_of_n[0].register_hook(lambda g: self.get_layer_output_grad(g, n))
+
+                # self.out_tensors.append(out_tensors_of_n[0])
+
+            # output_t = out_tensors_of_n[0]
+            # output_t.retain_grad()
+            # output_t.register_hook(lambda g: self.get_layer_output_grad(g, n))
+            # node_to_output_tensors_dict.update({n: [output_t]})
+            if isinstance(out_tensors_of_n, list):
+                node_to_output_tensors_dict.update({n: out_tensors_of_n})
+            else:
+                node_to_output_tensors_dict.update({n: [out_tensors_of_n]})
+
+        outputs = generate_outputs(self.interest_points,
+                                   node_to_output_tensors_dict)
+
+        return outputs
+
+    def get_layer_output_grad(self, grad, n):
+        print(n)
+        self.grads.append(grad)
+
+    def get_op_func(self, n: BaseNode) -> Any:
+        """
+        Gets the operation function that runs the actual inference of the nodes compatible layer.
+
+        Args:
+            n: The corresponding node of the layer it runs.
+            configurable_nodes_names: A list of names of configurable nodes in the quantized model.
+
+        Returns: Module/functional to apply to the input tensors.
+
+        """
+
+        return n.type if isinstance(n, FunctionalNode) else getattr(self, n.name)

--- a/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
@@ -169,7 +169,7 @@ def pytorch_model_grad(graph_float: common.Graph,
                        model_input_tensors: Dict[BaseNode, torch.Tensor],
                        interest_points: List[BaseNode],
                        all_outputs_indices: List[int],
-                       alpha: float = 0.1) -> List[float]:
+                       alpha: float = 0.3) -> List[float]:
     """
     Computes the gradients of a Pytorch model's outputs with respect to the feature maps of the set of given
     interest points. It then uses the gradients to compute the hessian trace for each interest point and normalized the

--- a/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
@@ -155,7 +155,8 @@ class PytorchModelGradients(torch.nn.Module):
                 node_to_output_tensors_dict.update({n: output_t})
             else:
                 assert isinstance(out_tensors_of_n, torch.Tensor)
-                out_tensors_of_n.retain_grad()
+                if out_tensors_of_n.requires_grad:
+                    out_tensors_of_n.retain_grad()
                 node_to_output_tensors_dict.update({n: [out_tensors_of_n]})
 
         outputs = generate_outputs(self.interest_points,
@@ -208,7 +209,7 @@ def pytorch_model_grad(graph_float: common.Graph,
 
     output_loss.backward()
 
-    ipt_gradients = [t.grad for t in output_tensors]
+    ipt_gradients = [torch.Tensor([0.0]) if t.grad is None else t.grad for t in output_tensors]
     r_ipt_gradients = [torch.reshape(t, shape=(t.shape[0], -1)) for t in ipt_gradients]
     hessian_trace_aprrox = [torch.mean(torch.sum(torch.pow(ipt_grad, 2.0), dim=-1)) for ipt_grad in r_ipt_gradients]
 

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -394,7 +394,7 @@ class PytorchImplementation(FrameworkImplementation):
             graph_float: Graph to build its corresponding Keras model.
             model_input_tensors: A mapping between model input nodes to an input batch.
             interest_points: List of nodes which we want to get their feature map as output, to calculate distance metric.
-            output_list: List of nodes that considered as model's output for the purpose of gradients computation.
+            output_list: List of nodes that considered as model's output for the purpose of gradients computation. (Not used in this function)
             all_outputs_indices: Indices of the model outputs and outputs replacements (if exists),
                 in a topological sorted interest points list.
             alpha: A tuning parameter to allow calibration between the contribution of the output feature maps returned

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -385,7 +385,7 @@ class PytorchImplementation(FrameworkImplementation):
                    interest_points: List[BaseNode],
                    output_list: List[BaseNode],  # dummy - not used in pytorch
                    all_outputs_indices: List[int],
-                   alpha: float = 0.1) -> List[float]:
+                   alpha: float = 0.3) -> List[float]:
         """
         Calls a PyTorch specific model gradient calculation function, which computes the gradients of the model's
         outputs with respect to the feature maps of the set of given interest points.

--- a/tests/keras_tests/function_tests/test_model_gradients.py
+++ b/tests/keras_tests/function_tests/test_model_gradients.py
@@ -13,9 +13,9 @@ from model_compression_toolkit.core.common.quantization.set_node_quantization_co
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
 from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute
-from model_compression_toolkit.core.tpc_models.default_tpc.v3.tp_model import generate_tp_model, \
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import generate_tp_model, \
     get_op_quantization_configs
-from model_compression_toolkit.core.tpc_models.default_tpc.v3.tpc_keras import generate_keras_tpc
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import generate_keras_tpc
 
 import model_compression_toolkit as mct
 tp = mct.target_platform

--- a/tests/keras_tests/function_tests/test_model_gradients.py
+++ b/tests/keras_tests/function_tests/test_model_gradients.py
@@ -1,7 +1,6 @@
 import keras
 import unittest
 
-from keras.layers import Softmax
 from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, Input, SeparableConv2D, Reshape
 from tensorflow import initializers
 import numpy as np
@@ -114,7 +113,7 @@ class TestModelGradients(unittest.TestCase):
                                   interest_points=interest_points,
                                   output_list=output_nodes,
                                   all_outputs_indices=[len(interest_points) - 1],
-                                  alpha=0.1)
+                                  alpha=0.3)
 
         # Checking that the wiehgts where computed and normalized correctly
         self.assertTrue(np.isclose(np.sum(x), 1))
@@ -183,7 +182,7 @@ class TestModelGradients(unittest.TestCase):
                                   interest_points=interest_points,
                                   output_list=output_nodes,
                                   all_outputs_indices=output_indices,
-                                  alpha=0.1)
+                                  alpha=0.3)
 
         # Checking that the wiehgts where computed and normalized correctly
         self.assertTrue(np.isclose(np.sum(x), 1))

--- a/tests/pytorch_tests/function_tests/model_gradients_test.py
+++ b/tests/pytorch_tests/function_tests/model_gradients_test.py
@@ -211,7 +211,7 @@ class ModelGradientsBasicModelTest(BasePytorchTest):
                                          model_input_tensors=input_tensors,
                                          interest_points=ipts,
                                          all_outputs_indices=[len(ipts) - 1],
-                                         alpha=0.1)
+                                         alpha=0.3)
 
         # Checking that the weights where computed and normalized correctly
         self.unit_test.assertTrue(np.isclose(np.sum(model_grads), 1))
@@ -243,7 +243,7 @@ class ModelGradientsAdvancedModelTest(BasePytorchTest):
                                          model_input_tensors=input_tensors,
                                          interest_points=ipts,
                                          all_outputs_indices=[len(ipts) - 1],
-                                         alpha=0.1)
+                                         alpha=0.3)
 
         # Checking that the weights where computed and normalized correctly
         self.unit_test.assertTrue(np.isclose(np.sum(model_grads), 1))
@@ -277,7 +277,7 @@ class ModelGradientsOutputReplacementTest(BasePytorchTest):
                                          model_input_tensors=input_tensors,
                                          interest_points=ipts,
                                          all_outputs_indices=output_indices,
-                                         alpha=0.1)
+                                         alpha=0.3)
 
         # Checking that the weights where computed and normalized correctly
         self.unit_test.assertTrue(np.isclose(np.sum(model_grads), 1))

--- a/tests/pytorch_tests/function_tests/model_gradients_test.py
+++ b/tests/pytorch_tests/function_tests/model_gradients_test.py
@@ -26,9 +26,9 @@ from model_compression_toolkit import DEFAULTCONFIG
 from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
 from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute
-from model_compression_toolkit.core.tpc_models.default_tpc.v3.tp_model import get_op_quantization_configs, \
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_op_quantization_configs, \
     generate_tp_model
-from model_compression_toolkit.core.tpc_models.default_tpc.v3.tpc_pytorch import generate_pytorch_tpc
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import generate_pytorch_tpc
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 
 """

--- a/tests/pytorch_tests/function_tests/model_gradients_test.py
+++ b/tests/pytorch_tests/function_tests/model_gradients_test.py
@@ -1,0 +1,220 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import torch
+from torch.nn import Conv2d, BatchNorm2d, ReLU
+
+from model_compression_toolkit.core.common.quantization.set_node_quantization_config import \
+    set_quantization_configuration_to_graph
+from model_compression_toolkit.core.pytorch.back2framework.model_gradients import PytorchModelGradients
+from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
+import numpy as np
+
+from model_compression_toolkit import DEFAULTCONFIG
+from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
+from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
+from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute
+from model_compression_toolkit.core.tpc_models.default_tpc.v3.tp_model import get_op_quantization_configs, \
+    generate_tp_model
+from model_compression_toolkit.core.tpc_models.default_tpc.v3.tpc_pytorch import generate_pytorch_tpc
+from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
+
+"""
+This test checks the BatchNorm info collection.
+"""
+
+
+def bn_weight_change(bn: torch.nn.Module):
+    bw_shape = bn.weight.shape
+    delattr(bn, 'weight')
+    delattr(bn, 'bias')
+    delattr(bn, 'running_var')
+    delattr(bn, 'running_mean')
+    bn.register_buffer('weight', torch.rand(bw_shape))
+    bn.register_buffer('bias', torch.rand(bw_shape))
+    bn.register_buffer('running_var', torch.abs(torch.rand(bw_shape)))
+    bn.register_buffer('running_mean', torch.rand(bw_shape))
+    return bn
+
+
+class create_model_1(torch.nn.Module):
+    def __init__(self):
+        super(create_model_1, self).__init__()
+        self.conv1 = Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn = BatchNorm2d(3)
+        self.bn = bn_weight_change(self.bn)
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = self.bn(x)
+        return x + inp
+
+
+class create_model_2(torch.nn.Module):
+    def __init__(self):
+        super(create_model_2, self).__init__()
+        self.conv1 = Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn = BatchNorm2d(3)
+        self.bn = bn_weight_change(self.bn)
+        self.bn2 = BatchNorm2d(3)
+        self.bn2 = bn_weight_change(self.bn2)
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x2 = self.bn(x)
+        y = self.bn2(x)
+        return x2 + y + inp
+
+
+class create_model_3(torch.nn.Module):
+    def __init__(self):
+        super(create_model_3, self).__init__()
+        self.conv1 = Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn = BatchNorm2d(3)
+        self.bn = bn_weight_change(self.bn)
+        self.bn2 = BatchNorm2d(3)
+        self.bn2 = bn_weight_change(self.bn2)
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = self.bn(x)
+        x = self.bn2(x)
+        return x + inp
+
+
+class create_model_4(torch.nn.Module):
+    def __init__(self):
+        super(create_model_4, self).__init__()
+        self.bn = BatchNorm2d(3)
+        self.bn = bn_weight_change(self.bn)
+        self.bn2 = BatchNorm2d(3)
+        self.bn2 = bn_weight_change(self.bn2)
+
+    def forward(self, inp):
+        x = self.bn(inp)
+        x = self.bn2(x)
+        return x + inp
+
+
+class create_model_5(torch.nn.Module):
+    def __init__(self):
+        super(create_model_5, self).__init__()
+        self.bn = BatchNorm2d(3)
+        self.bn = bn_weight_change(self.bn)
+        self.relu1 = ReLU()
+        self.bn2 = BatchNorm2d(3)
+        self.bn2 = bn_weight_change(self.bn2)
+        self.bn3 = BatchNorm2d(3)
+        self.bn3 = bn_weight_change(self.bn3)
+
+    def forward(self, inp):
+        x = self.bn(inp)
+        x = self.relu1(x)
+        x = self.bn2(x)
+        x = x + inp
+        x = self.bn3(x)
+        return x + inp
+
+
+class create_model_6(torch.nn.Module):
+    def __init__(self):
+        super(create_model_6, self).__init__()
+        self.bn = BatchNorm2d(3)
+        self.bn = bn_weight_change(self.bn)
+        self.bn2 = BatchNorm2d(3)
+        self.bn2 = bn_weight_change(self.bn2)
+
+    def forward(self, inp):
+        x = self.bn(inp)
+        x2 = self.bn2(inp)
+        return x2 + x + inp
+
+
+class ModelGradientsTest(BasePytorchTest):
+
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.val_batch_size = 1
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 3, 32, 32]]
+
+    @staticmethod
+    def generate_inputs(input_shapes):
+        inputs = []
+        for in_shape in input_shapes:
+            t = torch.randn(*in_shape)
+            t.requires_grad_()
+            inputs.append(t)
+        inputs = to_torch_tensor(inputs)
+        return inputs
+
+    def representative_data_gen(self):
+        input_shapes = self.create_inputs_shape()
+        return self.generate_inputs(input_shapes)
+
+    def prepare_graph(self, in_model):
+        fw_info = DEFAULT_PYTORCH_INFO
+        qc = DEFAULTCONFIG
+        pytorch_impl = PytorchImplementation()
+
+        graph = pytorch_impl.model_reader(in_model, self.representative_data_gen)  # model reading
+        graph = substitute(graph, pytorch_impl.get_substitutions_prepare_graph())
+        for node in graph.nodes:
+            node.prior_info = pytorch_impl.get_node_prior_info(node=node,
+                                                               fw_info=fw_info,
+                                                               graph=graph)
+        graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(qc))
+
+        base_config, op_cfg_list = get_op_quantization_configs()
+        tp = generate_tp_model(base_config, base_config, op_cfg_list, "model_grad_test")
+        tpc = generate_pytorch_tpc(name="model_grad_test", tp_model=tp)
+
+        graph.set_fw_info(fw_info)
+        graph.set_tpc(tpc)
+
+        graph = set_quantization_configuration_to_graph(graph=graph,
+                                                        quant_config=qc)
+        return graph
+
+    def run_test(self, seed=0):
+        model_float = create_model_1()
+        graph = self.prepare_graph(model_float)
+
+        model_grads = PytorchModelGradients(graph_float=graph,
+                                            model_input_tensors=None,
+                                            interest_points=[n for n in graph.get_topo_sorted_nodes()],
+                                            output_list=None,
+                                            all_outputs_indices=None)
+        input_tensors = self.representative_data_gen()
+        # for t in input_tensors:
+        #     t.required_grad = True
+        output = model_grads.forward(input_tensors)
+        loss = torch.sum(output[0])
+        loss.backward()
+        # print(model_grads.grads)
+        for t in output:
+            print(t.grad)
+        # self.unit_test.assertTrue(len(transformed_graph.find_node_by_name('conv1_bn')) == 1)
+        # conv_bn_node = transformed_graph.find_node_by_name('conv1_bn')[0]
+        #
+        # prior_std = conv_bn_node.prior_info.std_output
+        # prior_mean = conv_bn_node.prior_info.mean_output
+        #
+        # bn_layer = model_float.bn
+        # gamma = bn_layer.weight
+        # beta = bn_layer.bias
+        #
+        # self.unit_test.assertTrue((abs(gamma.cpu().data.numpy()) == prior_std).all())
+        # self.unit_test.assertTrue((beta.cpu().data.numpy() == prior_mean).all())

--- a/tests/pytorch_tests/function_tests/model_gradients_test.py
+++ b/tests/pytorch_tests/function_tests/model_gradients_test.py
@@ -49,9 +49,19 @@ def bn_weight_change(bn: torch.nn.Module):
     return bn
 
 
-class create_model_1(torch.nn.Module):
+class basic_derivative_model(torch.nn.Module):
     def __init__(self):
-        super(create_model_1, self).__init__()
+        super(basic_derivative_model, self).__init__()
+
+    def forward(self, inp):
+        x = torch.mul(inp, 2)
+        x = x + 1
+        return x
+
+
+class basic_model(torch.nn.Module):
+    def __init__(self):
+        super(basic_model, self).__init__()
         self.conv1 = Conv2d(3, 3, kernel_size=1, stride=1)
         self.bn = BatchNorm2d(3)
         self.relu = ReLU()
@@ -63,8 +73,86 @@ class create_model_1(torch.nn.Module):
         return x
 
 
-class ModelGradientsTest(BasePytorchTest):
+class advanced_model(torch.nn.Module):
+    def __init__(self):
+        super(advanced_model, self).__init__()
+        self.conv1 = Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn1 = BatchNorm2d(3)
+        self.relu1 = ReLU()
 
+        self.conv2 = Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn2 = BatchNorm2d(3)
+        self.relu2 = ReLU()
+
+        self.bn3 = BatchNorm2d(3)
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = self.bn1(x)
+        x = self.relu1(x)
+        x = self.conv2(x)
+        x = self.bn2(x)
+        x = self.relu2(x)
+
+        x = torch.reshape(x, [-1])
+        x = self.bn3(x)
+        return x
+
+
+class model_with_output_replacements(torch.nn.Module):
+    def __init__(self):
+        super(model_with_output_replacements, self).__init__()
+
+        self.conv = Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn = BatchNorm2d(3)
+        self.relu = ReLU()
+        self.soft = torch.nn.Softmax(dim=1)
+
+    def forward(self, inp):
+        x = self.conv(inp)
+        x = self.bn(x)
+        x = self.relu(x)
+        x = self.soft(x)
+        x = torch.argmax(x)
+        return x
+
+
+def prepare_graph(in_model, representative_data_gen):
+    fw_info = DEFAULT_PYTORCH_INFO
+    qc = DEFAULTCONFIG
+    pytorch_impl = PytorchImplementation()
+
+    graph = pytorch_impl.model_reader(in_model, representative_data_gen)  # model reading
+    graph = substitute(graph, pytorch_impl.get_substitutions_prepare_graph())
+    for node in graph.nodes:
+        node.prior_info = pytorch_impl.get_node_prior_info(node=node,
+                                                           fw_info=fw_info,
+                                                           graph=graph)
+    graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(qc))
+
+    base_config, op_cfg_list = get_op_quantization_configs()
+    tp = generate_tp_model(base_config, base_config, op_cfg_list, "model_grad_test")
+    tpc = generate_pytorch_tpc(name="model_grad_test", tp_model=tp)
+
+    graph.set_fw_info(fw_info)
+    graph.set_tpc(tpc)
+
+    graph = set_quantization_configuration_to_graph(graph=graph,
+                                                    quant_config=qc)
+    return graph
+
+
+def generate_inputs(inputs_shape):
+    inputs = []
+    for in_shape in inputs_shape:
+        t = torch.randn(*in_shape)
+        t.requires_grad_()
+        inputs.append(t)
+    inputs = to_torch_tensor(inputs)
+    return inputs
+
+
+class ModelGradientsCalculationTest(BasePytorchTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
         self.val_batch_size = 1
@@ -74,62 +162,133 @@ class ModelGradientsTest(BasePytorchTest):
 
     @staticmethod
     def generate_inputs(input_shapes):
-        inputs = []
-        for in_shape in input_shapes:
-            t = torch.randn(*in_shape)
-            t.requires_grad_()
-            inputs.append(t)
-        inputs = to_torch_tensor(inputs)
-        return inputs
+        return generate_inputs(input_shapes)
 
     def representative_data_gen(self):
         input_shapes = self.create_inputs_shape()
         return self.generate_inputs(input_shapes)
 
-    def prepare_graph(self, in_model):
-        fw_info = DEFAULT_PYTORCH_INFO
-        qc = DEFAULTCONFIG
-        pytorch_impl = PytorchImplementation()
+    def run_test(self, seed=0):
+        model_float = basic_derivative_model()
+        graph = prepare_graph(model_float, self.representative_data_gen)
+        input_tensors = {inode: self.representative_data_gen()[0] for inode in graph.get_inputs()}
 
-        graph = pytorch_impl.model_reader(in_model, self.representative_data_gen)  # model reading
-        graph = substitute(graph, pytorch_impl.get_substitutions_prepare_graph())
-        for node in graph.nodes:
-            node.prior_info = pytorch_impl.get_node_prior_info(node=node,
-                                                               fw_info=fw_info,
-                                                               graph=graph)
-        graph = substitute(graph, pytorch_impl.get_substitutions_pre_statistics_collection(qc))
+        ipts = [n for n in graph.get_topo_sorted_nodes()]
+        model_grads = pytorch_model_grad(graph_float=graph,
+                                         model_input_tensors=input_tensors,
+                                         interest_points=ipts,
+                                         all_outputs_indices=[len(ipts) - 1],
+                                         alpha=0)
 
-        base_config, op_cfg_list = get_op_quantization_configs()
-        tp = generate_tp_model(base_config, base_config, op_cfg_list, "model_grad_test")
-        tpc = generate_pytorch_tpc(name="model_grad_test", tp_model=tp)
+        self.unit_test.assertTrue(np.isclose(model_grads[0], 0.8))
+        self.unit_test.assertTrue(np.isclose(model_grads[1], 0.2))
+        self.unit_test.assertTrue(model_grads[2] == 0.0)
 
-        graph.set_fw_info(fw_info)
-        graph.set_tpc(tpc)
 
-        graph = set_quantization_configuration_to_graph(graph=graph,
-                                                        quant_config=qc)
-        return graph
+class ModelGradientsBasicModelTest(BasePytorchTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.val_batch_size = 1
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 3, 32, 32]]
+
+    @staticmethod
+    def generate_inputs(input_shapes):
+        return generate_inputs(input_shapes)
+
+    def representative_data_gen(self):
+        input_shapes = self.create_inputs_shape()
+        return self.generate_inputs(input_shapes)
 
     def run_test(self, seed=0):
-        model_float = create_model_1()
-        graph = self.prepare_graph(model_float)
-        input_tensors = self.representative_data_gen()
+        model_float = basic_model()
+        graph = prepare_graph(model_float, self.representative_data_gen)
+        input_tensors = {inode: self.representative_data_gen()[0] for inode in graph.get_inputs()}
+
+        ipts = [n for n in graph.get_topo_sorted_nodes()]
+        model_grads = pytorch_model_grad(graph_float=graph,
+                                         model_input_tensors=input_tensors,
+                                         interest_points=ipts,
+                                         all_outputs_indices=[len(ipts) - 1],
+                                         alpha=0.1)
+
+        # Checking that the weights where computed and normalized correctly
+        self.unit_test.assertTrue(np.isclose(np.sum(model_grads), 1))
+
+
+class ModelGradientsAdvancedModelTest(BasePytorchTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.val_batch_size = 1
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 3, 32, 32]]
+
+    @staticmethod
+    def generate_inputs(input_shapes):
+        return generate_inputs(input_shapes)
+
+    def representative_data_gen(self):
+        input_shapes = self.create_inputs_shape()
+        return self.generate_inputs(input_shapes)
+
+    def run_test(self, seed=0):
+        model_float = basic_model()
+        graph = prepare_graph(model_float, self.representative_data_gen)
+        input_tensors = {inode: self.representative_data_gen()[0] for inode in graph.get_inputs()}
+
+        ipts = [n for n in graph.get_topo_sorted_nodes()]
+        model_grads = pytorch_model_grad(graph_float=graph,
+                                         model_input_tensors=input_tensors,
+                                         interest_points=ipts,
+                                         all_outputs_indices=[len(ipts) - 1],
+                                         alpha=0.1)
+
+        # Checking that the weights where computed and normalized correctly
+        self.unit_test.assertTrue(np.isclose(np.sum(model_grads), 1))
+
+
+class ModelGradientsOutputReplacementTest(BasePytorchTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.val_batch_size = 1
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 3, 32, 32]]
+
+    @staticmethod
+    def generate_inputs(input_shapes):
+        return generate_inputs(input_shapes)
+
+    def representative_data_gen(self):
+        input_shapes = self.create_inputs_shape()
+        return self.generate_inputs(input_shapes)
+
+    def run_test(self, seed=0):
+        model_float = model_with_output_replacements()
+        graph = prepare_graph(model_float, self.representative_data_gen)
+        input_tensors = {inode: self.representative_data_gen()[0] for inode in graph.get_inputs()}
+
+        ipts = [n for n in graph.get_topo_sorted_nodes()]
+        output_indices = [len(ipts) - 3]
 
         model_grads = pytorch_model_grad(graph_float=graph,
                                          model_input_tensors=input_tensors,
-                                         interest_points=[n for n in graph.get_topo_sorted_nodes()][1:],
-                                         all_outputs_indices=[1])
+                                         interest_points=ipts,
+                                         all_outputs_indices=output_indices,
+                                         alpha=0.1)
 
-        print(model_grads)
-        # self.unit_test.assertTrue(len(transformed_graph.find_node_by_name('conv1_bn')) == 1)
-        # conv_bn_node = transformed_graph.find_node_by_name('conv1_bn')[0]
-        #
-        # prior_std = conv_bn_node.prior_info.std_output
-        # prior_mean = conv_bn_node.prior_info.mean_output
-        #
-        # bn_layer = model_float.bn
-        # gamma = bn_layer.weight
-        # beta = bn_layer.bias
-        #
-        # self.unit_test.assertTrue((abs(gamma.cpu().data.numpy()) == prior_std).all())
-        # self.unit_test.assertTrue((beta.cpu().data.numpy() == prior_mean).all())
+        # Checking that the weights where computed and normalized correctly
+        self.unit_test.assertTrue(np.isclose(np.sum(model_grads), 1))
+
+        model_grads_2 = pytorch_model_grad(graph_float=graph,
+                                           model_input_tensors=input_tensors,
+                                           interest_points=ipts,
+                                           all_outputs_indices=output_indices,
+                                           alpha=0)
+
+        # Checking that the weights where computed and normalized correctly
+        zero_count = len(list(filter(lambda v: v == np.float32(0), model_grads_2)))
+        self.unit_test.assertTrue(zero_count == 3)
+        self.unit_test.assertTrue(np.isclose(np.sum(model_grads_2), 1))

--- a/tests/pytorch_tests/function_tests/test_function_runner.py
+++ b/tests/pytorch_tests/function_tests/test_function_runner.py
@@ -19,6 +19,7 @@ from tests.pytorch_tests.function_tests.bn_info_collection_test import BNInfoCol
     BNLayerInfoCollectionTest, INP2BNInfoCollectionTest
 from tests.pytorch_tests.function_tests.kpi_data_test import TestKPIDataBasicAllBitwidth, \
     TestKPIDataBasicPartialBitwidth, TestKPIDataComplexPartialBitwidth, TestKPIDataComplesAllBitwidth
+from tests.pytorch_tests.function_tests.model_gradients_test import ModelGradientsTest
 
 
 class FunctionTestRunner(unittest.TestCase):
@@ -85,6 +86,12 @@ class FunctionTestRunner(unittest.TestCase):
         This test checks the KPI data Pytorch API.
         """
         TestKPIDataComplexPartialBitwidth(self).run_test()
+
+    def test_model_gradients(self):
+        """
+        This test checks the KPI data Pytorch API.
+        """
+        ModelGradientsTest(self).run_test()
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_tests/function_tests/test_function_runner.py
+++ b/tests/pytorch_tests/function_tests/test_function_runner.py
@@ -19,7 +19,8 @@ from tests.pytorch_tests.function_tests.bn_info_collection_test import BNInfoCol
     BNLayerInfoCollectionTest, INP2BNInfoCollectionTest
 from tests.pytorch_tests.function_tests.kpi_data_test import TestKPIDataBasicAllBitwidth, \
     TestKPIDataBasicPartialBitwidth, TestKPIDataComplexPartialBitwidth, TestKPIDataComplesAllBitwidth
-from tests.pytorch_tests.function_tests.model_gradients_test import ModelGradientsTest
+from tests.pytorch_tests.function_tests.model_gradients_test import ModelGradientsBasicModelTest, \
+    ModelGradientsCalculationTest, ModelGradientsAdvancedModelTest, ModelGradientsOutputReplacementTest
 
 
 class FunctionTestRunner(unittest.TestCase):
@@ -89,9 +90,12 @@ class FunctionTestRunner(unittest.TestCase):
 
     def test_model_gradients(self):
         """
-        This test checks the KPI data Pytorch API.
+        This test checks the Model Gradients Pytorch computation.
         """
-        ModelGradientsTest(self).run_test()
+        ModelGradientsBasicModelTest(self).run_test()
+        ModelGradientsCalculationTest(self).run_test()
+        ModelGradientsAdvancedModelTest(self).run_test()
+        ModelGradientsOutputReplacementTest(self).run_test()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Added support to gradient-based weights for the distance metric computation in Pytorch framework.
* Default value for alpha parameter (tuning between output layers and regular layers) is changed to 0.3 (based on experimental study).
* Default weights for metric computation remained uniform (gradient-based weights option needs to be activated by an argument to mixed-precision quantization config).
* Minor fix in Keras gradient model tests TPC imports.