### PR TITLE
Bit-operations count implementation in Pytorch

### DIFF
--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -43,10 +43,6 @@ LAST_AXIS = -1
 DATA_TYPE = 'dtype'
 FLOAT_32 = 'float32'
 
-# Common layers attributes and operations names:
-ACTIVATION = 'activation'
-LINEAR = 'linear'
-
 # Version
 LATEST = 'latest'
 

--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -17,7 +17,7 @@ from typing import Dict, Any, Tuple
 
 from model_compression_toolkit import FrameworkInfo
 from model_compression_toolkit.core.common.constants import VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX, \
-    VIRTUAL_WEIGHTS_SUFFIX, DEFAULT_CANDIDATE_BITWIDTH, VIRTUAL_ACTIVATION_SUFFIX, ACTIVATION, LINEAR, FLOAT_BITWIDTH
+    VIRTUAL_WEIGHTS_SUFFIX, DEFAULT_CANDIDATE_BITWIDTH, VIRTUAL_ACTIVATION_SUFFIX, FLOAT_BITWIDTH
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
 import numpy as np
 
@@ -84,7 +84,7 @@ class VirtualSplitActivationNode(VirtualSplitNode):
     activation candidate quantization config.
     """
 
-    def __init__(self, origin_node: BaseNode, activation_class: type):
+    def __init__(self, origin_node: BaseNode, activation_class: type, fw_attr: dict):
         """
         Init a VirtualSplitActivationNode object.
 
@@ -95,7 +95,7 @@ class VirtualSplitActivationNode(VirtualSplitNode):
         super().__init__(origin_node)
 
         self.name = origin_node.name + VIRTUAL_ACTIVATION_SUFFIX
-        self.framework_attr = {ACTIVATION: LINEAR}  # TODO: verify that these values work for Pytorch substitution as well (when implementing in Pytorch)
+        self.framework_attr = fw_attr
         self.prior_info = origin_node.prior_info
         self.input_shape = origin_node.output_shape  # the kernel output is the activation input
         self.weights = {}

--- a/model_compression_toolkit/core/common/mixed_precision/kpi_tools/kpi_data.py
+++ b/model_compression_toolkit/core/common/mixed_precision/kpi_tools/kpi_data.py
@@ -30,8 +30,7 @@ def compute_kpi_data(in_model: Any,
                      core_config: CoreConfig,
                      tpc: TargetPlatformCapabilities,
                      fw_info: FrameworkInfo,
-                     fw_impl: FrameworkImplementation,
-                     bops_kpi: bool = True) -> KPI:
+                     fw_impl: FrameworkImplementation) -> KPI:
     """
     Compute KPI information that can be relevant for defining target KPI for mixed precision search.
     Calculates maximal activation tensor, sum of weights' parameters and total (sum of both).
@@ -44,7 +43,6 @@ def compute_kpi_data(in_model: Any,
                                               the attached framework operator's information.
         fw_info: Information needed for quantization about the specific framework.
         fw_impl: FrameworkImplementation object with a specific framework methods implementation.
-        bops_kpi: A flag that indicates whether to compute Bit-operations count as part of the KPI data. TODO: Remove this flag once BOPs KPI is supported in Pytorch framework.
 
     Returns: A KPI object with the results.
 
@@ -76,11 +74,8 @@ def compute_kpi_data(in_model: Any,
     total_size = total_weights_params + max_activation_tensor_size
 
     # Compute BOPS kpi - total count of bit-operations for all configurable layers with kernel
-    if bops_kpi:
-        bops_count = compute_total_bops(graph=transformed_graph, fw_info=fw_info, fw_impl=fw_impl)
-        bops_count = np.inf if len(bops_count) == 0 else sum(bops_count)
-    else:
-        bops_count = np.inf
+    bops_count = compute_total_bops(graph=transformed_graph, fw_info=fw_info, fw_impl=fw_impl)
+    bops_count = np.inf if len(bops_count) == 0 else sum(bops_count)
 
     return KPI(weights_memory=total_weights_params,
                activation_memory=max_activation_tensor_size,

--- a/model_compression_toolkit/core/common/substitutions/virtual_activation_weights_composition.py
+++ b/model_compression_toolkit/core/common/substitutions/virtual_activation_weights_composition.py
@@ -1,0 +1,72 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from model_compression_toolkit.core.common import BaseNode, Graph, BaseSubstitution
+from model_compression_toolkit.core.common.logger import Logger
+from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualActivationWeightsNode
+
+
+class BaseVirtualActivationWeightsComposition(BaseSubstitution):
+    def __init__(self, matcher_instance):
+        super().__init__(matcher_instance=matcher_instance)
+
+    def substitute(self,
+                   graph: Graph,
+                   weights_node: BaseNode) -> Graph:
+        """
+        Combines an activation --> weights edge's node into one virtual composed node that contains the activation
+        operation and the linear operation (in that order).
+        The node's quantization configuration candidates include the cartesian product of both node's candidates.
+        Note that if the activation node has multiple outputs (beside its matched weights node) than the substitution
+        would not apply.
+
+        Args:
+            graph: Graph we apply the substitution on.
+            weights_node: A node with linear operation to be combined with its preceding activation.
+
+        Returns:
+            Graph after applying the substitution.
+        """
+
+        predecessors = graph.get_prev_nodes(weights_node)
+        if len(predecessors) != 1:
+            return graph
+
+        act_node = predecessors[0]
+
+        if len(graph.out_edges(act_node)) > 1:
+            Logger.warning(f"Node {act_node.name} has multiple outgoing edges, which is not supported with "
+                           f"mixed-precision bit-operations KPI, thus, edge {act_node.name} --> {weights_node.name} "
+                           f"would not be counted in the bit-operations calculations.")
+            return graph
+
+        # Virtual composed activation-weights node
+        # we pass a dummy initialization dict to initialize the super BaseNode class,
+        # the actual arguments values are irrelevant because they are being overridden or not used
+        v_node = VirtualActivationWeightsNode(act_node,
+                                              weights_node,
+                                              **weights_node.__dict__)
+
+        # Update graph
+        graph.add_node(v_node)
+        graph.reconnect_in_edges(current_node=act_node, new_node=v_node)
+        graph.reconnect_out_edges(current_node=weights_node, new_node=v_node)
+        graph.replace_input_node(current_node=act_node, new_node=v_node)
+        graph.replace_output_node(current_node=weights_node, new_node=v_node)
+        graph.remove_edge(act_node, weights_node)
+        graph.remove_node(weights_node)
+        graph.remove_node(act_node)
+
+        return graph

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/weights_activation_split.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/weights_activation_split.py
@@ -12,21 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
+import tensorflow as tf
 from tensorflow.keras.layers import Dense, DepthwiseConv2D, Conv2D, Conv2DTranspose
 from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher
-from model_compression_toolkit.core.common.substitutions.virtual_activation_weights_composition import \
-    BaseVirtualActivationWeightsComposition
+from model_compression_toolkit.core.common.substitutions.weights_activation_split import BaseWeightsActivationSplit
+from model_compression_toolkit.core.keras.constants import LINEAR, ACTIVATION
 
 """
 Matches: (DepthwiseConv2D, Conv2D, Dense, Conv2DTranspose)
 """
+OP2D_NODE = NodeOperationMatcher(DepthwiseConv2D) | \
+            NodeOperationMatcher(Conv2D) | \
+            NodeOperationMatcher(Dense) | \
+            NodeOperationMatcher(Conv2DTranspose)
 
-WEIGHTS_NODE = NodeOperationMatcher(DepthwiseConv2D) | \
-               NodeOperationMatcher(Conv2D) | \
-               NodeOperationMatcher(Dense) | \
-               NodeOperationMatcher(Conv2DTranspose)
 
+class WeightsActivationSplit(BaseWeightsActivationSplit):
+    """
+    Substitution extends BaseWeightsActivationSplit for Keras framework.
+    """
 
-class VirtualActivationWeightsComposition(BaseVirtualActivationWeightsComposition):
     def __init__(self):
-        super().__init__(matcher_instance=WEIGHTS_NODE)
+        """
+        Initializes a WeightsActivationSplit substitution for Keras framework.
+        """
+
+        super().__init__(activation_layer_type=tf.keras.layers.Activation,
+                         fw_attr={ACTIVATION: LINEAR},
+                         matcher_instance=OP2D_NODE)

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -27,7 +27,7 @@ from model_compression_toolkit.core.keras.back2framework.model_gradients import 
 from model_compression_toolkit.core.keras.constants import ACTIVATION, SOFTMAX, SIGMOID, ARGMAX, LAYER_NAME
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.virtual_activation_weights_composition import \
     VirtualActivationWeightsComposition
-from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weight_activation_split import \
+from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weights_activation_split import \
     WeightsActivationSplit
 from model_compression_toolkit.core.keras.mixed_precision.set_layer_to_bitwidth import set_layer_to_bitwidth
 
@@ -506,7 +506,7 @@ class KerasImplementation(FrameworkImplementation):
             node: A graph node that wraps the operation for which the MAC count is computed.
             fw_info: FrameworkInfo object with information about the Keras model.
 
-        Returns: The MAC count of the operation
+        Returns: The MAC count og the operation
         """
 
         input_shape = node.input_shape
@@ -514,7 +514,7 @@ class KerasImplementation(FrameworkImplementation):
         kernel_shape = node.get_weights_by_keys(fw_info.get_kernel_op_attributes(node.type)[0]).shape
         output_channel_axis, input_channel_axis = fw_info.kernel_channels_mapping.get(node.type)
 
-        if node.type in [Conv2D, Conv2DTranspose]:
+        if node.type is Conv2D or node.type is Conv2DTranspose:
             # (C_out * W_out * H_out) * C_in * (W_kernel * H_kernel)
             return np.prod([x for x in output_shape if x is not None]) * \
                    input_shape[input_channel_axis] * \

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/virtual_activation_weights_composition.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/virtual_activation_weights_composition.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from tensorflow.keras.layers import Dense, DepthwiseConv2D, Conv2D, Conv2DTranspose
+from torch.nn import Conv2d, Linear, ConvTranspose2d
 from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher
 from model_compression_toolkit.core.common.substitutions.virtual_activation_weights_composition import \
     BaseVirtualActivationWeightsComposition
@@ -21,10 +21,9 @@ from model_compression_toolkit.core.common.substitutions.virtual_activation_weig
 Matches: (DepthwiseConv2D, Conv2D, Dense, Conv2DTranspose)
 """
 
-WEIGHTS_NODE = NodeOperationMatcher(DepthwiseConv2D) | \
-               NodeOperationMatcher(Conv2D) | \
-               NodeOperationMatcher(Dense) | \
-               NodeOperationMatcher(Conv2DTranspose)
+WEIGHTS_NODE = NodeOperationMatcher(Conv2d) | \
+               NodeOperationMatcher(Linear) | \
+               NodeOperationMatcher(ConvTranspose2d)
 
 
 class VirtualActivationWeightsComposition(BaseVirtualActivationWeightsComposition):

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/weights_activation_split.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/weights_activation_split.py
@@ -12,21 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from tensorflow.keras.layers import Dense, DepthwiseConv2D, Conv2D, Conv2DTranspose
+import torch.nn
+from torch.nn import Conv2d, Linear, ConvTranspose2d
 from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher
-from model_compression_toolkit.core.common.substitutions.virtual_activation_weights_composition import \
-    BaseVirtualActivationWeightsComposition
+from model_compression_toolkit.core.common.substitutions.weights_activation_split import BaseWeightsActivationSplit
 
 """
 Matches: (DepthwiseConv2D, Conv2D, Dense, Conv2DTranspose)
 """
-
-WEIGHTS_NODE = NodeOperationMatcher(DepthwiseConv2D) | \
-               NodeOperationMatcher(Conv2D) | \
-               NodeOperationMatcher(Dense) | \
-               NodeOperationMatcher(Conv2DTranspose)
+OP2D_NODE = NodeOperationMatcher(Conv2d) | \
+            NodeOperationMatcher(Linear) | \
+            NodeOperationMatcher(ConvTranspose2d)
 
 
-class VirtualActivationWeightsComposition(BaseVirtualActivationWeightsComposition):
+class WeightsActivationSplit(BaseWeightsActivationSplit):
+    """
+    Substitution extends BaseWeightsActivationSplit for Keras framework.
+    """
+
     def __init__(self):
-        super().__init__(matcher_instance=WEIGHTS_NODE)
+        """
+        Initializes a WeightsActivationSplit substitution for Keras framework.
+        """
+
+        super().__init__(activation_layer_type=torch.nn.Identity,
+                         fw_attr={},
+                         matcher_instance=OP2D_NODE)

--- a/model_compression_toolkit/core/pytorch/kpi_data_facade.py
+++ b/model_compression_toolkit/core/pytorch/kpi_data_facade.py
@@ -90,8 +90,7 @@ if importlib.util.find_spec("torch") is not None:
                                 core_config,
                                 target_platform_capabilities,
                                 fw_info,
-                                fw_impl,
-                                bops_kpi=False)
+                                fw_impl)
 
 
     def pytorch_kpi_data_experimental(in_model: Module,
@@ -144,8 +143,7 @@ if importlib.util.find_spec("torch") is not None:
                                 core_config,
                                 target_platform_capabilities,
                                 fw_info,
-                                fw_impl,
-                                bops_kpi=False)
+                                fw_impl)
 
 else:
     # If torch is not installed,

--- a/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
+++ b/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
@@ -22,14 +22,14 @@ import numpy as np
 from model_compression_toolkit import DEFAULTCONFIG, MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.common.fusion.layer_fusing import fusion
 from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualSplitActivationNode, \
-    VirtualSplitWeightsNode, VirtualActivationWeightsNode
+    VirtualActivationWeightsNode
 from model_compression_toolkit.core.common.quantization.filter_nodes_candidates import filter_nodes_candidates
 from model_compression_toolkit.core.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.virtual_activation_weights_composition import \
     VirtualActivationWeightsComposition
-from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weight_activation_split import \
+from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weights_activation_split import \
     WeightsActivationSplit
 from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
 from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute

--- a/tests/keras_tests/function_tests/test_weights_activation_split_substitution.py
+++ b/tests/keras_tests/function_tests/test_weights_activation_split_substitution.py
@@ -27,7 +27,7 @@ from model_compression_toolkit.core.common.quantization.filter_nodes_candidates 
 from model_compression_toolkit.core.common.quantization.set_node_quantization_config import \
     set_quantization_configuration_to_graph
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
-from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weight_activation_split import \
+from model_compression_toolkit.core.keras.graph_substitutions.substitutions.weights_activation_split import \
     WeightsActivationSplit
 from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
 from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -119,7 +119,7 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                 torch_traced = torch.jit.trace(quantized_model, input_x)
                 torch_script_model = torch.jit.script(torch_traced)
 
-    def run_test(self, seed=0):
+    def run_test(self, seed=0, experimental_facade=False,):
         np.random.seed(seed)
         random.seed(a=seed)
         torch.random.manual_seed(seed)
@@ -131,29 +131,37 @@ class BasePytorchTest(BaseFeatureNetworkTest):
 
         ptq_models = {}
         model_float = self.create_feature_network(input_shapes)
-        quant_config_dict = self.get_quantization_configs()
-        for model_name in quant_config_dict.keys():
-            quant_config = quant_config_dict[model_name]
-            tpc = self.get_tpc()[model_name]
-            if isinstance(quant_config, MixedPrecisionQuantizationConfig):
-                ptq_model, quantization_info = mct.pytorch_post_training_quantization_mixed_precision(model_float,
-                                                                                                      representative_data_gen,
-                                                                                                      n_iter=self.num_calibration_iter,
-                                                                                                      quant_config=quant_config,
-                                                                                                      fw_info=DEFAULT_PYTORCH_INFO,
-                                                                                                      network_editor=self.get_network_editor(),
-                                                                                                      gptq_config=self.get_gptq_config(),
-                                                                                                      target_kpi=self.get_kpi(),
-                                                                                                      target_platform_capabilities=tpc)
-                ptq_models.update({model_name: ptq_model})
-            else:
-                ptq_model, quantization_info = mct.pytorch_post_training_quantization(model_float,
-                                                                                      representative_data_gen,
-                                                                                      n_iter=1,
-                                                                                      quant_config=quant_config,
-                                                                                      fw_info=DEFAULT_PYTORCH_INFO,
-                                                                                      network_editor=self.get_network_editor(),
-                                                                                      target_platform_capabilities=tpc)
-                ptq_models.update({model_name: ptq_model})
+        if experimental_facade:
+            ptq_model, quantization_info = mct.pytorch_post_training_quantization_experimental(model_float,
+                                                                                               representative_data_gen,
+                                                                                               target_kpi=self.get_kpi(),
+                                                                                               core_config=self.get_core_config(),
+                                                                                               target_platform_capabilities=self.get_tpc())
+        else:
+            quant_config_dict = self.get_quantization_configs()
+            for model_name in quant_config_dict.keys():
+                quant_config = quant_config_dict[model_name]
+                tpc = self.get_tpc()[model_name]
+
+                if isinstance(quant_config, MixedPrecisionQuantizationConfig):
+                    ptq_model, quantization_info = mct.pytorch_post_training_quantization_mixed_precision(model_float,
+                                                                                                          representative_data_gen,
+                                                                                                          n_iter=self.num_calibration_iter,
+                                                                                                          quant_config=quant_config,
+                                                                                                          fw_info=DEFAULT_PYTORCH_INFO,
+                                                                                                          network_editor=self.get_network_editor(),
+                                                                                                          gptq_config=self.get_gptq_config(),
+                                                                                                          target_kpi=self.get_kpi(),
+                                                                                                          target_platform_capabilities=tpc)
+                    ptq_models.update({model_name: ptq_model})
+                else:
+                    ptq_model, quantization_info = mct.pytorch_post_training_quantization(model_float,
+                                                                                          representative_data_gen,
+                                                                                          n_iter=1,
+                                                                                          quant_config=quant_config,
+                                                                                          fw_info=DEFAULT_PYTORCH_INFO,
+                                                                                          network_editor=self.get_network_editor(),
+                                                                                          target_platform_capabilities=tpc)
+                    ptq_models.update({model_name: ptq_model})
 
         self.compare(ptq_models, model_float, input_x=x, quantization_info=quantization_info)

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_bops_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_bops_test.py
@@ -1,0 +1,223 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import torch.nn
+from model_compression_toolkit import MixedPrecisionQuantizationConfigV2, KPI
+from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
+
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_op_quantization_configs
+from tests.common_tests.helpers.activation_mp_tp_model import generate_tp_model_with_activation_mp
+from tests.pytorch_tests.tpc_pytorch import generate_activation_mp_tpc_pytorch
+
+
+def get_base_mp_nbits_candidates():
+    return [(4, 8), (4, 4), (4, 2),
+            (8, 8), (8, 4), (8, 2),
+            (2, 8), (2, 4), (2, 2)]
+
+
+class BaseBopsNetwork(torch.nn.Module):
+    def __init__(self, input_shape):
+        super(BaseBopsNetwork, self).__init__()
+
+        _, in_channels, _, _ = input_shape[0]
+        self.conv1 = torch.nn.Conv2d(in_channels, 4, kernel_size=(3, 3))
+        self.bn1 = torch.nn.BatchNorm2d(4)
+        self.relu = torch.nn.ReLU()
+        self.conv2 = torch.nn.Conv2d(4, 4, kernel_size=(3, 3))
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = self.bn1(x)
+        x = self.relu(x)
+        output = self.conv2(x)
+
+        return output
+
+
+class MultipleEdgesBopsNetwork(torch.nn.Module):
+    def __init__(self, input_shape):
+        super(MultipleEdgesBopsNetwork, self).__init__()
+
+        _, in_channels, _, _ = input_shape[0]
+        self.conv1 = torch.nn.Conv2d(in_channels, 4, kernel_size=(3, 3))
+        self.conv2 = torch.nn.Conv2d(in_channels, 4, kernel_size=(3, 3))
+        self.relu1 = torch.nn.ReLU()
+        self.relu2 = torch.nn.ReLU()
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        y = self.conv2(inp)
+
+        x = self.relu1(x)
+        y = self.relu2(y)
+
+        output = x + y
+        return output
+
+
+class AllWeightsBopsNetwork(torch.nn.Module):
+    def __init__(self, input_shape):
+        super(AllWeightsBopsNetwork, self).__init__()
+
+        _, in_channels, _, _ = input_shape[0]
+        self.conv1 = torch.nn.Conv2d(in_channels, 4, kernel_size=(3, 3))
+        self.conv2 = torch.nn.Conv2d(4, 4, kernel_size=(3, 3))
+        self.bn1 = torch.nn.BatchNorm2d(4)
+        self.relu1 = torch.nn.ReLU()
+        self.conv_trans = torch.nn.ConvTranspose2d(4, 4, kernel_size=(3, 3))
+        self.bn2 = torch.nn.BatchNorm2d(4)
+        self.relu2 = torch.nn.ReLU()
+        self.depthwise = torch.nn.Conv2d(4, 4, kernel_size=(1, 1), groups=4)
+        self.linear = torch.nn.Linear(30, 5)
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = self.conv2(x)
+        x = self.bn1(x)
+        x = self.relu1(x)
+        x = self.conv_trans(x)
+        x = self.bn2(x)
+        x = self.relu2(x)
+        x = self.depthwise(x)
+        output = self.linear(x)
+
+        return output
+
+
+class BaseMixedPrecisionBopsTest(BasePytorchTest):
+    def __init__(self, unit_test, mixed_precision_candidates_list):
+        super().__init__(unit_test)
+
+        self.mixed_precision_candidates_list = mixed_precision_candidates_list
+
+    def get_tpc(self):
+        base_config, _ = get_op_quantization_configs()
+        mp_tp_model = generate_tp_model_with_activation_mp(base_config, self.mixed_precision_candidates_list)
+
+        return generate_activation_mp_tpc_pytorch(tp_model=mp_tp_model)
+
+    def get_mixed_precision_v2_config(self):
+        # return {"mixed_precision_v2": MixedPrecisionQuantizationConfigV2(num_of_images=1)}
+        return MixedPrecisionQuantizationConfigV2(num_of_images=1)
+
+    def get_input_shapes(self):
+        return [[self.val_batch_size, 16, 16, 3]]
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        # Verify that some layers got bit-width smaller than 8 bits (so checking candidate index is not 0)
+        self.unit_test.assertTrue(all(i > 0 for i in quantization_info.mixed_precision_cfg))
+        # Verify final BOPs KPI
+        self.unit_test.assertTrue(quantization_info.final_kpi.bops <= self.get_kpi().bops)
+
+
+class MixedPrecisionBopsBasicTest(BaseMixedPrecisionBopsTest):
+    def __init__(self, unit_test):
+
+        mixed_precision_candidates_list = get_base_mp_nbits_candidates()
+
+        super().__init__(unit_test, mixed_precision_candidates_list)
+
+    def create_feature_network(self, input_shape):
+        return BaseBopsNetwork(input_shape)
+
+    def get_kpi(self):
+        return KPI(bops=1350000)  # should require some quantization to all layers
+
+
+class MixedPrecisionBopsAllWeightsLayersTest(BaseMixedPrecisionBopsTest):
+    def __init__(self, unit_test, mixed_precision_candidates_list=None):
+
+        if mixed_precision_candidates_list is None:
+            mixed_precision_candidates_list = get_base_mp_nbits_candidates()
+
+        super().__init__(unit_test, mixed_precision_candidates_list)
+
+    def create_feature_network(self, input_shape):
+        return AllWeightsBopsNetwork(input_shape)
+
+    def get_kpi(self):
+        return KPI(bops=1785000)  # should require some quantization to all layers
+
+
+class MixedPrecisionWeightsOnlyBopsTest(MixedPrecisionBopsAllWeightsLayersTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test, mixed_precision_candidates_list=[(8, 8), (4, 8), (2, 8)])
+
+    def get_kpi(self):
+        return KPI(bops=7135000)  # should require some quantization to all layers
+
+
+class MixedPrecisionActivationOnlyBopsTest(MixedPrecisionBopsAllWeightsLayersTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test, mixed_precision_candidates_list=[(8, 8), (8, 4), (8, 2)])
+
+    def get_kpi(self):
+        return KPI(bops=7135000)  # should require some quantization to all layers
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        # Verify that some layers got bit-width smaller than 8 bits (so checking candidate index is not 0)
+        self.unit_test.assertTrue(any(i > 0 for i in quantization_info.mixed_precision_cfg))
+        # Verify final BOPs KPI
+        self.unit_test.assertTrue(quantization_info.final_kpi.bops <= self.get_kpi().bops)
+
+
+class MixedPrecisionBopsAndWeightsKPITest(MixedPrecisionBopsAllWeightsLayersTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def get_kpi(self):
+        return KPI(weights_memory=150, bops=1800000)  # should require some quantization to all layers
+
+
+class MixedPrecisionBopsAndActivationKPITest(MixedPrecisionBopsAllWeightsLayersTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def get_kpi(self):
+        return KPI(activation_memory=1000, bops=1785000)  # should require some quantization to all layers
+
+
+class MixedPrecisionBopsAndTotalKPITest(MixedPrecisionBopsAllWeightsLayersTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def get_kpi(self):
+        return KPI(total_memory=1100, bops=1800000)  # should require some quantization to all layers
+
+
+class MixedPrecisionBopsWeightsActivationKPITest(MixedPrecisionBopsAllWeightsLayersTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def get_kpi(self):
+        return KPI(weights_memory=150, activation_memory=1000, bops=1800000)  # should require some quantization to all layers
+
+
+class MixedPrecisionBopsMultipleOutEdgesTest(BaseMixedPrecisionBopsTest):
+    def __init__(self, unit_test):
+
+        mixed_precision_candidates_list = get_base_mp_nbits_candidates()
+
+        super().__init__(unit_test, mixed_precision_candidates_list)
+
+    def create_feature_network(self, input_shape):
+        return MultipleEdgesBopsNetwork(input_shape)
+
+    def get_kpi(self):
+        return KPI(bops=1)  # No layers with BOPs count
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        # Verify that all layers got 8 bits (so checking candidate index is 0)
+        self.unit_test.assertTrue(all(i == 0 for i in quantization_info.mixed_precision_cfg))

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -16,6 +16,10 @@ import unittest
 
 from tests.pytorch_tests.model_tests.feature_models.add_net_test import AddNetTest
 from tests.pytorch_tests.model_tests.feature_models.conv2d_replacement_test import DwConv2dReplacementTest
+from tests.pytorch_tests.model_tests.feature_models.mixed_precision_bops_test import MixedPrecisionBopsBasicTest, \
+    MixedPrecisionBopsAllWeightsLayersTest, MixedPrecisionWeightsOnlyBopsTest, MixedPrecisionActivationOnlyBopsTest, \
+    MixedPrecisionBopsAndWeightsKPITest, MixedPrecisionBopsAndActivationKPITest, MixedPrecisionBopsAndTotalKPITest, \
+    MixedPrecisionBopsWeightsActivationKPITest, MixedPrecisionBopsMultipleOutEdgesTest
 from tests.pytorch_tests.model_tests.feature_models.relu_replacement_test import SingleLayerReplacementTest, \
     ReluReplacementTest, ReluReplacementWithAddBiasTest
 from tests.pytorch_tests.model_tests.feature_models.remove_assert_test import AssertNetTest
@@ -368,6 +372,20 @@ class FeatureModelsTestRunner(unittest.TestCase):
         This test checks the activation Mixed Precision search with functional node.
         """
         MixedPercisionActivationSearch4BitFunctional(self).run_test()
+
+    def test_mixed_precision_bops_kpi(self):
+        """
+        This test checks different scenarios for mixed-precision quantization with bit-operations constraint.
+        """
+        MixedPrecisionBopsBasicTest(self).run_test(experimental_facade=True)
+        MixedPrecisionBopsAllWeightsLayersTest(self).run_test(experimental_facade=True)
+        MixedPrecisionWeightsOnlyBopsTest(self).run_test(experimental_facade=True)
+        MixedPrecisionActivationOnlyBopsTest(self).run_test(experimental_facade=True)
+        MixedPrecisionBopsAndWeightsKPITest(self).run_test(experimental_facade=True)
+        MixedPrecisionBopsAndActivationKPITest(self).run_test(experimental_facade=True)
+        MixedPrecisionBopsAndTotalKPITest(self).run_test(experimental_facade=True)
+        MixedPrecisionBopsWeightsActivationKPITest(self).run_test(experimental_facade=True)
+        MixedPrecisionBopsMultipleOutEdgesTest(self).run_test(experimental_facade=True)
 
     def test_mha_layer_test(self):
         """


### PR DESCRIPTION
Support BOPs KPI in Pytorch.
Virtual graph substitutions were moved to a common location and created framework specific substitutions wrappers for both Pytorch and Keras.
Also required small modification to VirtualSplitActivationNode.