### PR TITLE
Replace output node for jacobian-based weights computation for GPTQ 

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -436,21 +436,21 @@ class FrameworkImplementation(ABC):
                              f'framework\'s model_grad method.')
 
     @abstractmethod
-    def is_node_compatible_for_mp_metric_outputs(self,
+    def is_node_compatible_for_metric_outputs(self,
                                                  node: BaseNode) -> bool:
         """
-        Checks and returns whether the given node is compatible as output for mixed-precision metric computation
-        purposes.
+        Checks and returns whether the given node is compatible as output for metric computation
+        purposes and gradient-based weights calculation.
 
         Args:
             node: A BaseNode object.
 
-        Returns: Whether the node is compatible as output for MP metric computation or not.
+        Returns: Whether the node is compatible as output for metric computation or not.
 
         """
 
         raise NotImplemented(f'{self.__class__.__name__} have to implement the '
-                             f'framework\'s is_node_compatible_for_mp_metric_outputs method.')
+                             f'framework\'s is_node_compatible_for_metric_outputs method.')
 
     @abstractmethod
     def get_node_mac_operations(self,

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -442,7 +442,7 @@ def get_output_replacement_nodes(graph: Graph,
     replacement_outputs = []
     for n in graph.get_outputs():
         prev_node = n.node
-        while not fw_impl.is_node_compatible_for_mp_metric_outputs(prev_node):
+        while not fw_impl.is_node_compatible_for_metric_outputs(prev_node):
             prev_node = graph.get_prev_nodes(n.node)
             assert len(prev_node) == 1, "A none MP compatible output node has multiple inputs, " \
                                         "which is incompatible for metric computation."

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -517,16 +517,16 @@ class KerasImplementation(FrameworkImplementation):
         return keras_iterative_approx_jacobian_trace(graph_float, model_input_tensors, interest_points, output_list,
                                                      all_outputs_indices, alpha, n_iter, norm_weights=norm_weights)
 
-    def is_node_compatible_for_mp_metric_outputs(self,
-                                                 node: BaseNode) -> Any:
+    def is_node_compatible_for_metric_outputs(self,
+                                              node: BaseNode) -> Any:
         """
-        Checks and returns whether the given node is compatible as output for mixed-precision metric computation
-        purposes.
+        Checks and returns whether the given node is compatible as output for metric computation
+        purposes and gradient-based weights calculation.
 
         Args:
             node: A BaseNode object.
 
-        Returns: Whether the node is compatible as output for MP metric computation or not.
+        Returns: Whether the node is compatible as output for metric computation or not.
 
         """
 

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -474,16 +474,16 @@ class PytorchImplementation(FrameworkImplementation):
         return pytorch_iterative_approx_jacobian_trace(graph_float, model_input_tensors, interest_points, output_list,
                                                        all_outputs_indices, alpha, n_iter, norm_weights=norm_weights)
 
-    def is_node_compatible_for_mp_metric_outputs(self,
-                                                 node: BaseNode) -> bool:
+    def is_node_compatible_for_metric_outputs(self,
+                                              node: BaseNode) -> bool:
         """
-        Checks and returns whether the given node is compatible as output for mixed-precision metric computation
-        purposes.
+        Checks and returns whether the given node is compatible as output for metric computation
+        purposes and gradient-based weights calculation.
 
         Args:
             node: A BaseNode object.
 
-        Returns: Whether the node is compatible as output for MP metric computation or not.
+        Returns: Whether the node is compatible as output for metric computation or not.
 
         """
 


### PR DESCRIPTION
In case of an incompatible output node for jacobian-based weights computation (argmax or softmax), the output nodes of the model will be replaced for the sake of the computation of the weight only.
This solution is similar to the one implemented for mixed-precision weights but it does not alter the interest points list like in mixed-precision.