### PR TITLE
Change GPTQ node search method

### DIFF
--- a/model_compression_toolkit/core/keras/back2framework/instance_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/instance_builder.py
@@ -32,9 +32,14 @@ class OperationHandler:
     """
 
     def __init__(self, graph: Graph):
-        self.node_sort = list(topological_sort(graph))  # hold nodes after sorting them
-        self.node_to_fw_op_dict = instance_builder(self.node_sort)  # hold dictionary from node to its equivalent
-        # Keras layer
+        # hold nodes after sorting them
+        self.node_sort = list(topological_sort(graph))
+
+        self.layer_to_node_dict = {}
+
+        # hold dictionary from node to its equivalent Keras layer
+        self.node_to_fw_op_dict = instance_builder(self.node_sort)
+
 
     def get_node_op_function(self, n: BaseNode) -> Layer:
         """

--- a/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
@@ -19,7 +19,6 @@ import tensorflow as tf
 from keras.models import Model
 
 from model_compression_toolkit.core.common.back2framework.base_model_builder import BaseModelBuilder
-
 from model_compression_toolkit.core.common.user_info import UserInformation
 
 # As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
@@ -281,5 +280,16 @@ class KerasModelBuilder(BaseModelBuilder):
                         f"Trying to quantize node {n.name} activation of type {out_tensors_of_n_float.dtype} "
                         f"which is not supported, expected type float32")
                 out_tensors_of_n = self._quantize_node_activations(n, out_tensors_of_n_float)
+
+        # Save a mapping from the layer that created the tensor to the node (as this layer is not the
+        # same instance as op_func. We do this to solve an issue that names are different between these
+        # layers, thus we can not rely on the op_func name during model cloning (such as GPTQ, MP, etc.)
+        if isinstance(out_tensors_of_n_float, list):
+            # If layer has multiple outputs (e.g., split) we take the layer of the first output (as all outputs are
+            # from the same layer).
+            layer_from_tensor = out_tensors_of_n_float[0].node.layer
+        else:
+            layer_from_tensor = out_tensors_of_n_float.node.layer
+        self.oh.layer_to_node_dict[layer_from_tensor] = n
 
         return out_tensors_of_n, out_tensors_of_n_float


### PR DESCRIPTION
Add mapping in Keras model builder from layers to their graph nodes. This is since there are times we rely on the layer's name (during cloning in GPTQ, MP, etc.) but the layer's in the final model can be different from the node's name, so we save a mapping of the layer's output tensor to the node.