### PR TITLE
Graph substitutions for weight and activation composition (BOPs KPI preparations)

### DIFF
--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -54,6 +54,7 @@ SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS = 16
 
 # Default bitwidth for disabled quantization candidate
 DEFAULT_CANDIDATE_BITWIDTH = 16
+FLOAT_BITWIDTH = 32
 
 # In Mixed-Precision, a node can have multiple candidates for weights and activations quantization configuration.
 # In order to display a single view of a node (for example, for logging in TensorBoard) we need to track the attributes
@@ -95,3 +96,9 @@ BITS_TO_BYTES = 8.0
 
 # Default threshold for Softmax layer
 SOFTMAX_THRESHOLD = 1
+
+
+# Substitutions node names
+VIRTUAL_WEIGHTS_SUFFIX = '_v_weights'
+VIRTUAL_ACTIVATION_SUFFIX = '_v_activation'
+VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX = 'virtual'

--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -43,6 +43,10 @@ LAST_AXIS = -1
 DATA_TYPE = 'dtype'
 FLOAT_32 = 'float32'
 
+# Common layers attributes and operations names:
+ACTIVATION = 'activation'
+LINEAR = 'linear'
+
 # Version
 LATEST = 'latest'
 

--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -102,3 +102,14 @@ SOFTMAX_THRESHOLD = 1
 VIRTUAL_WEIGHTS_SUFFIX = '_v_weights'
 VIRTUAL_ACTIVATION_SUFFIX = '_v_activation'
 VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX = 'virtual'
+
+# Quantization config candidate initialization
+ACTIVATION_QUANTIZATION_CFG = 'activation_quantization_cfg'
+WEIGHTS_QUANTIZATION_CFG = 'weights_quantization_cfg'
+QC = 'qc'
+OP_CFG = 'op_cfg'
+ACTIVATION_QUANTIZATION_FN = 'activation_quantization_fn'
+WEIGHTS_QUANTIZATION_FN = 'weights_quantization_fn'
+ACTIVATION_QUANT_PARAMS_FN = 'activation_quantization_params_fn'
+WEIGHTS_QUANT_PARAMS_FN = 'weights_quantization_params_fn'
+WEIGHTS_CHANNELS_AXIS = 'weights_channels_axis'

--- a/model_compression_toolkit/core/common/graph/base_graph.py
+++ b/model_compression_toolkit/core/common/graph/base_graph.py
@@ -391,6 +391,8 @@ class Graph(nx.MultiDiGraph, GraphSearches):
             new_node: New node to set as an input node if the current node is an input node.
 
         """
+        if new_node is None:
+            Logger.error("Graph received a None value as a new input node.")
 
         graph_inputs = self.get_inputs()
         new_graph_inputs = copy(graph_inputs)

--- a/model_compression_toolkit/core/common/graph/base_graph.py
+++ b/model_compression_toolkit/core/common/graph/base_graph.py
@@ -377,6 +377,28 @@ class Graph(nx.MultiDiGraph, GraphSearches):
                 new_graph_outputs[graph_ot_index] = OutTensor(new_node, ot.node_out_index)
         self.set_outputs(new_graph_outputs)
 
+    def replace_input_node(self,
+                           current_node: BaseNode,
+                           new_node: BaseNode):
+        """
+        If a node is being substituted with another node, and it is an input node, the graph's input
+        should be updated as well. This function takes care of it by going over the graph's inputs, and
+        replacing the current input node with a new input node.
+        If current node is not an input node, nothing gets changed.
+
+        Args:
+            current_node: Node that (possibly) is an input node.
+            new_node: New node to set as an input node if the current node is an input node.
+
+        """
+
+        graph_inputs = self.get_inputs()
+        new_graph_inputs = copy(graph_inputs)
+        if current_node in graph_inputs:
+            new_graph_inputs.remove(current_node)
+            new_graph_inputs.append(new_node)
+        self.set_inputs(new_graph_inputs)
+
     def remove_node(self,
                     node_to_remove: BaseNode,
                     new_graph_inputs: List[BaseNode] = None,

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -367,8 +367,8 @@ class BaseNode:
     def get_unique_weights_candidates(self) -> List[Any]:
         """
         Returns a list with node's candidates of unique weights bit-width value.
-        If the node have multiple candidates with the same weights bit-width, the candidate with the highest
-        activation bit-width is returned.
+        If the node have multiple candidates with the same weights bit-width,
+        the first candidate in the list is returned.
 
         Returns: A list with node's candidates of unique weights bit-width value.
         """
@@ -383,8 +383,8 @@ class BaseNode:
     def get_unique_activation_candidates(self) -> List[Any]:
         """
         Returns a list with node's candidates of unique activation bit-width value.
-        If the node have multiple candidates with the same activation bit-width, the candidate with the highest
-        weights bit-width is returned.
+        If the node have multiple candidates with the same activation bit-width,
+        the first candidate in the list is returned.
 
         Returns: A list with node's candidates of unique activation bit-width value.
         """

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -363,3 +363,35 @@ class BaseNode:
                 max_candidates.append((i, c))
 
         return [i for i, a_n_bits in max_candidates]
+
+    def get_unique_weights_candidates(self) -> List[Any]:
+        """
+        Returns a list with node's candidates of unique weights bit-width value.
+        If the node have multiple candidates with the same weights bit-width, the candidate with the highest
+        activation bit-width is returned.
+
+        Returns: A list with node's candidates of unique weights bit-width value.
+        """
+
+        unique_candidates = copy.deepcopy(self.candidates_quantization_cfg)
+        seen_candidates = set()
+        unique_candidates = [candidate for candidate in unique_candidates if
+                             candidate.weights_quantization_cfg not in seen_candidates
+                             and not seen_candidates.add(candidate.weights_quantization_cfg)]
+        return unique_candidates
+
+    def get_unique_activation_candidates(self) -> List[Any]:
+        """
+        Returns a list with node's candidates of unique activation bit-width value.
+        If the node have multiple candidates with the same activation bit-width, the candidate with the highest
+        weights bit-width is returned.
+
+        Returns: A list with node's candidates of unique activation bit-width value.
+        """
+
+        unique_candidates = copy.deepcopy(self.candidates_quantization_cfg)
+        seen_candidates = set()
+        unique_candidates = [candidate for candidate in unique_candidates if
+                             candidate.activation_quantization_cfg not in seen_candidates
+                             and not seen_candidates.add(candidate.activation_quantization_cfg)]
+        return unique_candidates

--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -95,7 +95,7 @@ class VirtualSplitActivationNode(VirtualSplitNode):
         super().__init__(origin_node)
 
         self.name = origin_node.name + VIRTUAL_ACTIVATION_SUFFIX
-        self.framework_attr = {ACTIVATION: LINEAR}
+        self.framework_attr = {ACTIVATION: LINEAR}  # TODO: verify that these values work for Pytorch substitution as well (when implementing in Pytorch)
         self.prior_info = origin_node.prior_info
         self.input_shape = origin_node.output_shape  # the kernel output is the activation input
         self.weights = {}

--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -112,6 +112,12 @@ class VirtualActivationWeightsNode(BaseNode):
     A node that represents a composition of pair of sequential activation node and weights (kernel) node.
     This structure is used for mixed-precision search with bit-operation KPI.
     The node's candidates are the cartesian product of both nodes' candidates.
+
+    Important: note that not like regular BaseNode or FunctionalNode, in VirtualActivationWeightsNode the activation
+    candidates config refer to the quantization config of the activation that precedes the linear operation! instead of
+    the output of the linear operation.
+    It is ok, since this node is not meant to be used in a graph for creating an actual model, but only a virtual
+    representation of the model's graph only for allowing to compute the bit-operations KPI in mixed-precision.
     """
 
     def __init__(self,
@@ -177,21 +183,3 @@ class VirtualActivationWeightsNode(BaseNode):
                                          c.activation_quantization_cfg.activation_n_bits), reverse=True)
 
         self.candidates_quantization_cfg = v_candidates
-
-    def get_bops_count(self, fw_impl: Any, fw_info: FrameworkInfo, candidate_idx: int) -> float:
-        """
-        Computes the composed node's (edge) bit-operation count.
-
-        Args:
-            fw_impl: A FrameworkImplementation object with framework specific methods.
-            fw_info: A FrameworkInfo object with framework specific information,
-            candidate_idx: The index of the node's quantization candidate configuration.
-
-        Returns: The BOPS count of the composed node.
-
-        """
-        node_mac = fw_impl.get_node_mac_operations(self.original_weights_node, fw_info)
-        node_bops = self.candidates_quantization_cfg[candidate_idx].weights_quantization_cfg.weights_n_bits * \
-                    self.candidates_quantization_cfg[candidate_idx].activation_quantization_cfg.activation_n_bits * \
-                    node_mac
-        return node_bops

--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -1,0 +1,198 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Dict, Any, Tuple
+
+from model_compression_toolkit import FrameworkInfo
+from model_compression_toolkit.core.common.constants import VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX, \
+    VIRTUAL_WEIGHTS_SUFFIX, DEFAULT_CANDIDATE_BITWIDTH, VIRTUAL_ACTIVATION_SUFFIX
+from model_compression_toolkit.core.common.graph.base_node import BaseNode
+import numpy as np
+
+from model_compression_toolkit.core.common.quantization.candidate_node_quantization_config import \
+    CandidateNodeQuantizationConfig
+from model_compression_toolkit.core.keras.constants import ACTIVATION, LINEAR
+
+
+class VirtualSplitNode(BaseNode):
+    """
+    A class that represents a node that was split from a kernel node (node with weights).
+    """
+
+    def __init__(self, origin_node):
+        """
+        Init a VirtualSplitNode object.
+
+        Args:
+            origin_node: The original node from which the new node was split.
+        """
+
+        super().__init__(origin_node.name,
+                         origin_node.framework_attr,
+                         origin_node.input_shape,
+                         origin_node.output_shape,
+                         origin_node.weights,
+                         origin_node.layer_class,
+                         origin_node.reuse,
+                         origin_node.reuse_group,
+                         origin_node.quantization_attr,
+                         origin_node.has_activation)
+
+        self.origin_node = origin_node
+
+
+class VirtualSplitWeightsNode(VirtualSplitNode):
+    """
+    A class that represents a node that was split from a kernel node (node with weights) and holds the weights of
+    the original node. This node contains the original node's weights and the relevant weights candidate quantization
+    config.
+    """
+
+    def __init__(self, origin_node):
+        """
+        Init a VirtualSplitWeightsNode object.
+
+        Args:
+            origin_node: The original node from which the new node was split.
+        """
+
+        super().__init__(origin_node)
+
+        self.name = origin_node.name + VIRTUAL_WEIGHTS_SUFFIX
+
+        self.candidates_quantization_cfg = origin_node.get_unique_weights_candidates()
+        for c in self.candidates_quantization_cfg:
+            c.activation_quantization_cfg.enable_activation_quantization = False
+            c.activation_quantization_cfg.activation_n_bits = DEFAULT_CANDIDATE_BITWIDTH
+
+
+class VirtualSplitActivationNode(VirtualSplitNode):
+    """
+    A class that represents a node that was split from a kernel node (node with weights) and holds the activation
+    operation of the original node. This node baisically does not apply any operation and only holds the relevant
+    activation candidate quantization config.
+    """
+
+    def __init__(self, origin_node, activation_class):
+        """
+        Init a VirtualSplitActivationNode object.
+
+        Args:
+            origin_node: The original node from which the new node was split.
+        """
+
+        super().__init__(origin_node)
+
+        self.name = origin_node.name + VIRTUAL_ACTIVATION_SUFFIX
+        self.framework_attr = {ACTIVATION: LINEAR}
+        self.prior_info = origin_node.prior_info
+        self.input_shape = origin_node.output_shape  # the kernel output is the activation input
+        self.weights = {}
+        self.layer_class = activation_class
+
+        self.candidates_quantization_cfg = origin_node.get_unique_activation_candidates()
+        for c in self.candidates_quantization_cfg:
+            c.weights_quantization_cfg.enable_weights_quantization = False
+            c.weights_quantization_cfg.weights_n_bits = DEFAULT_CANDIDATE_BITWIDTH
+
+
+class VirtualActivationWeightsNode(BaseNode):
+    """
+    A node that represents a composition of pair of sequential activation node and weights (kernel) node.
+    This structure is used for mixed-precision with search with bit-operation KPI.
+    The node's candidates are the product of both nodes' candidates.
+    """
+
+    def __init__(self,
+                 act_node: BaseNode,
+                 weights_node: BaseNode,
+                 name: str,
+                 framework_attr: Dict[str, Any],
+                 input_shape: Tuple[Any],
+                 output_shape: Tuple[Any],
+                 weights: Dict[str, np.ndarray],
+                 layer_class: type,
+                 reuse: bool = False,
+                 reuse_group: str = None,
+                 quantization_attr: Dict[str, Any] = None,
+                 has_activation: bool = True,
+                 **kwargs):
+        """
+        Init a VirtualActivationWeightsNode object.
+
+        Args:
+            act_node: The original activation node.
+            weights_node: The original weights node.
+            name: Node's name
+            framework_attr: Framework attributes the layer had which the node holds.
+            input_shape: Input tensor shape of the node.
+            output_shape: Input tensor shape of the node.
+            weights: Dictionary from a variable name to the weights with that name in the layer the node represents.
+            layer_class: Class path of the layer this node represents.
+            reuse: Whether this node was duplicated and represents a reused layer.
+            reuse_group: Name of group of nodes from the same reused layer.
+            quantization_attr: Attributes the node holds regarding how it should be quantized.
+            has_activation: Whether the node has activations that we might want to quantize.
+            **kwargs: Additional arguments that can be passed but are not used (allows to init the object with an
+                existing node's __dict__).
+
+        """
+
+        super().__init__(name,
+                         framework_attr,
+                         input_shape,
+                         output_shape,
+                         weights,
+                         layer_class,
+                         reuse,
+                         reuse_group,
+                         quantization_attr,
+                         has_activation)
+
+        self.name = f"{VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX}_{act_node.name}_{weights_node.name}"
+
+        self.original_activation_node = act_node
+        self.original_weights_node = weights_node
+
+        v_candidates = []
+        for c_a in act_node.candidates_quantization_cfg:
+            for c_w in weights_node.candidates_quantization_cfg:
+                composed_candidate = CandidateNodeQuantizationConfig(activation_quantization_cfg=c_a.activation_quantization_cfg,
+                                                                     weights_quantization_cfg=c_w.weights_quantization_cfg)
+                v_candidates.append(composed_candidate)
+
+        # sorting the candidates by weights number of bits first and then by activation number of bits (reversed order)
+        v_candidates.sort(key=lambda c: (c.weights_quantization_cfg.weights_n_bits,
+                                         c.activation_quantization_cfg.activation_n_bits), reverse=True)
+
+        self.candidates_quantization_cfg = v_candidates
+
+    def get_bops_count(self, fw_impl: Any, fw_info: FrameworkInfo, candidate_idx: int) -> float:
+        """
+        Computes the composed node's (edge) bit-operation count.
+
+        Args:
+            fw_impl: A FrameworkImplementation object with framework specific methods.
+            fw_info: A FrameworkInfo object with framework specific information,
+            candidate_idx: The index of the node's quantization candidate configuration.
+
+        Returns: The BOPS count of the composed node.
+
+        """
+        node_mac = fw_impl.get_node_mac_operations(self.original_weights_node, fw_info)
+        node_bops = self.candidates_quantization_cfg[candidate_idx].weights_quantization_cfg.weights_n_bits * \
+                    self.candidates_quantization_cfg[candidate_idx].activation_quantization_cfg.activation_n_bits * \
+                    node_mac
+        return node_bops

--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -17,13 +17,12 @@ from typing import Dict, Any, Tuple
 
 from model_compression_toolkit import FrameworkInfo
 from model_compression_toolkit.core.common.constants import VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX, \
-    VIRTUAL_WEIGHTS_SUFFIX, DEFAULT_CANDIDATE_BITWIDTH, VIRTUAL_ACTIVATION_SUFFIX
+    VIRTUAL_WEIGHTS_SUFFIX, DEFAULT_CANDIDATE_BITWIDTH, VIRTUAL_ACTIVATION_SUFFIX, ACTIVATION, LINEAR
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
 import numpy as np
 
 from model_compression_toolkit.core.common.quantization.candidate_node_quantization_config import \
     CandidateNodeQuantizationConfig
-from model_compression_toolkit.core.keras.constants import ACTIVATION, LINEAR
 
 
 class VirtualSplitNode(BaseNode):
@@ -31,7 +30,7 @@ class VirtualSplitNode(BaseNode):
     A class that represents a node that was split from a kernel node (node with weights).
     """
 
-    def __init__(self, origin_node):
+    def __init__(self, origin_node: BaseNode):
         """
         Init a VirtualSplitNode object.
 
@@ -60,7 +59,7 @@ class VirtualSplitWeightsNode(VirtualSplitNode):
     config.
     """
 
-    def __init__(self, origin_node):
+    def __init__(self, origin_node: BaseNode):
         """
         Init a VirtualSplitWeightsNode object.
 
@@ -81,11 +80,11 @@ class VirtualSplitWeightsNode(VirtualSplitNode):
 class VirtualSplitActivationNode(VirtualSplitNode):
     """
     A class that represents a node that was split from a kernel node (node with weights) and holds the activation
-    operation of the original node. This node baisically does not apply any operation and only holds the relevant
+    operation of the original node. This node basically does not apply any operation and only holds the relevant
     activation candidate quantization config.
     """
 
-    def __init__(self, origin_node, activation_class):
+    def __init__(self, origin_node: BaseNode, activation_class: type):
         """
         Init a VirtualSplitActivationNode object.
 
@@ -111,8 +110,8 @@ class VirtualSplitActivationNode(VirtualSplitNode):
 class VirtualActivationWeightsNode(BaseNode):
     """
     A node that represents a composition of pair of sequential activation node and weights (kernel) node.
-    This structure is used for mixed-precision with search with bit-operation KPI.
-    The node's candidates are the product of both nodes' candidates.
+    This structure is used for mixed-precision search with bit-operation KPI.
+    The node's candidates are the cartesian product of both nodes' candidates.
     """
 
     def __init__(self,

--- a/model_compression_toolkit/core/common/quantization/candidate_node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/candidate_node_quantization_config.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.core.common.constants import ACTIVATION_QUANTIZATION_CFG, WEIGHTS_QUANTIZATION_CFG, QC, \
+    OP_CFG, ACTIVATION_QUANTIZATION_FN, WEIGHTS_QUANTIZATION_FN, ACTIVATION_QUANT_PARAMS_FN, WEIGHTS_QUANT_PARAMS_FN, \
+    WEIGHTS_CHANNELS_AXIS
 from model_compression_toolkit.core.common.quantization.node_quantization_config import BaseNodeNodeQuantizationConfig, \
     NodeWeightsQuantizationConfig, NodeActivationQuantizationConfig
 
@@ -28,20 +31,20 @@ class CandidateNodeQuantizationConfig(BaseNodeNodeQuantizationConfig):
     """
 
     def __init__(self, **kwargs):
-        activation_quantization_cfg = kwargs.get('activation_quantization_cfg', None)
+        activation_quantization_cfg = kwargs.get(ACTIVATION_QUANTIZATION_CFG, None)
         if activation_quantization_cfg is not None:
             self.activation_quantization_cfg = activation_quantization_cfg
         else:
-            self.activation_quantization_cfg = NodeActivationQuantizationConfig(kwargs.get('qc'),
-                                                                                kwargs.get('op_cfg'),
-                                                                                kwargs.get('activation_quantization_fn'),
-                                                                                kwargs.get('activation_quantization_params_fn'))
-        weights_quantization_cfg = kwargs.get('weights_quantization_cfg', None)
+            self.activation_quantization_cfg = NodeActivationQuantizationConfig(kwargs.get(QC),
+                                                                                kwargs.get(OP_CFG),
+                                                                                kwargs.get(ACTIVATION_QUANTIZATION_FN),
+                                                                                kwargs.get(ACTIVATION_QUANT_PARAMS_FN))
+        weights_quantization_cfg = kwargs.get(WEIGHTS_QUANTIZATION_CFG, None)
         if weights_quantization_cfg is not None:
             self.weights_quantization_cfg = weights_quantization_cfg
         else:
-            self.weights_quantization_cfg = NodeWeightsQuantizationConfig(kwargs.get('qc'),
-                                                                          kwargs.get('op_cfg'),
-                                                                          kwargs.get('weights_quantization_fn'),
-                                                                          kwargs.get('weights_quantization_params_fn'),
-                                                                          kwargs.get('weights_channels_axis'))
+            self.weights_quantization_cfg = NodeWeightsQuantizationConfig(kwargs.get(QC),
+                                                                          kwargs.get(OP_CFG),
+                                                                          kwargs.get(WEIGHTS_QUANTIZATION_FN),
+                                                                          kwargs.get(WEIGHTS_QUANT_PARAMS_FN),
+                                                                          kwargs.get(WEIGHTS_CHANNELS_AXIS))

--- a/model_compression_toolkit/core/common/quantization/candidate_node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/candidate_node_quantization_config.py
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-
-from typing import Callable
-
-from model_compression_toolkit.core.common.target_platform import OpQuantizationConfig
 from model_compression_toolkit.core.common.quantization.node_quantization_config import BaseNodeNodeQuantizationConfig, \
     NodeWeightsQuantizationConfig, NodeActivationQuantizationConfig
-from model_compression_toolkit.core.common.quantization.quantization_config import QuantizationConfig
 
 
 ##########################################
@@ -32,34 +26,22 @@ class CandidateNodeQuantizationConfig(BaseNodeNodeQuantizationConfig):
     """
     Class for representing candidate node configuration, which includes weights and activation configuration combined.
     """
-    def __init__(self,
-                 qc: QuantizationConfig,
-                 op_cfg: OpQuantizationConfig,
-                 activation_quantization_fn: Callable,
-                 activation_quantization_params_fn: Callable,
-                 weights_quantization_fn: Callable,
-                 weights_quantization_params_fn: Callable,
-                 weights_channels_axis: int
-                 ):
-        """
 
-        Args:
-            qc: QuantizationConfig to create the node's config from.
-            op_cfg: OpQuantizationConfig of the node with quantizers types to use when creating node quantization configuration.
-            activation_quantization_fn: Function to use when quantizing the node's activations.
-            activation_quantization_params_fn: Function to use when computing the threshold for quantizing a node's activations.
-            weights_quantization_fn: Function to use when quantizing the node's weights.
-            weights_quantization_params_fn:  Function to use when computing the threshold for quantizing a node's weights.
-            weights_channels_axis: Axis to quantize a node's kernel when quantizing per-channel.
-        """
-
-        self.activation_quantization_cfg = NodeActivationQuantizationConfig(qc,
-                                                                            op_cfg,
-                                                                            activation_quantization_fn,
-                                                                            activation_quantization_params_fn)
-
-        self.weights_quantization_cfg = NodeWeightsQuantizationConfig(qc,
-                                                                      op_cfg,
-                                                                      weights_quantization_fn,
-                                                                      weights_quantization_params_fn,
-                                                                      weights_channels_axis)
+    def __init__(self, **kwargs):
+        activation_quantization_cfg = kwargs.get('activation_quantization_cfg', None)
+        if activation_quantization_cfg is not None:
+            self.activation_quantization_cfg = activation_quantization_cfg
+        else:
+            self.activation_quantization_cfg = NodeActivationQuantizationConfig(kwargs.get('qc'),
+                                                                                kwargs.get('op_cfg'),
+                                                                                kwargs.get('activation_quantization_fn'),
+                                                                                kwargs.get('activation_quantization_params_fn'))
+        weights_quantization_cfg = kwargs.get('weights_quantization_cfg', None)
+        if weights_quantization_cfg is not None:
+            self.weights_quantization_cfg = weights_quantization_cfg
+        else:
+            self.weights_quantization_cfg = NodeWeightsQuantizationConfig(kwargs.get('qc'),
+                                                                          kwargs.get('op_cfg'),
+                                                                          kwargs.get('weights_quantization_fn'),
+                                                                          kwargs.get('weights_quantization_params_fn'),
+                                                                          kwargs.get('weights_channels_axis'))

--- a/model_compression_toolkit/core/common/quantization/filter_nodes_candidates.py
+++ b/model_compression_toolkit/core/common/quantization/filter_nodes_candidates.py
@@ -53,7 +53,15 @@ def filter_node_candidates(node: BaseNode) -> List[CandidateNodeQuantizationConf
 
     filtered_candidates = copy.deepcopy(node.candidates_quantization_cfg)
 
-    if not node.is_activation_quantization_enabled():
+    if not node.is_weights_quantization_enabled() and not node.is_activation_quantization_enabled():
+        # If both weights and activation quantization are disabled, but for some reason the node has multiple candidates
+        # then replace it with a single dummy candidate with default bit-width values.
+        single_dummy_candidate = filtered_candidates[0]
+        single_dummy_candidate.activation_quantization_cfg.activation_n_bits = DEFAULT_CANDIDATE_BITWIDTH
+        single_dummy_candidate.weights_quantization_cfg.weights_n_bits = DEFAULT_CANDIDATE_BITWIDTH
+        filtered_candidates = [single_dummy_candidate]
+
+    elif not node.is_activation_quantization_enabled():
         # Remove candidates that have duplicated weights candidates for node with disabled activation quantization.
         # Replacing the activation n_bits in the remained configurations with default value to prevent confusion.
         seen_candidates = set()

--- a/model_compression_toolkit/core/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/set_node_quantization_config.py
@@ -15,13 +15,11 @@
 
 
 import copy
-from typing import List, Dict
+from typing import List
 
 from model_compression_toolkit.core.common import Logger, BaseNode
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo
 from model_compression_toolkit.core.common.graph.base_graph import Graph
-from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
-    MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.common.quantization.candidate_node_quantization_config import \
     CandidateNodeQuantizationConfig
 from model_compression_toolkit.core.common.quantization.node_quantization_config import NodeActivationQuantizationConfig
@@ -153,13 +151,13 @@ def create_node_qc_candidate(qc: QuantizationConfig,
 
     activation_quantization_params_fn = get_activation_quantization_params_fn(op_cfg.activation_quantization_method)
 
-    return CandidateNodeQuantizationConfig(qc,
-                                           op_cfg,
-                                           activation_quantization_fn,
-                                           activation_quantization_params_fn,
-                                           weights_quantization_fn,
-                                           weights_quantization_params_fn,
-                                           weight_channel_axis)
+    return CandidateNodeQuantizationConfig(qc=qc,
+                                           op_cfg=op_cfg,
+                                           activation_quantization_fn=activation_quantization_fn,
+                                           activation_quantization_params_fn=activation_quantization_params_fn,
+                                           weights_quantization_fn=weights_quantization_fn,
+                                           weights_quantization_params_fn=weights_quantization_params_fn,
+                                           weight_channel_axis=weight_channel_axis)
 
 
 def _create_node_candidates_qc(qc: QuantizationConfig,

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
@@ -42,7 +42,7 @@ class VirtualActivationWeightsComposition(common.BaseSubstitution):
         """
         Combines an activation --> weights edge's node into one virtual composed node that contains the activation
         operation and the linear operation (in that order).
-        The node's quantization configuration candidates include the product of both node's candidates.
+        The node's quantization configuration candidates include the cartesian product of both node's candidates.
         Note that if the activation node has multiple outputs (beside its matched weights node) than the substitution
         would not apply.
 

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
@@ -1,0 +1,84 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Tuple
+from tensorflow.keras.layers import Dense, DepthwiseConv2D, Conv2D, Conv2DTranspose
+from model_compression_toolkit.core import common
+from model_compression_toolkit.core.common import BaseNode, Graph
+from model_compression_toolkit.core.common.logger import Logger
+from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher, EdgeMatcher
+from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualActivationWeightsNode
+
+
+class VirtualActivationWeightsComposition(common.BaseSubstitution):
+    def __init__(self):
+        """
+        Matches: Edge (Activation) --> (DepthwiseConv2D, Conv2D, Dense, Conv2DTranspose)
+        """
+
+        weights_node = NodeOperationMatcher(DepthwiseConv2D) | \
+                       NodeOperationMatcher(Conv2D) | \
+                       NodeOperationMatcher(Dense) | \
+                       NodeOperationMatcher(Conv2DTranspose)
+
+        act_node = weights_node.logic_not()
+
+        super().__init__(matcher_instance=EdgeMatcher(act_node, weights_node))
+
+    def substitute(self,
+                   graph: Graph,
+                   edge_nodes: Tuple[BaseNode, BaseNode]) -> Graph:
+        """
+        Combines an activation --> weights edge's node into one virtual composed node that contains the activation
+        operation and the linear operation (in that order).
+        The node's quantization configuration candidates include the product of both node's candidates.
+        Note that if the activation node has multiple outputs (beside its matched weights node) than the substitution
+        would not apply.
+
+        Args:
+            graph: Graph we apply the substitution on.
+            edge_nodes: An edge to be composed.
+
+        Returns:
+            Graph after applying the substitution.
+        """
+
+        act_node = edge_nodes[0]
+        weights_node = edge_nodes[1]
+
+        if len(graph.out_edges(act_node)) > 1:
+            Logger.warning(f"Node {act_node.name} has multiple outgoing edges, which is not supported with "
+                           f"mixed-precision bit-operations KPI, thus, edge {act_node.name} --> {weights_node.name} "
+                           f"would not be counted in the bit-operations calculations.")
+            return graph
+
+        # Virtual composed activation-weights node
+        # we pass a dummy initialization dict to initialize the super BaseNode class,
+        # the actual arguments values are irrelevant because they are being overridden or not used
+        v_node = VirtualActivationWeightsNode(act_node,
+                                              weights_node,
+                                              **weights_node.__dict__)
+
+        # Update graph
+        graph.add_node(v_node)
+        graph.reconnect_in_edges(current_node=act_node, new_node=v_node)
+        graph.reconnect_out_edges(current_node=weights_node, new_node=v_node)
+        graph.replace_input_node(current_node=act_node, new_node=v_node)
+        graph.replace_output_node(current_node=weights_node, new_node=v_node)
+        graph.remove_edge(act_node, weights_node)
+        graph.remove_node(weights_node)
+        graph.remove_node(act_node)
+
+        return graph
+

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
@@ -32,7 +32,7 @@ class VirtualActivationWeightsComposition(common.BaseSubstitution):
                        NodeOperationMatcher(Dense) | \
                        NodeOperationMatcher(Conv2DTranspose)
 
-        super().__init__(matcher_instance=EdgeMatcher(act_node, weights_node))
+        super().__init__(matcher_instance=weights_node)
 
     def substitute(self,
                    graph: Graph,

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/virtual_activation_weights_composition.py
@@ -24,7 +24,7 @@ from model_compression_toolkit.core.common.graph.virtual_activation_weights_node
 class VirtualActivationWeightsComposition(common.BaseSubstitution):
     def __init__(self):
         """
-        Matches: Edge (Activation) --> (DepthwiseConv2D, Conv2D, Dense, Conv2DTranspose)
+        Matches: (DepthwiseConv2D, Conv2D, Dense, Conv2DTranspose)
         """
 
         weights_node = NodeOperationMatcher(DepthwiseConv2D) | \
@@ -32,13 +32,11 @@ class VirtualActivationWeightsComposition(common.BaseSubstitution):
                        NodeOperationMatcher(Dense) | \
                        NodeOperationMatcher(Conv2DTranspose)
 
-        act_node = weights_node.logic_not()
-
         super().__init__(matcher_instance=EdgeMatcher(act_node, weights_node))
 
     def substitute(self,
                    graph: Graph,
-                   edge_nodes: Tuple[BaseNode, BaseNode]) -> Graph:
+                   weights_node: BaseNode) -> Graph:
         """
         Combines an activation --> weights edge's node into one virtual composed node that contains the activation
         operation and the linear operation (in that order).
@@ -48,14 +46,17 @@ class VirtualActivationWeightsComposition(common.BaseSubstitution):
 
         Args:
             graph: Graph we apply the substitution on.
-            edge_nodes: An edge to be composed.
+            weights_node: A node with linear operation to be combined with its preceding activation.
 
         Returns:
             Graph after applying the substitution.
         """
 
-        act_node = edge_nodes[0]
-        weights_node = edge_nodes[1]
+        predecessors = graph.get_prev_nodes(weights_node)
+        if len(predecessors) != 1:
+            return graph
+
+        act_node = predecessors[0]
 
         if len(graph.out_edges(act_node)) > 1:
             Logger.warning(f"Node {act_node.name} has multiple outgoing edges, which is not supported with "

--- a/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
+++ b/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
@@ -135,7 +135,8 @@ class TestActivationWeightsComposition(unittest.TestCase):
     def test_two_conv_net_compose_without_split(self):
         """
         Note that this test checks a hypothetical case that should not be used - we should not run nodes
-        composition running weights nodes split before, otherwise we'll might get duplication in the composed node's candidates.
+        composition without running weights nodes split before, otherwise we'll might get duplication
+        in the composed node's candidates.
         """
 
         in_model = two_conv_model()

--- a/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
+++ b/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
@@ -1,0 +1,264 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import keras
+import unittest
+
+from keras.layers import Conv2D, Conv2DTranspose, DepthwiseConv2D, Dense, BatchNormalization, ReLU, Input, Add
+import numpy as np
+
+from model_compression_toolkit import DEFAULTCONFIG, MixedPrecisionQuantizationConfig
+from model_compression_toolkit.core.common.fusion.layer_fusing import fusion
+from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualSplitActivationNode, \
+    VirtualSplitWeightsNode, VirtualActivationWeightsNode
+from model_compression_toolkit.core.common.quantization.filter_nodes_candidates import filter_nodes_candidates
+from model_compression_toolkit.core.common.quantization.set_node_quantization_config import \
+    set_quantization_configuration_to_graph
+from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
+from model_compression_toolkit.core.keras.graph_substitutions.substitutions.virtual_activation_weights_composition import \
+    VirtualActivationWeightsComposition
+from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weight_activation_split import \
+    WeightsActivationSplit
+from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
+from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_op_quantization_configs
+
+import model_compression_toolkit as mct
+from tests.common_tests.helpers.activation_mp_tp_model import generate_tp_model_with_activation_mp
+from tests.keras_tests.tpc_keras import generate_activation_mp_tpc_keras
+
+tp = mct.target_platform
+
+INPUT_SHAPE = (8, 8, 3)
+
+
+def _get_base_mp_nbits_candidates():
+    return [(4, 8), (4, 4), (4, 2),
+            (8, 8), (8, 4), (8, 2),
+            (2, 8), (2, 4), (2, 2)]
+
+
+def two_conv_model():
+    inputs = Input(shape=INPUT_SHAPE)
+    x = Conv2D(2, 3)(inputs)
+    x = BatchNormalization()(x)
+    x = ReLU()(x)
+    outputs = Conv2D(2, 3)(x)
+    return keras.Model(inputs=inputs, outputs=outputs)
+
+
+def multiple_weights_nodes_model():
+    inputs = Input(shape=INPUT_SHAPE)
+    x = Conv2D(2, 3)(inputs)
+    x = Conv2D(2, 3)(x)
+    x = BatchNormalization()(x)
+    x = ReLU()(x)
+    x = Conv2DTranspose(4, 3)(x)
+    x = BatchNormalization()(x)
+    x = ReLU()(x)
+    x = DepthwiseConv2D(3, depth_multiplier=10)(x)
+    outputs = Dense(20)(x)
+    return keras.Model(inputs=inputs, outputs=outputs)
+
+
+def multiple_outputs_activation_model():
+    inputs = Input(shape=INPUT_SHAPE)
+    x = Conv2D(2, 3)(inputs)
+    y = Conv2D(2, 3)(inputs)
+    x_relu = ReLU()(x)
+    y_relu = ReLU()(y)
+    outputs = Add()([x_relu, y_relu])
+    return keras.Model(inputs=inputs, outputs=outputs)
+
+
+def representative_dataset():
+    return [np.random.randn(1, 8, 8, 3).astype(np.float32)]
+
+
+def prepare_graph(in_model, keras_impl, mixed_precision_candidates_list, base_config):
+    fw_info = DEFAULT_KERAS_INFO
+    qc = MixedPrecisionQuantizationConfig(DEFAULTCONFIG)
+
+    graph = keras_impl.model_reader(in_model, representative_dataset)  # model reading
+
+    mp_tp_model = generate_tp_model_with_activation_mp(base_config, mixed_precision_candidates_list)
+    tpc = generate_activation_mp_tpc_keras(tp_model=mp_tp_model)
+
+    graph.set_fw_info(fw_info)
+    graph.set_tpc(tpc)
+
+    # Standard graph substitutions
+    graph = substitute(graph, keras_impl.get_substitutions_prepare_graph())
+    for node in graph.nodes:
+        node.prior_info = keras_impl.get_node_prior_info(node=node,
+                                                         fw_info=fw_info, graph=graph)
+    graph = substitute(graph, keras_impl.get_substitutions_pre_statistics_collection(qc))
+
+    graph = set_quantization_configuration_to_graph(graph=graph,
+                                                    quant_config=qc,
+                                                    mixed_precision_enable=True)
+    graph = fusion(graph, tpc)
+    graph = filter_nodes_candidates(graph)
+
+    return graph
+
+
+class TestActivationWeightsComposition(unittest.TestCase):
+
+    def _verify_two_conv_with_split_test(self, graph, v_graph, num_weights_candidates, num_activation_candidates):
+        self.assertTrue(len(v_graph.nodes) == len(graph.nodes),
+                        "Both convolutions should be split and then composed with their predecessor activation node."
+                        "So no change in number of node is expected.")
+        self.assertTrue(len(graph.input_nodes) == len(v_graph.input_nodes))
+        self.assertTrue(len(graph.output_nodes) == len(v_graph.output_nodes))
+
+        composed_node_1 = v_graph.get_topo_sorted_nodes()[0]
+        composed_node_2 = v_graph.get_topo_sorted_nodes()[2]
+
+        self.assertTrue(len(composed_node_1.candidates_quantization_cfg) == num_weights_candidates,
+                        "The composed node should have the product of the activation and weights nodes candidates.")
+        self.assertTrue(len(composed_node_2.candidates_quantization_cfg) == num_activation_candidates,
+                        "The composed node should have the product of the activation and weights nodes candidates.")
+
+    def test_two_conv_net_compose_without_split(self):
+        """
+        Note that this test checks a hypothetical case that should not be used - we should not run nodes
+        composition running weights nodes split before, otherwise we'll might get duplication in the composed node's candidates.
+        """
+
+        in_model = two_conv_model()
+        keras_impl = KerasImplementation()
+
+        base_config, _ = get_op_quantization_configs()
+        graph = prepare_graph(in_model, keras_impl,
+                              mixed_precision_candidates_list=_get_base_mp_nbits_candidates(), base_config=base_config)
+
+        # Nodes composition substitution
+        v_graph = substitute(graph, [VirtualActivationWeightsComposition()])
+
+        self.assertTrue(len(v_graph.nodes) == len(graph.nodes) - 2,
+                        "Both convolution nodes should be composed with their predecessor activation node.")
+        self.assertTrue(len(graph.input_nodes) == len(v_graph.input_nodes))
+        self.assertTrue(len(graph.output_nodes) == len(v_graph.output_nodes))
+
+        composed_node_1 = v_graph.get_topo_sorted_nodes()[0]
+        composed_node_2 = v_graph.get_topo_sorted_nodes()[1]
+        graph_sorted_nodes = graph.get_topo_sorted_nodes()
+
+        self.assertTrue(composed_node_1.original_activation_node.name == graph_sorted_nodes[0].name)
+        self.assertTrue(composed_node_1.original_weights_node.name == graph_sorted_nodes[1].name)
+        self.assertTrue(composed_node_2.original_activation_node.name == graph_sorted_nodes[2].name)
+        self.assertTrue(composed_node_2.original_weights_node.name == graph_sorted_nodes[3].name)
+
+    def test_two_conv_net_compose_after_split(self):
+        in_model = two_conv_model()
+        keras_impl = KerasImplementation()
+
+        base_config, _ = get_op_quantization_configs()
+        graph = prepare_graph(in_model, keras_impl,
+                              mixed_precision_candidates_list=_get_base_mp_nbits_candidates(), base_config=base_config)
+
+        # Nodes split and composition substitution
+        split_graph = substitute(graph, [WeightsActivationSplit()])
+        v_graph = substitute(split_graph, [VirtualActivationWeightsComposition()])
+
+        self._verify_two_conv_with_split_test(graph, v_graph, 9, 9)
+
+    def test_two_conv_net_compose_after_split_weights_only(self):
+        in_model = two_conv_model()
+        keras_impl = KerasImplementation()
+
+        base_config, _ = get_op_quantization_configs()
+        base_config = base_config.clone_and_edit(enable_activation_quantization=False)
+        graph = prepare_graph(in_model, keras_impl,
+                              mixed_precision_candidates_list=_get_base_mp_nbits_candidates(), base_config=base_config)
+
+        # Nodes split and composition substitution
+        split_graph = substitute(graph, [WeightsActivationSplit()])
+        v_graph = substitute(split_graph, [VirtualActivationWeightsComposition()])
+
+        self._verify_two_conv_with_split_test(graph, v_graph, 3, 3)
+
+    def test_two_conv_net_compose_after_split_activation_only(self):
+        in_model = two_conv_model()
+        keras_impl = KerasImplementation()
+
+        base_config, _ = get_op_quantization_configs()
+        base_config = base_config.clone_and_edit(enable_weights_quantization=False)
+        graph = prepare_graph(in_model, keras_impl,
+                              mixed_precision_candidates_list=_get_base_mp_nbits_candidates(), base_config=base_config)
+
+        # Nodes split and composition substitution
+        split_graph = substitute(graph, [WeightsActivationSplit()])
+        v_graph = substitute(split_graph, [VirtualActivationWeightsComposition()])
+
+        self._verify_two_conv_with_split_test(graph, v_graph, 3, 3)
+
+    def test_all_weights_layers_composition(self):
+        in_model = multiple_weights_nodes_model()
+        keras_impl = KerasImplementation()
+
+        base_config, _ = get_op_quantization_configs()
+        graph = prepare_graph(in_model, keras_impl,
+                              mixed_precision_candidates_list=_get_base_mp_nbits_candidates(),
+                              base_config=base_config)
+
+        # Nodes split and composition substitution
+        split_graph = substitute(graph, [WeightsActivationSplit()])
+        v_graph = substitute(split_graph, [VirtualActivationWeightsComposition()])
+
+        self.assertTrue(len(v_graph.nodes) == 8)
+        self.assertTrue(len([n for n in v_graph.nodes if isinstance(n, VirtualActivationWeightsNode)]) == 5)
+
+        sorted_v_nodes = v_graph.get_topo_sorted_nodes()
+        # Input-Conv1 composed node
+        self.assertTrue(len(sorted_v_nodes[0].candidates_quantization_cfg) == 9)
+        # Conv1-Conv2 composed node
+        self.assertTrue(len(sorted_v_nodes[1].candidates_quantization_cfg) == 9)
+        # Conv2-Activation node
+        self.assertTrue(isinstance(sorted_v_nodes[2], VirtualSplitActivationNode))
+        self.assertTrue(len(sorted_v_nodes[2].candidates_quantization_cfg) == 3)
+        # Relu1-ConvTranspose composed node
+        self.assertTrue(len(sorted_v_nodes[3].candidates_quantization_cfg) == 9)
+        # ConvTranspose Activation
+        self.assertTrue(isinstance(sorted_v_nodes[4], VirtualSplitActivationNode))
+        self.assertTrue(len(sorted_v_nodes[4].candidates_quantization_cfg) == 3)
+        # Relu2-Depthwise composed node
+        self.assertTrue(len(sorted_v_nodes[5].candidates_quantization_cfg) == 9)
+        # Depthwise-Dense composed node
+        self.assertTrue(len(sorted_v_nodes[6].candidates_quantization_cfg) == 9)
+        # Dense Activation
+        self.assertTrue(isinstance(sorted_v_nodes[7], VirtualSplitActivationNode))
+        self.assertTrue(len(sorted_v_nodes[7].candidates_quantization_cfg) == 3)
+
+    def test_multiple_output_activation(self):
+        in_model = multiple_outputs_activation_model()
+        keras_impl = KerasImplementation()
+
+        base_config, _ = get_op_quantization_configs()
+        graph = prepare_graph(in_model, keras_impl,
+                              mixed_precision_candidates_list=_get_base_mp_nbits_candidates(), base_config=base_config)
+
+        # Nodes composition substitution
+        v_graph = substitute(graph, [VirtualActivationWeightsComposition()])
+
+        #  Since the only activation before the convolutions is the Input layer activation, and it goes to both
+        # convolutions (the input node has multiple output edges) no composition should be made.
+        self.assertTrue(len(v_graph.nodes) == len(graph.nodes))
+        self.assertTrue(not any([isinstance(n, VirtualActivationWeightsNode) for n in v_graph.nodes]))
+
+        sorted_v_nodes = v_graph.get_topo_sorted_nodes()
+        for i, n in enumerate(graph.get_topo_sorted_nodes()):
+            self.assertTrue(n.name == sorted_v_nodes[i].name)

--- a/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
+++ b/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
@@ -128,9 +128,9 @@ class TestActivationWeightsComposition(unittest.TestCase):
         composed_node_2 = v_graph.get_topo_sorted_nodes()[2]
 
         self.assertTrue(len(composed_node_1.candidates_quantization_cfg) == num_weights_candidates,
-                        "The composed node should have the product of the activation and weights nodes candidates.")
+                        "The composed node should have the cartesian product of the activation and weights nodes candidates.")
         self.assertTrue(len(composed_node_2.candidates_quantization_cfg) == num_activation_candidates,
-                        "The composed node should have the product of the activation and weights nodes candidates.")
+                        "The composed node should have the cartesian product of the activation and weights nodes candidates.")
 
     def test_two_conv_net_compose_without_split(self):
         """

--- a/tests/keras_tests/function_tests/test_weights_activation_split_substitution.py
+++ b/tests/keras_tests/function_tests/test_weights_activation_split_substitution.py
@@ -1,0 +1,183 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import keras
+import unittest
+
+from keras.layers import Conv2D, Conv2DTranspose, DepthwiseConv2D, Dense, BatchNormalization, ReLU, Input
+import numpy as np
+
+from model_compression_toolkit import DEFAULTCONFIG, MixedPrecisionQuantizationConfig
+from model_compression_toolkit.core.common.fusion.layer_fusing import fusion
+from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualSplitActivationNode, \
+    VirtualSplitWeightsNode
+from model_compression_toolkit.core.common.quantization.filter_nodes_candidates import filter_nodes_candidates
+from model_compression_toolkit.core.common.quantization.set_node_quantization_config import \
+    set_quantization_configuration_to_graph
+from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
+from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weight_activation_split import \
+    WeightsActivationSplit
+from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
+from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_op_quantization_configs
+
+import model_compression_toolkit as mct
+from tests.common_tests.helpers.activation_mp_tp_model import generate_tp_model_with_activation_mp
+from tests.keras_tests.tpc_keras import generate_activation_mp_tpc_keras
+
+tp = mct.target_platform
+
+INPUT_SHAPE = (8, 8, 3)
+
+
+def _get_base_mp_nbits_candidates():
+    return [(4, 8), (4, 4), (4, 2),
+            (8, 8), (8, 4), (8, 2),
+            (2, 8), (2, 4), (2, 2)]
+
+
+def single_conv_model():
+    inputs = Input(shape=INPUT_SHAPE)
+    x = Conv2D(2, 3)(inputs)
+    x = BatchNormalization()(x)
+    outputs = ReLU()(x)
+    return keras.Model(inputs=inputs, outputs=outputs)
+
+
+def multiple_weights_nodes_model():
+    inputs = Input(shape=INPUT_SHAPE)
+    x = Conv2D(2, 3)(inputs)
+    x = Conv2DTranspose(4, 3)(x)
+    x = DepthwiseConv2D(3, depth_multiplier=10)(x)
+    outputs = Dense(20)(x)
+    return keras.Model(inputs=inputs, outputs=outputs)
+
+
+def representative_dataset():
+    return [np.random.randn(1, 8, 8, 3).astype(np.float32)]
+
+
+def prepare_graph(in_model, keras_impl, mixed_precision_candidates_list):
+    fw_info = DEFAULT_KERAS_INFO
+    qc = MixedPrecisionQuantizationConfig(DEFAULTCONFIG)
+
+    graph = keras_impl.model_reader(in_model, representative_dataset)  # model reading
+
+    base_config, _ = get_op_quantization_configs()
+    mp_tp_model = generate_tp_model_with_activation_mp(base_config, mixed_precision_candidates_list)
+    tpc = generate_activation_mp_tpc_keras(tp_model=mp_tp_model)
+
+    graph.set_fw_info(fw_info)
+    graph.set_tpc(tpc)
+
+    # Standard graph substitutions
+    graph = substitute(graph, keras_impl.get_substitutions_prepare_graph())
+    for node in graph.nodes:
+        node.prior_info = keras_impl.get_node_prior_info(node=node,
+                                                         fw_info=fw_info, graph=graph)
+    graph = substitute(graph, keras_impl.get_substitutions_pre_statistics_collection(qc))
+
+    graph = set_quantization_configuration_to_graph(graph=graph,
+                                                    quant_config=qc,
+                                                    mixed_precision_enable=True)
+    graph = fusion(graph, tpc)
+    graph = filter_nodes_candidates(graph)
+
+    # Split graph substitution
+    split_graph = substitute(graph, [WeightsActivationSplit()])
+
+    return graph, split_graph
+
+
+class TestWeightsActivationSplit(unittest.TestCase):
+
+    def _verify_single_conv_test(self, graph, split_graph, num_weights_candidates, num_activation_candidates):
+        # verify that the convolution layer was split and that the new virtual node have the correct candidates
+        self.assertTrue(len(split_graph.nodes) == len(graph.nodes) + 1,
+                        "Split graph should have exactly 1 more node than the original graph.")
+
+        split_weights_node = split_graph.get_topo_sorted_nodes()[1]
+        split_activation_node = split_graph.get_topo_sorted_nodes()[2]
+        self.assertTrue(isinstance(split_weights_node, VirtualSplitWeightsNode))
+        self.assertTrue(isinstance(split_activation_node, VirtualSplitActivationNode))
+
+        self.assertTrue(len(split_weights_node.candidates_quantization_cfg) == num_weights_candidates,
+                        "The weights split node should have only weights configurable candidates.")
+        self.assertTrue(len(split_activation_node.candidates_quantization_cfg) == num_activation_candidates,
+                        "The activation split node should have only activation configurable candidates.")
+
+        self.assertTrue(not any([c.activation_quantization_cfg.enable_activation_quantization
+                                 for c in split_weights_node.candidates_quantization_cfg]),
+                        "All weights node's candidates activation quantization should be disabled.")
+        self.assertTrue(not any([c.weights_quantization_cfg.enable_weights_quantization
+                                 for c in split_activation_node.candidates_quantization_cfg]),
+                        "All activation node's candidates weights quantization should be disabled.")
+
+        origin_conv = graph.get_topo_sorted_nodes()[1]
+        self.assertTrue(split_weights_node.origin_node.name == origin_conv.name)
+        self.assertTrue(split_activation_node.origin_node.name == origin_conv.name)
+        self.assertTrue(split_graph.out_edges(split_weights_node)[0].sink_node == split_activation_node)
+
+    def test_single_conv_net_split(self):
+        in_model = single_conv_model()
+        keras_impl = KerasImplementation()
+
+        graph, split_graph = prepare_graph(in_model, keras_impl, mixed_precision_candidates_list=_get_base_mp_nbits_candidates())
+        self._verify_single_conv_test(graph, split_graph, num_weights_candidates=3, num_activation_candidates=3)
+
+    def test_single_conv_net_weights_only_split(self):
+        in_model = single_conv_model()
+        keras_impl = KerasImplementation()
+
+        graph, split_graph = prepare_graph(in_model, keras_impl, mixed_precision_candidates_list=[(8, 8), (4, 8), (2, 8)])
+        self._verify_single_conv_test(graph, split_graph, num_weights_candidates=3, num_activation_candidates=1)
+
+    def test_single_conv_net_activation_only_split(self):
+        in_model = single_conv_model()
+        keras_impl = KerasImplementation()
+
+        graph, split_graph = prepare_graph(in_model, keras_impl, mixed_precision_candidates_list=[(8, 8), (8, 4), (8, 2)])
+        self._verify_single_conv_test(graph, split_graph, num_weights_candidates=1, num_activation_candidates=3)
+
+    def test_all_weights_layers_split(self):
+        in_model = multiple_weights_nodes_model()
+        keras_impl = KerasImplementation()
+
+        graph, split_graph = prepare_graph(in_model, keras_impl, mixed_precision_candidates_list=_get_base_mp_nbits_candidates())
+        weights_node_types = [Conv2D, Conv2DTranspose, DepthwiseConv2D, Dense]
+        original_weights_nodes = [n for n in graph.get_topo_sorted_nodes() if n.type in weights_node_types]
+
+        self.assertTrue(len(split_graph.nodes) == len(graph.nodes) + len(original_weights_nodes))
+
+        for n in split_graph.get_topo_sorted_nodes():
+            if isinstance(n, VirtualSplitWeightsNode):
+                self.assertTrue(len(n.candidates_quantization_cfg) == 3,
+                                "The weights split node should have only weights configurable candidates.")
+                self.assertTrue(not any([c.activation_quantization_cfg.enable_activation_quantization
+                                         for c in n.candidates_quantization_cfg]),
+                                "All weights node's candidates activation quantization should be disabled.")
+            if isinstance(n, VirtualSplitActivationNode):
+                self.assertTrue(len(n.candidates_quantization_cfg) == 3,
+                                "The activation split node should have only activation configurable candidates.")
+                self.assertTrue(not any([c.weights_quantization_cfg.enable_weights_quantization
+                                         for c in n.candidates_quantization_cfg]),
+                                "All activation node's candidates weights quantization should be disabled.")
+
+    def test_non_composite_candidates_config(self):
+        in_model = single_conv_model()
+        keras_impl = KerasImplementation()
+
+        with self.assertRaises(Exception):
+            prepare_graph(in_model, keras_impl, mixed_precision_candidates_list=[(8, 2), (2, 4), (4, 8)])


### PR DESCRIPTION
This is a PR that include new substitutions and classes as part of several PRs that will eventually incorporate Bit-Operations KPI into our Mixed-precision search.

This PR includes the following additions:
- Implemented WeightsActivationSplit and VirtualActivationWeightsComposition substitutions, to prepare a virtual computation graph for mixed-precision search with bit-operations KPI constraint.
- Implemented virtual nodes classes for constructing the virtual graph.
- Several peripheral modifications.