### PR TITLE
 Mixed-Precision LUT TPC

### DIFF
--- a/model_compression_toolkit/core/tpc_models/default_tpc/target_platform_capabilities.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/target_platform_capabilities.py
@@ -24,11 +24,13 @@ if FOUND_TF:
     from model_compression_toolkit.core.tpc_models.default_tpc.v1.tpc_keras import get_keras_tpc as get_keras_tpc_v1
     from model_compression_toolkit.core.tpc_models.default_tpc.v2.tpc_keras import get_keras_tpc as get_keras_tpc_v2
     from model_compression_toolkit.core.tpc_models.default_tpc.v3.tpc_keras import get_keras_tpc as get_keras_tpc_v3
+    from model_compression_toolkit.core.tpc_models.default_tpc.v3_lut.tpc_keras import get_keras_tpc as get_keras_tpc_v3_lut
 
     # Keras: TPC versioning
     keras_tpc_models_dict = {'v1': get_keras_tpc_v1(),
                              'v2': get_keras_tpc_v2(),
                              'v3': get_keras_tpc_v3(),
+                             'v3_lut': get_keras_tpc_v3_lut(),
                              LATEST: get_keras_tpc_latest()}
 
 ###############################
@@ -43,11 +45,14 @@ if FOUND_TORCH:
         get_pytorch_tpc as get_pytorch_tpc_v2
     from model_compression_toolkit.core.tpc_models.default_tpc.v3.tpc_pytorch import \
         get_pytorch_tpc as get_pytorch_tpc_v3
+    from model_compression_toolkit.core.tpc_models.default_tpc.v3_lut.tpc_pytorch import \
+        get_pytorch_tpc as get_pytorch_tpc_v3_lut
 
     # Pytorch: TPC versioning
     pytorch_tpc_models_dict = {'v1': get_pytorch_tpc_v1(),
                                'v2': get_pytorch_tpc_v2(),
                                'v3': get_pytorch_tpc_v3(),
+                               'v3_lut': get_pytorch_tpc_v3_lut(),
                                LATEST: get_pytorch_tpc_latest()}
 
 tpc_dict = {TENSORFLOW: keras_tpc_models_dict,

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/__init__.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/tp_model.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/tp_model.py
@@ -1,0 +1,160 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import List, Tuple
+
+import model_compression_toolkit as mct
+from model_compression_toolkit.core.common.target_platform import OpQuantizationConfig, TargetPlatformModel, \
+    QuantizationMethod
+
+tp = mct.target_platform
+
+
+def get_tp_model() -> TargetPlatformModel:
+    """
+    A method that generates a default target platform model, with base 8-bit quantization configuration and 8, 4, 2
+    bits configuration list for mixed-precision quantization.
+    NOTE: in order to generate a target platform model with different configurations but with the same Operators Sets
+    (for tests, experiments, etc.), use this method implementation as a test-case, i.e., override the
+    'get_op_quantization_configs' method and use its output to call 'generate_tp_model' with your configurations.
+
+    Returns: A TargetPlatformModel object.
+
+    """
+
+    base_config, mixed_precision_cfg_list = get_op_quantization_configs()
+
+    return generate_tp_model(default_config=base_config,
+                             base_config=base_config,
+                             mixed_precision_cfg_list=mixed_precision_cfg_list,
+                             name='lut_mp_tp_model')
+
+
+def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantizationConfig]]:
+    """
+    Creates a default configuration object for 8-bit quantization, to be used to set a default TargetPlatformModel.
+    In addition, creates a default configuration objects list (with 8, 4 and 2 bit quantization) to be used as
+    default configuration for mixed-precision quantization with non-uniform quantizer for 2 and 4 bit candidates.
+
+    Returns: An OpQuantizationConfig config object and a list of OpQuantizationConfig objects.
+
+    """
+    # Create a quantization config.
+    # A quantization configuration defines how an operator
+    # should be quantized on the modeled hardware:
+    eight_bits = tp.OpQuantizationConfig(
+        activation_quantization_method=tp.QuantizationMethod.POWER_OF_TWO,
+        weights_quantization_method=tp.QuantizationMethod.POWER_OF_TWO,
+        activation_n_bits=8,
+        weights_n_bits=8,
+        weights_per_channel_threshold=True,
+        enable_weights_quantization=True,
+        enable_activation_quantization=True,
+        quantization_preserving=False,
+        fixed_scale=None,
+        fixed_zero_point=None,
+        weights_multiplier_nbits=None)
+
+    # Creating OpQuantizationConfig list to quantize a model using mixed-precision with non-uniform quantizer
+    # for 2 and 4 bit candidates (with Lookup-Table method).
+    four_bits_lut = eight_bits.clone_and_edit(weights_n_bits=4,
+                                              weights_quantization_method=QuantizationMethod.LUT_QUANTIZER)
+    two_bits_lut = eight_bits.clone_and_edit(weights_n_bits=2,
+                                             weights_quantization_method=QuantizationMethod.LUT_QUANTIZER)
+    mixed_precision_cfg_list = [eight_bits, four_bits_lut, two_bits_lut]
+
+    return eight_bits, mixed_precision_cfg_list
+
+
+def generate_tp_model(default_config: OpQuantizationConfig,
+                      base_config: OpQuantizationConfig,
+                      mixed_precision_cfg_list: List[OpQuantizationConfig],
+                      name: str) -> TargetPlatformModel:
+    """
+    Generates TargetPlatformModel with default defined Operators Sets, based on the given base configuration and
+    mixed-precision configurations options list.
+
+    Args
+        default_config: A default OpQuantizationConfig to set as the TP model default configuration.
+        base_config: An OpQuantizationConfig to set as the TargetPlatformModel base configuration for mixed-precision purposes only.
+        mixed_precision_cfg_list: A list of OpQuantizationConfig to be used as the TP model mixed-precision
+            quantization configuration options.
+        name: The name of the TargetPlatformModel.
+
+    Returns: A TargetPlatformModel object.
+
+    """
+    # Create a QuantizationConfigOptions, which defines a set
+    # of possible configurations to consider when quantizing a set of operations (in mixed-precision, for example).
+    # If the QuantizationConfigOptions contains only one configuration,
+    # this configuration will be used for the operation quantization:
+    default_configuration_options = tp.QuantizationConfigOptions([default_config])
+
+    # Create a TargetPlatformModel and set its default quantization config.
+    # This default configuration will be used for all operations
+    # unless specified otherwise (see OperatorsSet, for example):
+    generated_tpc = tp.TargetPlatformModel(default_configuration_options, name=name)
+
+    # To start defining the model's components (such as operator sets, and fusing patterns),
+    # use 'with' the TargetPlatformModel instance, and create them as below:
+    with generated_tpc:
+        # Create an OperatorsSet to represent a set of operations.
+        # Each OperatorsSet has a unique label.
+        # If a quantization configuration options is passed, these options will
+        # be used for operations that will be attached to this set's label.
+        # Otherwise, it will be a configure-less set (used in fusing):
+
+        # May suit for operations like: Dropout, Reshape, etc.
+        tp.OperatorsSet("NoQuantization",
+                        tp.get_default_quantization_config_options().clone_and_edit(
+                            enable_weights_quantization=False,
+                            enable_activation_quantization=False))
+
+        # Create Mixed-Precision quantization configuration options from the given list of OpQuantizationConfig objects
+        mixed_precision_configuration_options = tp.QuantizationConfigOptions(mixed_precision_cfg_list,
+                                                                             base_config=base_config)
+
+        # Define operator sets that use mixed_precision_configuration_options:
+        conv = tp.OperatorsSet("Conv", mixed_precision_configuration_options)
+        fc = tp.OperatorsSet("FullyConnected", mixed_precision_configuration_options)
+
+        # Define operations sets without quantization configuration
+        # options (useful for creating fusing patterns, for example):
+        any_relu = tp.OperatorsSet("AnyReLU")
+        add = tp.OperatorsSet("Add")
+        sub = tp.OperatorsSet("Sub")
+        mul = tp.OperatorsSet("Mul")
+        div = tp.OperatorsSet("Div")
+        prelu = tp.OperatorsSet("PReLU")
+        swish = tp.OperatorsSet("Swish")
+        sigmoid = tp.OperatorsSet("Sigmoid")
+        tanh = tp.OperatorsSet("Tanh")
+
+        # Combine multiple operators into a single operator to avoid quantization between
+        # them. To do this we define fusing patterns using the OperatorsSets that were created.
+        # To group multiple sets with regard to fusing, an OperatorSetConcat can be created
+        activations_after_conv_to_fuse = tp.OperatorSetConcat(any_relu, swish, prelu, sigmoid, tanh)
+        activations_after_fc_to_fuse = tp.OperatorSetConcat(any_relu, swish, sigmoid)
+        any_binary = tp.OperatorSetConcat(add, sub, mul, div)
+
+        # ------------------- #
+        # Fusions
+        # ------------------- #
+        tp.Fusing([conv, activations_after_conv_to_fuse])
+        tp.Fusing([fc, activations_after_fc_to_fuse])
+        tp.Fusing([conv, add, any_relu])
+        tp.Fusing([conv, any_relu, add])
+        tp.Fusing([any_binary, any_relu])
+
+    return generated_tpc

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/tpc_keras.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/tpc_keras.py
@@ -1,0 +1,86 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import tensorflow as tf
+
+if tf.__version__ < "2.6":
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
+        Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D
+else:
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D
+
+from model_compression_toolkit.core.tpc_models.default_tpc.v3_lut.tp_model import get_tp_model
+import model_compression_toolkit as mct
+
+tp = mct.target_platform
+
+
+def get_keras_tpc() -> tp.TargetPlatformCapabilities:
+    """
+    get a Keras TargetPlatformCapabilities object with default operation sets to layers mapping.
+    Returns: a Keras TargetPlatformCapabilities object for the given TargetPlatformModel.
+    """
+    lut_mp_tp_model = get_tp_model()
+    return generate_keras_tpc(name='default_keras_lut_mp_tpc', tp_model=lut_mp_tp_model)
+
+
+def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
+    """
+    Generates a TargetPlatformCapabilities object with default operation sets to layers mapping.
+
+    Args:
+        name: Name of the TargetPlatformCapabilities.
+        tp_model: TargetPlatformModel object.
+
+    Returns: a TargetPlatformCapabilities object for the given TargetPlatformModel.
+    """
+
+    keras_tpc = tp.TargetPlatformCapabilities(tp_model, name=name)
+
+    with keras_tpc:
+        tp.OperationsSetToLayers("NoQuantization", [Reshape,
+                                                    tf.reshape,
+                                                    Flatten,
+                                                    Cropping2D,
+                                                    ZeroPadding2D,
+                                                    Dropout,
+                                                    MaxPooling2D,
+                                                    tf.split,
+                                                    tf.quantization.fake_quant_with_min_max_vars,
+                                                    tf.math.argmax,
+                                                    tf.shape,
+                                                    tf.__operators__.getitem,
+                                                    tf.compat.v1.shape])
+
+        tp.OperationsSetToLayers("Conv", [Conv2D,
+                                          DepthwiseConv2D,
+                                          tf.nn.conv2d,
+                                          tf.nn.depthwise_conv2d])
+        tp.OperationsSetToLayers("FullyConnected", [Dense])
+        tp.OperationsSetToLayers("AnyReLU", [tf.nn.relu,
+                                             tf.nn.relu6,
+                                             tp.LayerFilterParams(ReLU, negative_slope=0.0),
+                                             tp.LayerFilterParams(Activation, activation="relu")])
+        tp.OperationsSetToLayers("Add", [tf.add, Add])
+        tp.OperationsSetToLayers("Sub", [tf.subtract, Subtract])
+        tp.OperationsSetToLayers("Mul", [tf.math.multiply, Multiply])
+        tp.OperationsSetToLayers("Div", [tf.math.divide])
+        tp.OperationsSetToLayers("PReLU", [PReLU])
+        tp.OperationsSetToLayers("Swish", [tf.nn.swish, tp.LayerFilterParams(Activation, activation="swish")])
+        tp.OperationsSetToLayers("Sigmoid", [tf.nn.sigmoid, tp.LayerFilterParams(Activation, activation="sigmoid")])
+        tp.OperationsSetToLayers("Tanh", [tf.nn.tanh, tp.LayerFilterParams(Activation, activation="tanh")])
+
+    return keras_tpc

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v3_lut/tpc_pytorch.py
@@ -1,0 +1,85 @@
+# Copyright 2022 Sony Semiconductors Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import operator
+
+import torch
+from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind
+from torch.nn import Conv2d, Linear, BatchNorm2d
+from torch.nn import Dropout, Flatten, Hardtanh
+from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh, Hardswish
+from torch.nn.functional import relu, relu6, prelu, silu, hardtanh, hardswish
+
+from model_compression_toolkit.core.tpc_models.default_tpc.v3_lut.tp_model import get_tp_model
+import model_compression_toolkit as mct
+
+tp = mct.target_platform
+
+
+def get_pytorch_tpc() -> tp.TargetPlatformCapabilities:
+    """
+    get a Pytorch TargetPlatformCapabilities object with default operation sets to layers mapping.
+    Returns: a Pytorch TargetPlatformCapabilities object for the given TargetPlatformModel.
+    """
+    lut_mp_tp_model = get_tp_model()
+    return generate_pytorch_tpc(name='default_pytorch_lut_mp_tpc', tp_model=lut_mp_tp_model)
+
+
+def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
+    """
+    Generates a TargetPlatformCapabilities object with default operation sets to layers mapping.
+    Args:
+        name: Name of the TargetPlatformModel.
+        tp_model: TargetPlatformModel object.
+    Returns: a TargetPlatformCapabilities object for the given TargetPlatformModel.
+    """
+
+    pytorch_tpc = tp.TargetPlatformCapabilities(tp_model,
+                                                name=name)
+
+    with pytorch_tpc:
+        tp.OperationsSetToLayers("NoQuantization", [Dropout,
+                                                    Flatten,
+                                                    dropout,
+                                                    flatten,
+                                                    split,
+                                                    operator.getitem,
+                                                    reshape,
+                                                    unsqueeze,
+                                                    BatchNorm2d,
+                                                    chunk,
+                                                    unbind,
+                                                    torch.Tensor.size])
+
+        tp.OperationsSetToLayers("Conv", [Conv2d])
+        tp.OperationsSetToLayers("FullyConnected", [Linear])
+        tp.OperationsSetToLayers("AnyReLU", [torch.relu,
+                                             ReLU,
+                                             ReLU6,
+                                             relu,
+                                             relu6,
+                                             tp.LayerFilterParams(Hardtanh, min_val=0),
+                                             tp.LayerFilterParams(hardtanh, min_val=0)])
+
+        tp.OperationsSetToLayers("Add", [operator.add, add])
+        tp.OperationsSetToLayers("Sub", [operator.sub, sub])
+        tp.OperationsSetToLayers("Mul", [operator.mul, mul])
+        tp.OperationsSetToLayers("Div", [operator.truediv, div])
+        tp.OperationsSetToLayers("PReLU", [PReLU, prelu])
+        tp.OperationsSetToLayers("Swish", [SiLU, silu, Hardswish, hardswish])
+        tp.OperationsSetToLayers("Sigmoid", [Sigmoid, sigmoid])
+        tp.OperationsSetToLayers("Tanh", [Tanh, tanh])
+
+    return pytorch_tpc


### PR DESCRIPTION
Added Mixed-Precision LUT TPC. 
Enables execution of mixed-precision quantization using non-uniform quantizer for 2 and 4 bits.