### PR TITLE
Support DW-Conv2D in QAT when quantizing per weights per channel

### DIFF
--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat_test.py
@@ -15,6 +15,7 @@
 
 
 import tensorflow as tf
+import numpy as np
 from tensorflow_model_optimization.python.core.quantization.keras.default_8bit.default_8bit_quantize_configs import NoOpQuantizeConfig
 
 from tests.keras_tests.tpc_keras import get_tpc
@@ -40,9 +41,8 @@ class QuantizationAwareTrainingTest(BaseKerasFeatureNetworkTest):
         outputs = layers.Conv2D(3, 4, activation='relu')(inputs)
         return keras.Model(inputs=inputs, outputs=outputs)
 
-    def run_test(self):
+    def run_test(self, experimental_facade=False):
         model_float = self.create_networks()
-        qc = self.get_quantization_config()
         ptq_model, quantization_info, custom_objects = mct.keras_quantization_aware_training_init(model_float,
                                                                                                   self.representative_data_gen,
                                                                                                   fw_info=self.get_fw_info(),
@@ -64,3 +64,32 @@ class QuantizationAwareTrainingTest(BaseKerasFeatureNetworkTest):
             _, qconfig = quantized_model.layers[2].quantize_config.get_weights_and_quantizers(quantized_model.layers[2].layer)[0]
             self.unit_test.assertTrue(qconfig.num_bits == self.weight_bits)
         self.unit_test.assertTrue(isinstance(quantized_model.layers[3], layers.Activation))
+
+
+class QuantizationAwareTrainingQuantizersTest(QuantizationAwareTrainingTest):
+
+    def __init__(self, unit_test, weight_bits=8, activation_bits=4, finalize=False):
+        super().__init__(unit_test, weight_bits=weight_bits,
+                         activation_bits=activation_bits, finalize=finalize)
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        dw_conv2d = layers.DepthwiseConv2D(5, activation='relu')
+        outputs = dw_conv2d(inputs)
+        w = np.arange(5 * 5 * 3, dtype=np.float32).reshape((3, 5, 5, 1)).transpose((1, 2, 0, 3))
+        # Add LSB to verify the correct threshold is chosen and applied per channel
+        w[0, 0, :, 0] += np.array([0.25, 0.5, 0.])
+        dw_conv2d.weights[0].assign(w)
+        return keras.Model(inputs=inputs, outputs=outputs)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        if self.finalize:
+            self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.DepthwiseConv2D))
+            dw_weight = float_model.layers[1].weights[0].numpy()
+            quantized_dw_weight = quantized_model.layers[2].weights[0].numpy()
+        else:
+            self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
+            dw_weight = quantized_model.layers[2].weights[0].numpy()
+            qconfig = quantized_model.layers[2].quantize_config.get_weights_and_quantizers(quantized_model.layers[2].layer)[0][1]
+            quantized_dw_weight = qconfig(dw_weight, False, qconfig.quantizer_parameters).numpy()
+        self.unit_test.assertTrue(np.all(dw_weight == quantized_dw_weight))

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -89,7 +89,8 @@ from tests.keras_tests.feature_networks_tests.feature_networks.lut_quantizer imp
     LUTActivationQuantizerTest
 from tests.keras_tests.feature_networks_tests.feature_networks.multi_head_attention_test import MultiHeadAttentionTest
 from tests.keras_tests.feature_networks_tests.feature_networks.layer_norm_substitution_test import LayerNormSub
-from tests.keras_tests.feature_networks_tests.feature_networks.qat_test import QuantizationAwareTrainingTest
+from tests.keras_tests.feature_networks_tests.feature_networks.qat_test import QuantizationAwareTrainingTest, \
+    QuantizationAwareTrainingQuantizersTest
 import tensorflow as tf
 from tensorflow.keras.layers import ReLU, PReLU, ELU
 
@@ -513,6 +514,8 @@ class FeatureNetworkTest(unittest.TestCase):
     def test_qat(self):
         QuantizationAwareTrainingTest(self).run_test()
         QuantizationAwareTrainingTest(self, finalize=True).run_test()
+        QuantizationAwareTrainingQuantizersTest(self).run_test()
+        QuantizationAwareTrainingQuantizersTest(self, finalize=True).run_test()
 
 
 if __name__ == '__main__':

--- a/tutorials/example_pytorch_quantization_mnist.ipynb
+++ b/tutorials/example_pytorch_quantization_mnist.ipynb
@@ -29,7 +29,7 @@
    "id": "743dbc3d",
    "metadata": {},
    "source": [
-    "This quick start guide covers how to use the Model Compression Toolkit (MCT) for quantizing a PyTorch model. We will do so by giving an end-to-end example, training a model from scratch on MNIST data, then quantizing it using the MCT. Let us start with the relevant imports:"
+    "This quick start guide covers how to use the Model Compression Toolkit (MCT) for quantizing a PyTorch model. We will do so by giving an end-to-end example, training a model from scratch on MNIST data, then quantizing it using the MCT."
    ]
   },
   {


### PR DESCRIPTION
Fix bug with weight quantization per output channel when channel axis isn't the last axis