### PR TITLE
Added necessary layers types to TPC No Quantization list

### DIFF
--- a/model_compression_toolkit/core/tpc_models/default_tpc/v4/tpc_keras.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v4/tpc_keras.py
@@ -16,12 +16,11 @@ import tensorflow as tf
 from packaging import version
 
 if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, \
-        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute
 else:
-    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute
 
 from model_compression_toolkit.core.tpc_models.default_tpc.v4.tp_model import get_tp_model
 import model_compression_toolkit as mct
@@ -56,6 +55,8 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
     with keras_tpc:
         tp.OperationsSetToLayers("NoQuantization", [Reshape,
                                                     tf.reshape,
+                                                    Permute,
+                                                    tf.transpose,
                                                     Flatten,
                                                     Cropping2D,
                                                     ZeroPadding2D,
@@ -65,6 +66,11 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     tf.quantization.fake_quant_with_min_max_vars,
                                                     tf.math.argmax,
                                                     tf.shape,
+                                                    tf.math.equal,
+                                                    tf.gather,
+                                                    tf.cast,
+                                                    tf.compat.v1.gather,
+                                                    tf.nn.top_k,
                                                     tf.__operators__.getitem,
                                                     tf.compat.v1.shape])
 

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v4/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v4/tpc_pytorch.py
@@ -16,7 +16,8 @@
 import operator
 
 import torch
-from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind
+from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind, \
+    permute, transpose, equal, gather, topk
 from torch.nn import Conv2d, Linear, BatchNorm2d
 from torch.nn import Dropout, Flatten, Hardtanh
 from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh, Hardswish, LeakyReLU
@@ -63,7 +64,12 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     BatchNorm2d,
                                                     chunk,
                                                     unbind,
-                                                    torch.Tensor.size])
+                                                    torch.Tensor.size,
+                                                    permute,
+                                                    transpose,
+                                                    equal,
+                                                    gather,
+                                                    topk])
 
         tp.OperationsSetToLayers("Conv", [Conv2d])
         tp.OperationsSetToLayers("FullyConnected", [Linear])

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v4_lut/tpc_keras.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v4_lut/tpc_keras.py
@@ -17,12 +17,11 @@ from packaging import version
 from model_compression_toolkit.core.tpc_models.default_tpc.v4_lut import __version__ as TPC_VERSION
 
 if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, \
-        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute
 else:
-    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute
 
 from model_compression_toolkit.core.tpc_models.default_tpc.v4_lut.tp_model import get_tp_model
 import model_compression_toolkit as mct
@@ -57,6 +56,8 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
     with keras_tpc:
         tp.OperationsSetToLayers("NoQuantization", [Reshape,
                                                     tf.reshape,
+                                                    Permute,
+                                                    tf.transpose,
                                                     Flatten,
                                                     Cropping2D,
                                                     ZeroPadding2D,
@@ -66,6 +67,11 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     tf.quantization.fake_quant_with_min_max_vars,
                                                     tf.math.argmax,
                                                     tf.shape,
+                                                    tf.math.equal,
+                                                    tf.gather,
+                                                    tf.cast,
+                                                    tf.compat.v1.gather,
+                                                    tf.nn.top_k,
                                                     tf.__operators__.getitem,
                                                     tf.compat.v1.shape])
 

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v4_lut/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v4_lut/tpc_pytorch.py
@@ -16,7 +16,8 @@
 import operator
 
 import torch
-from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind
+from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind, topk, \
+    gather, equal, permute, transpose
 from torch.nn import Conv2d, Linear, BatchNorm2d
 from torch.nn import Dropout, Flatten, Hardtanh
 from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh, Hardswish, LeakyReLU
@@ -63,7 +64,12 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     BatchNorm2d,
                                                     chunk,
                                                     unbind,
-                                                    torch.Tensor.size])
+                                                    torch.Tensor.size,
+                                                    permute,
+                                                    transpose,
+                                                    equal,
+                                                    gather,
+                                                    topk])
 
         tp.OperationsSetToLayers("Conv", [Conv2d])
         tp.OperationsSetToLayers("FullyConnected", [Linear])

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v5/tpc_keras.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v5/tpc_keras.py
@@ -16,12 +16,11 @@ import tensorflow as tf
 from packaging import version
 
 if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, \
-        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU
+    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute
 else:
-    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU
+    from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute
 
 from model_compression_toolkit.core.tpc_models.default_tpc.v4.tp_model import get_tp_model
 import model_compression_toolkit as mct
@@ -56,6 +55,8 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
     with keras_tpc:
         tp.OperationsSetToLayers("NoQuantization", [Reshape,
                                                     tf.reshape,
+                                                    Permute,
+                                                    tf.transpose,
                                                     Flatten,
                                                     Cropping2D,
                                                     ZeroPadding2D,
@@ -65,6 +66,11 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     tf.quantization.fake_quant_with_min_max_vars,
                                                     tf.math.argmax,
                                                     tf.shape,
+                                                    tf.math.equal,
+                                                    tf.gather,
+                                                    tf.cast,
+                                                    tf.compat.v1.gather,
+                                                    tf.nn.top_k,
                                                     tf.__operators__.getitem,
                                                     tf.compat.v1.shape])
 

--- a/model_compression_toolkit/core/tpc_models/default_tpc/v5/tpc_pytorch.py
+++ b/model_compression_toolkit/core/tpc_models/default_tpc/v5/tpc_pytorch.py
@@ -16,7 +16,8 @@
 import operator
 
 import torch
-from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind
+from torch import add, sub, mul, div, flatten, reshape, split, unsqueeze, dropout, sigmoid, tanh, chunk, unbind, topk, \
+    gather, equal, transpose, permute
 from torch.nn import Conv2d, Linear, BatchNorm2d
 from torch.nn import Dropout, Flatten, Hardtanh
 from torch.nn import ReLU, ReLU6, PReLU, SiLU, Sigmoid, Tanh, Hardswish, LeakyReLU
@@ -63,7 +64,12 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     BatchNorm2d,
                                                     chunk,
                                                     unbind,
-                                                    torch.Tensor.size])
+                                                    torch.Tensor.size,
+                                                    permute,
+                                                    transpose,
+                                                    equal,
+                                                    gather,
+                                                    topk])
 
         tp.OperationsSetToLayers("Conv", [Conv2d])
         tp.OperationsSetToLayers("FullyConnected", [Linear])


### PR DESCRIPTION
Added the following layers to no quantization in Keras and Pytorch TPCs versions v5, v4, v4lut:
- permute, transpose, gather, top_k, cast (Keras only, no such module in Pytorch).