### PR TITLE
GPTQ fixes: remove unneeded log, skip gptq training when n_iter=0

### DIFF
--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/base_gumbel_rounding.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/base_gumbel_rounding.py
@@ -113,7 +113,6 @@ class GumbelRoundingBase(BaseTrainableQuantizer):
         self.g_t = None
         self.p_t = None
         scale = self.cycle_iterations / (-2 * np.log(0.001))
-        common.Logger.info(f"Setting Gumbel Rounding with cycle size of {self.cycle_iterations}")
 
         def tau_function(i):
             """

--- a/model_compression_toolkit/gptq/runner.py
+++ b/model_compression_toolkit/gptq/runner.py
@@ -51,7 +51,7 @@ def _apply_gptq(gptq_config: GradientPTQConfig,
     Returns:
 
     """
-    if gptq_config is not None:
+    if gptq_config is not None and gptq_config.n_iter > 0:
         common.Logger.info("Using experimental Gradient Based PTQ: If you encounter an issue "
                            "please file a bug. To disable it, do not pass a gptq configuration.")
 

--- a/tutorials/example_keras_mobilenet_gptq.py
+++ b/tutorials/example_keras_mobilenet_gptq.py
@@ -1,0 +1,102 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from keras.applications.mobilenet_v2 import MobileNetV2
+
+import model_compression_toolkit as mct
+
+"""
+This tutorial demonstrates how a model (more specifically, MobileNetV2) can be
+quantized and optimized using the Model Compression Toolkit (MCT) with GPTQ (gradient-based PTQ). 
+"""
+
+####################################
+# Preprocessing images
+####################################
+import cv2
+import numpy as np
+
+MEAN = 127.5
+STD = 127.5
+RESIZE_SCALE = 256 / 224
+SIZE = 224
+
+
+def resize(x):
+    resize_side = max(RESIZE_SCALE * SIZE / x.shape[0], RESIZE_SCALE * SIZE / x.shape[1])
+    height_tag = int(np.round(resize_side * x.shape[0]))
+    width_tag = int(np.round(resize_side * x.shape[1]))
+    resized_img = cv2.resize(x, (width_tag, height_tag))
+    offset_height = int((height_tag - SIZE) / 2)
+    offset_width = int((width_tag - SIZE) / 2)
+    cropped_img = resized_img[offset_height:offset_height + SIZE, offset_width:offset_width + SIZE]
+    return cropped_img
+
+
+def normalization(x):
+    return (x - MEAN) / STD
+
+
+if __name__ == '__main__':
+
+    # Set the batch size of the images at each calibration iteration.
+    batch_size = 50
+
+    # Set the path to the folder of images to load and use for the representative dataset.
+    # Notice that the folder have to contain at least one image.
+    folder = '/path/to/images/folder'
+
+    # Create a representative data generator, which returns a list of images.
+    # The images can be preprocessed using a list of preprocessing functions.
+    from model_compression_toolkit import FolderImageLoader
+
+    image_data_loader = FolderImageLoader(folder,
+                                          preprocessing=[resize, normalization],
+                                          batch_size=batch_size)
+
+
+    # Create a Callable representative dataset for calibration purposes.
+    # The function should be called without any arguments, and should return a list numpy arrays (array for each
+    # model's input).
+    # For example: A model has two input tensors - one with input shape of [32 X 32 X 3] and the second with
+    # an input shape of [224 X 224 X 3]. We calibrate the model using batches of 20 images.
+    # Calling representative_data_gen() should return a list
+    # of two numpy.ndarray objects where the arrays' shapes are [(20, 3, 32, 32), (20, 3, 224, 224)].
+    def representative_data_gen() -> list:
+        return [image_data_loader.sample()]
+
+
+    # Get a TargetPlatformModel object that models the hardware for the quantized model inference.
+    # The model determines the quantization methods to use during the MCT optimization process.
+    # Here, for example, we use the default target platform model that is attached to a Tensorflow
+    # layers representation.
+    target_platform_cap = mct.get_target_platform_capabilities('tensorflow', 'default')
+
+    # Create a model
+    model = MobileNetV2()
+
+    # Create a core quantization configuration and set the number of calibration iterations to 10.
+    config = mct.CoreConfig(n_iter=10)
+
+    # Create a GPTQ quantization configuration and set the number of training iterations to 5000.
+    gptq_config = mct.get_keras_gptq_config(n_iter=5000)
+
+    quantized_model, quantization_info = mct.keras_gradient_post_training_quantization_experimental(model,
+                                                                                                    representative_data_gen,
+                                                                                                    gptq_config=gptq_config,
+                                                                                                    core_config=config,
+                                                                                                    target_platform_capabilities=target_platform_cap)
+
+

--- a/tutorials/example_keras_mobilenet_gptq_mixed_precision.py
+++ b/tutorials/example_keras_mobilenet_gptq_mixed_precision.py
@@ -1,0 +1,121 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from keras.applications.mobilenet_v2 import MobileNetV2
+
+import model_compression_toolkit as mct
+
+"""
+This tutorial demonstrates how a model (more specifically, MobileNetV2) can be
+quantized and optimized using the Model Compression Toolkit (MCT) with 
+mixed-precision quantization and GPTQ (gradient-based PTQ). 
+"""
+
+####################################
+# Preprocessing images
+####################################
+import cv2
+import numpy as np
+
+MEAN = 127.5
+STD = 127.5
+RESIZE_SCALE = 256 / 224
+SIZE = 224
+
+
+def resize(x):
+    resize_side = max(RESIZE_SCALE * SIZE / x.shape[0], RESIZE_SCALE * SIZE / x.shape[1])
+    height_tag = int(np.round(resize_side * x.shape[0]))
+    width_tag = int(np.round(resize_side * x.shape[1]))
+    resized_img = cv2.resize(x, (width_tag, height_tag))
+    offset_height = int((height_tag - SIZE) / 2)
+    offset_width = int((width_tag - SIZE) / 2)
+    cropped_img = resized_img[offset_height:offset_height + SIZE, offset_width:offset_width + SIZE]
+    return cropped_img
+
+
+def normalization(x):
+    return (x - MEAN) / STD
+
+
+if __name__ == '__main__':
+
+    # Set the batch size of the images at each calibration iteration.
+    batch_size = 50
+
+    # Set the path to the folder of images to load and use for the representative dataset.
+    # Notice that the folder have to contain at least one image.
+    folder = '/path/to/images/folder'
+
+    # Create a representative data generator, which returns a list of images.
+    # The images can be preprocessed using a list of preprocessing functions.
+    from model_compression_toolkit import FolderImageLoader
+
+    image_data_loader = FolderImageLoader(folder,
+                                          preprocessing=[resize, normalization],
+                                          batch_size=batch_size)
+
+
+    # Create a Callable representative dataset for calibration purposes.
+    # The function should be called without any arguments, and should return a list numpy arrays (array for each
+    # model's input).
+    # For example: A model has two input tensors - one with input shape of [32 X 32 X 3] and the second with
+    # an input shape of [224 X 224 X 3]. We calibrate the model using batches of 20 images.
+    # Calling representative_data_gen() should return a list
+    # of two numpy.ndarray objects where the arrays' shapes are [(20, 3, 32, 32), (20, 3, 224, 224)].
+    def representative_data_gen() -> list:
+        return [image_data_loader.sample()]
+
+
+    # Get a TargetPlatformModel object that models the hardware for the quantized model inference.
+    # The model determines the quantization methods to use during the MCT optimization process.
+    # Here, for example, we use the default target platform model that is attached to a Tensorflow
+    # layers representation.
+    target_platform_cap = mct.get_target_platform_capabilities('tensorflow', 'default')
+
+    # Create a model
+    model = MobileNetV2()
+
+    # Create a mixed-precision quantization configuration.
+    mixed_precision_config = mct.MixedPrecisionQuantizationConfigV2()
+
+    # Create a core quantization configuration, set the mixed-precision configuration,
+    # and set the number of calibration iterations to 10.
+    config = mct.CoreConfig(n_iter=10,
+                            mixed_precision_config=mixed_precision_config)
+
+    # Get KPI information to constraint your model's memory size.
+    # Retrieve a KPI object with helpful information of each KPI metric,
+    # to constraint the quantized model to the desired memory size.
+    kpi_data = mct.keras_kpi_data_experimental(model,
+                                               representative_data_gen,
+                                               config,
+                                               target_platform_capabilities=target_platform_cap)
+
+    # Set a constraint for each of the KPI metrics.
+    # Create a KPI object to limit our returned model's size. Note that this values affects only layers and attributes
+    # that should be quantized (for example, the kernel of Conv2D in Keras will be affected by this value,
+    # while the bias will not):
+    kpi = mct.KPI(kpi_data.weights_memory * 0.75)  # About 0.75 of the model's weights memory size when quantized with 8 bits.
+
+    # Create a GPTQ quantization configuration and set the number of training iterations to 5000.
+    gptq_config = mct.get_keras_gptq_config(n_iter=5000)
+
+    quantized_model, quantization_info = mct.keras_gradient_post_training_quantization_experimental(model,
+                                                                                                    representative_data_gen,
+                                                                                                    gptq_config=gptq_config,
+                                                                                                    core_config=config,
+                                                                                                    target_platform_capabilities=target_platform_cap,
+                                                                                                    target_kpi=kpi)


### PR DESCRIPTION
GPTQ log was removed as it is unneeded.
Skip GPTQ training if number of iterations is 0.
Add tutorial to run GPTQ facade.