### PR TITLE
Disable activation quantization in mixed-precision metric computation for only weight MP search

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -299,7 +299,8 @@ class FrameworkImplementation(ABC):
                                   graph: Graph,
                                   quant_config: MixedPrecisionQuantizationConfigV2,
                                   representative_data_gen: Callable,
-                                  fw_info: FrameworkInfo) -> SensitivityEvaluation:
+                                  fw_info: FrameworkInfo,
+                                  disable_activation_for_metric: bool = False) -> SensitivityEvaluation:
         """
         Creates and returns an object which handles the computation of a sensitivity metric for a mixed-precision
         configuration (comparing to the float model).
@@ -309,6 +310,7 @@ class FrameworkImplementation(ABC):
             quant_config: QuantizationConfig of how the model should be quantized.
             representative_data_gen: Dataset to use for retrieving images for the models inputs.
             fw_info: FrameworkInfo object with information about the specific framework's model.
+            disable_activation_for_metric: Whether to disable activation quantization when computing the MP metric.
 
         Returns:
             A function that computes the metric.

--- a/model_compression_toolkit/core/common/graph/base_graph.py
+++ b/model_compression_toolkit/core/common/graph/base_graph.py
@@ -681,3 +681,12 @@ class Graph(nx.MultiDiGraph, GraphSearches):
 
         """
         self.fused_nodes.append(fusion)
+
+    def is_single_activation_cfg(self):
+        """
+        Checks whether all nodes in the graph that have activation quantization are quantized with the same bit-width.
+
+        Returns: True if all quantization config candidates of all nodes have the same activation quantization bit-width.
+
+        """
+        return all([n.is_all_activation_candidates_equal() for n in self.nodes])

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -84,13 +84,21 @@ def search_bit_width(graph_to_search_cfg: Graph,
         # Since Bit-operations count target KPI is set, we need to reconstruct the graph for the MP search
         graph = substitute(graph, fw_impl.get_substitutions_virtual_weights_activation_coupling())
 
+    # If we only run weights compression with MP than no need to consider activation quantization when computing the
+    # MP metric (it adds noise to the computation)
+    disable_activation_for_metric = target_kpi.weights_memory < np.inf and \
+                                    (target_kpi.activation_memory == np.inf and
+                                     target_kpi.total_memory == np.inf and
+                                     target_kpi.bops == np.inf)
+
     # Set Sensitivity Evaluator for MP search. It should always work with the original MP graph,
     # even if a virtual graph was created (and is used only for BOPS KPI computation purposes)
     se = fw_impl.get_sensitivity_evaluator(
         graph_to_search_cfg,
         mp_config,
         representative_data_gen=representative_data_gen,
-        fw_info=fw_info)
+        fw_info=fw_info,
+        disable_activation_for_metric=disable_activation_for_metric)
 
     # Each pair of (KPI method, KPI aggregation) should match to a specific provided kpi target
     kpi_functions = kpi_functions_mapping

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -86,10 +86,10 @@ def search_bit_width(graph_to_search_cfg: Graph,
 
     # If we only run weights compression with MP than no need to consider activation quantization when computing the
     # MP metric (it adds noise to the computation)
-    disable_activation_for_metric = target_kpi.weights_memory < np.inf and \
+    disable_activation_for_metric = (target_kpi.weights_memory < np.inf and
                                     (target_kpi.activation_memory == np.inf and
                                      target_kpi.total_memory == np.inf and
-                                     target_kpi.bops == np.inf)
+                                     target_kpi.bops == np.inf)) or graph_to_search_cfg.is_single_activation_cfg()
 
     # Set Sensitivity Evaluator for MP search. It should always work with the original MP graph,
     # even if a virtual graph was created (and is used only for BOPS KPI computation purposes)

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -171,8 +171,8 @@ class SensitivityEvaluation:
 
         evaluation_graph = copy.deepcopy(self.graph)
 
-        for n in evaluation_graph.get_topo_sorted_nodes():
-            if self.disable_activation_for_metric or n.is_all_activation_candidates_equal():
+        if self.disable_activation_for_metric:
+            for n in evaluation_graph.get_topo_sorted_nodes():
                 for c in n.candidates_quantization_cfg:
                     c.activation_quantization_cfg.enable_activation_quantization = False
 

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -360,7 +360,8 @@ class KerasImplementation(FrameworkImplementation):
                                   graph: Graph,
                                   quant_config: MixedPrecisionQuantizationConfigV2,
                                   representative_data_gen: Callable,
-                                  fw_info: FrameworkInfo) -> SensitivityEvaluation:
+                                  fw_info: FrameworkInfo,
+                                  disable_activation_for_metric: bool = False) -> SensitivityEvaluation:
         """
         Creates and returns an object which handles the computation of a sensitivity metric for a mixed-precision
         configuration (comparing to the float model).
@@ -370,6 +371,7 @@ class KerasImplementation(FrameworkImplementation):
             quant_config: QuantizationConfig of how the model should be quantized.
             representative_data_gen: Dataset to use for retrieving images for the models inputs.
             fw_info: FrameworkInfo object with information about the specific framework's model.
+            disable_activation_for_metric: Whether to disable activation quantization when computing the MP metric.
 
         Returns:
             A SensitivityEvaluation object.
@@ -381,7 +383,8 @@ class KerasImplementation(FrameworkImplementation):
                                      fw_info=fw_info,
                                      fw_impl=self,
                                      set_layer_to_bitwidth=set_layer_to_bitwidth,
-                                     get_quant_node_name=lambda node_name: f'quant_{node_name}')
+                                     get_quant_node_name=lambda node_name: f'quant_{node_name}',
+                                     disable_activation_for_metric=disable_activation_for_metric)
 
     def get_node_prior_info(self,
                             node: BaseNode,

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -330,7 +330,8 @@ class PytorchImplementation(FrameworkImplementation):
                                   graph: Graph,
                                   quant_config: MixedPrecisionQuantizationConfigV2,
                                   representative_data_gen: Callable,
-                                  fw_info: FrameworkInfo) -> SensitivityEvaluation:
+                                  fw_info: FrameworkInfo,
+                                  disable_activation_for_metric: bool = False) -> SensitivityEvaluation:
         """
         Creates and returns an object which handles the computation of a sensitivity metric for a mixed-precision
         configuration (comparing to the float model).
@@ -340,6 +341,7 @@ class PytorchImplementation(FrameworkImplementation):
             quant_config: QuantizationConfig of how the model should be quantized.
             representative_data_gen: Dataset to use for retrieving images for the models inputs.
             fw_info: FrameworkInfo object with information about the specific framework's model.
+            disable_activation_for_metric: Whether to disable activation quantization when computing the MP metric.
 
         Returns:
             A SensitivityEvaluation object.
@@ -351,7 +353,8 @@ class PytorchImplementation(FrameworkImplementation):
                                      fw_info=fw_info,
                                      fw_impl=self,
                                      set_layer_to_bitwidth=set_layer_to_bitwidth,
-                                     get_quant_node_name=lambda node_name: f'{node_name}')
+                                     get_quant_node_name=lambda node_name: f'{node_name}',
+                                     disable_activation_for_metric=disable_activation_for_metric)
 
     def get_node_prior_info(self,
                             node: BaseNode,


### PR DESCRIPTION
Disable activation quantization in mixed-precision metric computation when running mixed precision with target weights KPI only or for nodes that have only single activation candidates (so they are not part of the MP search)