### PR TITLE
Updating MCT default GPTQ arguments with Gumbel Rounding compatible values

### DIFF
--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -112,3 +112,6 @@ WEIGHTS_QUANTIZATION_FN = 'weights_quantization_fn'
 ACTIVATION_QUANT_PARAMS_FN = 'activation_quantization_params_fn'
 WEIGHTS_QUANT_PARAMS_FN = 'weights_quantization_params_fn'
 WEIGHTS_CHANNELS_AXIS = 'weights_channels_axis'
+
+# GPTQ Parameters
+GUMBEL_MAX_ITER = 10000

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -88,7 +88,8 @@ class GradientPTQConfig:
                  norm_weights: bool = False,
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
-                 optimizer_bias: Any = None):
+                 optimizer_bias: Any = None,
+                 gumbel_norm: float = 0.5):
         """
         Initialize a GradientPTQConfig.
 
@@ -113,6 +114,7 @@ class GradientPTQConfig:
             quantizer_config (Any): A class the contins the quantizer specific config.
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
+            gumbel_norm (float): A normalization factor for the gumbel tensor values.
 
         """
         self.n_iter = n_iter
@@ -135,6 +137,7 @@ class GradientPTQConfig:
         self.quantizer_config = quantizer_config
         self.optimizer_quantization_parameter = optimizer_quantization_parameter
         self.optimizer_bias = optimizer_bias
+        self.gumbel_norm = gumbel_norm
 
     @property
     def is_gumbel(self) -> bool:

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -25,6 +25,7 @@ N_CYCLES = 4
 MIM_TEMP = 0.5
 MAX_TEMP = 1.0
 GAMMA_TEMPERATURE = 0.1
+GUMBEL_SCALE = 0.5
 
 
 class RoundingType(Enum):
@@ -90,7 +91,7 @@ class GradientPTQConfig:
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
-                 gumbel_scale: float = 0.5):
+                 gumbel_scale: float = GUMBEL_SCALE):
         """
         Initialize a GradientPTQConfig.
 

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -90,7 +90,7 @@ class GradientPTQConfig:
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
-                 gumbel_norm: float = 0.5):
+                 gumbel_scale: float = 0.5):
         """
         Initialize a GradientPTQConfig.
 
@@ -115,7 +115,7 @@ class GradientPTQConfig:
             quantizer_config (Any): A class the contins the quantizer specific config.
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
-            gumbel_norm (float): A normalization factor for the gumbel tensor values.
+            gumbel_scale (float): A normalization factor for the gumbel tensor values.
 
         """
         self.n_iter = n_iter
@@ -138,7 +138,7 @@ class GradientPTQConfig:
         self.quantizer_config = quantizer_config
         self.optimizer_quantization_parameter = optimizer_quantization_parameter
         self.optimizer_bias = optimizer_bias
-        self.gumbel_norm = gumbel_norm
+        self.gumbel_scale = gumbel_scale
 
     @property
     def is_gumbel(self) -> bool:

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -24,6 +24,7 @@ MAX_LSBS_CHANGE_MAP = {8: 2,
 N_CYCLES = 4
 MIM_TEMP = 0.5
 MAX_TEMP = 1.0
+GAMMA_TEMPERATURE = 0.1
 
 
 class RoundingType(Enum):
@@ -46,7 +47,7 @@ class GumbelConfig(object):
                  n_cycles: int = N_CYCLES,
                  minimal_temp: float = MIM_TEMP,
                  maximal_temp: float = MAX_TEMP,
-                 gumbel_entropy_regularization: float = 0.01):
+                 gumbel_entropy_regularization: float = GAMMA_TEMPERATURE):
         """
         Initialize a GumbelConfig.
 

--- a/model_compression_toolkit/gptq/keras/gptq_loss.py
+++ b/model_compression_toolkit/gptq/keras/gptq_loss.py
@@ -118,7 +118,7 @@ def activation_mse(flp_act_list,
 
 
 class GPTQMultipleTensorsLoss:
-    def __init__(self, norm_loss: bool = True):
+    def __init__(self, norm_loss: bool = False):
         self.alpha = None
         self.norm_loss = norm_loss
 

--- a/model_compression_toolkit/gptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/gptq/keras/quantization_facade.py
@@ -35,6 +35,7 @@ LR_DEFAULT = 0.15
 LR_REST_DEFAULT = 1e-4
 LR_BIAS_DEFAULT = 1e-4
 LR_QUANTIZATION_PARAM_DEFAULT = 1e-3
+GPTQ_MOMENTUM = 0.9
 
 if common.constants.FOUND_TF:
     import tensorflow as tf
@@ -59,7 +60,7 @@ if common.constants.FOUND_TF:
     def get_keras_gptq_config(n_iter: int,
                               optimizer: OptimizerV2 = tf.keras.optimizers.Adam(learning_rate=LR_DEFAULT),
                               optimizer_rest: OptimizerV2 = tf.keras.optimizers.Adam(learning_rate=LR_REST_DEFAULT),
-                              loss: Callable = GPTQMultipleTensorsLoss(norm_loss=False),
+                              loss: Callable = GPTQMultipleTensorsLoss(),
                               log_function: Callable = None) -> GradientPTQConfig:
         """
         Create a GradientPTQConfig instance for Keras models.
@@ -92,8 +93,8 @@ if common.constants.FOUND_TF:
             The configuration can be passed to :func:`~model_compression_toolkit.keras_post_training_quantization` in order to quantize a keras model using gptq.
 
         """
-        bias_optimizer = tf.keras.optimizers.SGD(learning_rate=LR_BIAS_DEFAULT, momentum=0.9)
-        optimizer_quantization_parameter = tf.keras.optimizers.SGD(learning_rate=LR_QUANTIZATION_PARAM_DEFAULT, momentum=0.9)
+        bias_optimizer = tf.keras.optimizers.SGD(learning_rate=LR_BIAS_DEFAULT, momentum=GPTQ_MOMENTUM)
+        optimizer_quantization_parameter = tf.keras.optimizers.SGD(learning_rate=LR_QUANTIZATION_PARAM_DEFAULT, momentum=GPTQ_MOMENTUM)
         return GradientPTQConfig(n_iter,
                                  optimizer,
                                  optimizer_rest=optimizer_rest,

--- a/model_compression_toolkit/gptq/keras/quantizer/configs/weight_quantizer_gptq_config.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/configs/weight_quantizer_gptq_config.py
@@ -90,7 +90,8 @@ class WeightQuantizeConfig(BaseQuantizeConfig):
                                                                 quantization_axis=weight_channel_axis,
                                                                 max_lsbs_change_map=max_lsbs_change_map,
                                                                 max_iteration=gptq_config.n_iter,
-                                                                gumbel_config=gptq_config.quantizer_config)
+                                                                gumbel_config=gptq_config.quantizer_config,
+                                                                gumbel_norm=gptq_config.gumbel_norm)
             else:
                 common.Logger.error(
                     f"For quantization method {final_weights_quantization_cfg.weights_quantization_method}, GPTQ Rounding type {gptq_config.rounding_type} is not supported")

--- a/model_compression_toolkit/gptq/keras/quantizer/configs/weight_quantizer_gptq_config.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/configs/weight_quantizer_gptq_config.py
@@ -91,7 +91,7 @@ class WeightQuantizeConfig(BaseQuantizeConfig):
                                                                 max_lsbs_change_map=max_lsbs_change_map,
                                                                 max_iteration=gptq_config.n_iter,
                                                                 gumbel_config=gptq_config.quantizer_config,
-                                                                gumbel_norm=gptq_config.gumbel_norm)
+                                                                gumbel_scale=gptq_config.gumbel_scale)
             else:
                 common.Logger.error(
                     f"For quantization method {final_weights_quantization_cfg.weights_quantization_method}, GPTQ Rounding type {gptq_config.rounding_type} is not supported")

--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/gumbel_softmax.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/gumbel_softmax.py
@@ -29,7 +29,8 @@ def sample_gumbel(shape, eps=1e-6) -> tf.Tensor:
     return -tf.math.log(-tf.math.log(u + eps) + eps)
 
 
-def gumbel_softmax(in_pi: tf.Tensor, in_tau: tf.Tensor, in_gumbel: tf.Tensor, eps: float = 1e-6, axis=0) -> tf.Tensor:
+def gumbel_softmax(in_pi: tf.Tensor, in_tau: tf.Tensor, in_gumbel: tf.Tensor, eps: float = 1e-6, axis=0,
+                   gumbel_norm: float = 1.0) -> tf.Tensor:
     """
     A gumbel softmax function.
     Args:
@@ -38,11 +39,12 @@ def gumbel_softmax(in_pi: tf.Tensor, in_tau: tf.Tensor, in_gumbel: tf.Tensor, ep
         in_gumbel: A tensor of gumbel random variable.
         eps: A small number for numeric stability.
         axis: A integer representing the axis of which the gumbel softmax applyed on.
+        gumbel_norm: A normalization factor for the gumbel tensor values
 
     Returns: A gumbel softmax probability tensor.
 
     """
-    return tf.nn.softmax((tf.nn.log_softmax(in_pi, axis=axis) + in_gumbel) / (in_tau + eps), axis=axis)
+    return tf.nn.softmax((tf.nn.log_softmax(in_pi, axis=axis) + gumbel_norm * in_gumbel) / (in_tau + eps), axis=axis)
 
 
 def ste_gumbel(in_prob: tf.Tensor) -> tf.Tensor:

--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/gumbel_softmax.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/gumbel_softmax.py
@@ -30,7 +30,7 @@ def sample_gumbel(shape, eps=1e-6) -> tf.Tensor:
 
 
 def gumbel_softmax(in_pi: tf.Tensor, in_tau: tf.Tensor, in_gumbel: tf.Tensor, eps: float = 1e-6, axis=0,
-                   gumbel_norm: float = 1.0) -> tf.Tensor:
+                   gumbel_scale: float = 1.0) -> tf.Tensor:
     """
     A gumbel softmax function.
     Args:
@@ -39,12 +39,12 @@ def gumbel_softmax(in_pi: tf.Tensor, in_tau: tf.Tensor, in_gumbel: tf.Tensor, ep
         in_gumbel: A tensor of gumbel random variable.
         eps: A small number for numeric stability.
         axis: A integer representing the axis of which the gumbel softmax applyed on.
-        gumbel_norm: A normalization factor for the gumbel tensor values
+        gumbel_scale: A normalization factor for the gumbel tensor values
 
     Returns: A gumbel softmax probability tensor.
 
     """
-    return tf.nn.softmax((tf.nn.log_softmax(in_pi, axis=axis) + gumbel_norm * in_gumbel) / (in_tau + eps), axis=axis)
+    return tf.nn.softmax((tf.nn.log_softmax(in_pi, axis=axis) + gumbel_scale * in_gumbel) / (in_tau + eps), axis=axis)
 
 
 def ste_gumbel(in_prob: tf.Tensor) -> tf.Tensor:

--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/symmetric_gumbel.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/symmetric_gumbel.py
@@ -23,7 +23,7 @@ from tensorflow.python.framework.tensor_shape import TensorShape
 from model_compression_toolkit.core.common.defaultdict import DefaultDict
 from typing import Dict, Any, List
 from model_compression_toolkit.gptq.keras.quantizer.gumbel_rounding.gumbel_softmax import gumbel_softmax, ste_gumbel
-from model_compression_toolkit.core.common.constants import THRESHOLD
+from model_compression_toolkit.core.common.constants import THRESHOLD, GUMBEL_MAX_ITER
 from model_compression_toolkit.gptq.common import gptq_constants
 
 
@@ -73,7 +73,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
                  gumbel_config: GumbelConfig,
                  quantization_axis: int = -1,
                  max_lsbs_change_map: dict = DefaultDict({}, lambda: 1),
-                 max_iteration: int = 10000,
+                 max_iteration: int = GUMBEL_MAX_ITER,
                  gumbel_scale: float = 1.0):
         """
         Initialize a TrainableWeightQuantizer object with parameters to use

--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/symmetric_gumbel.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/symmetric_gumbel.py
@@ -73,7 +73,8 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
                  gumbel_config: GumbelConfig,
                  quantization_axis: int = -1,
                  max_lsbs_change_map: dict = DefaultDict({}, lambda: 1),
-                 max_iteration: int = 10000):
+                 max_iteration: int = 10000,
+                 gumbel_norm: float = 1.0):
         """
         Initialize a TrainableWeightQuantizer object with parameters to use
         for the quantization.
@@ -88,6 +89,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
             power_of_two: Whether the threshold should be constrained or not.
             max_lsbs_change_map: a mapping between number of bits to max lsb change.
             max_iteration: The number of iteration of gptq.
+            gumbel_norm: A normalization factor for the gumbel tensor values
         """
         super().__init__(num_bits, per_axis, signed, True, power_of_two, quantization_parameter_learning,
                          quantization_axis, gumbel_config,
@@ -97,6 +99,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
         self.threshold_values = np.reshape(np.asarray(threshold_values), [-1]) if self.per_axis else float(
             threshold_values)
         self.k_threshold = len(self.threshold_values) if self.per_axis else 1
+        self.gumbel_norm = gumbel_norm
 
     def build(self,
               tensor_shape: TensorShape,
@@ -178,7 +181,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
             # Gumbel Softmax
             #####################################################
             if training:
-                p_t = gumbel_softmax(auxvar, self.tau, self.g_t)
+                p_t = gumbel_softmax(auxvar, self.tau, self.g_t, gumbel_norm=self.gumbel_norm)
             else:
                 p_t = gumbel_softmax(auxvar, self.minimal_temp, 0)
                 p_t = ste_gumbel(p_t)

--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/symmetric_gumbel.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/symmetric_gumbel.py
@@ -74,7 +74,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
                  quantization_axis: int = -1,
                  max_lsbs_change_map: dict = DefaultDict({}, lambda: 1),
                  max_iteration: int = 10000,
-                 gumbel_norm: float = 1.0):
+                 gumbel_scale: float = 1.0):
         """
         Initialize a TrainableWeightQuantizer object with parameters to use
         for the quantization.
@@ -89,7 +89,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
             power_of_two: Whether the threshold should be constrained or not.
             max_lsbs_change_map: a mapping between number of bits to max lsb change.
             max_iteration: The number of iteration of gptq.
-            gumbel_norm: A normalization factor for the gumbel tensor values
+            gumbel_scale: A normalization factor for the gumbel tensor values
         """
         super().__init__(num_bits, per_axis, signed, True, power_of_two, quantization_parameter_learning,
                          quantization_axis, gumbel_config,
@@ -99,7 +99,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
         self.threshold_values = np.reshape(np.asarray(threshold_values), [-1]) if self.per_axis else float(
             threshold_values)
         self.k_threshold = len(self.threshold_values) if self.per_axis else 1
-        self.gumbel_norm = gumbel_norm
+        self.gumbel_scale = gumbel_scale
 
     def build(self,
               tensor_shape: TensorShape,
@@ -181,7 +181,7 @@ class SymmetricGumbelRounding(GumbelRoundingBase):
             # Gumbel Softmax
             #####################################################
             if training:
-                p_t = gumbel_softmax(auxvar, self.tau, self.g_t, gumbel_norm=self.gumbel_norm)
+                p_t = gumbel_softmax(auxvar, self.tau, self.g_t, gumbel_scale=self.gumbel_scale)
             else:
                 p_t = gumbel_softmax(auxvar, self.minimal_temp, 0)
                 p_t = ste_gumbel(p_t)


### PR DESCRIPTION
- Minor changes in default parameters to Keras GPTQ facade.
- Added a 'gumbel_scale' argument to gumbel softmax.