### PR TITLE
Change MP and QAT node search method

### DIFF
--- a/model_compression_toolkit/core/keras/back2framework/mixed_precision_model_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/mixed_precision_model_builder.py
@@ -98,9 +98,8 @@ class MixedPrecisionKerasModelBuilder(KerasModelBuilder):
         conf_nodes_names = self.graph.get_configurable_sorted_nodes_names()
 
         def _quantize_multiple_nbits(layer):
-            nodes = self.graph.find_node_by_name(get_node_name_from_layer(layer))
-            if len(nodes) == 1:
-                node = nodes[0]
+            node = self.oh.layer_to_node_dict.get(layer)
+            if node is not None:
                 # Wrap only if its weights should be quantized
                 if node.name in conf_nodes_names:
                     if node.layer_class in [TFOpLambda, SlicingOpLambda]:

--- a/model_compression_toolkit/qat/keras/qat_model_builder.py
+++ b/model_compression_toolkit/qat/keras/qat_model_builder.py
@@ -108,9 +108,8 @@ class QATKerasModelBuilder(KerasModelBuilder):
 
         # Wrap layers to be fine-tuned during QAT with QuantizeWrapper
         def _quantize(layer):
-            nodes = self.graph.find_node_by_name(get_node_name_from_layer(layer))
-            if len(nodes) == 1:
-                node = nodes[0]
+            node = self.oh.layer_to_node_dict.get(layer)
+            if node is not None:
                 if _is_qat_applicable(node, self.fw_info):
                     return QuantizeWrapper(layer,
                                            quantization_config_builder(node,


### PR DESCRIPTION
Use mapping in KerasModelBuilder from layers to nodes during MP and QAT model cloning.