### PR TITLE
Mixed precision tests coverage - KPI

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/kpi_tools/kpi_data.py
+++ b/model_compression_toolkit/core/common/mixed_precision/kpi_tools/kpi_data.py
@@ -152,8 +152,7 @@ def compute_total_bops(graph: Graph, fw_info: FrameworkInfo, fw_impl: FrameworkI
         if n.has_weights_to_quantize(fw_info):
             # If node doesn't have weights then its MAC count is 0, and we shouldn't consider it in the BOPS count.
             incoming_edges = graph.incoming_edges(n, sort_by_attr=EDGE_SINK_INDEX)
-            if len(incoming_edges) != 1:
-                Logger.warning(f"Can't compute BOPS metric for node {n.name} with multiple inputs.")
+            assert len(incoming_edges) == 1, f"Can't compute BOPS metric for node {n.name} with multiple inputs."
 
             node_mac = fw_impl.get_node_mac_operations(n, fw_info)
 

--- a/model_compression_toolkit/core/common/mixed_precision/kpi_tools/kpi_methods.py
+++ b/model_compression_toolkit/core/common/mixed_precision/kpi_tools/kpi_methods.py
@@ -243,15 +243,13 @@ def bops_kpi(mp_cfg: List[int],
                          fw_info,
                          fw_impl)
 
-    if len(mp_cfg) == 0:
-        # BOPs KPI method considers non-configurable nodes, therefore, it doesn't need separate implementation
-        # for non-configurable nodes only.
-        bops = []
-    else:
-        virtual_bops_nodes = [n for n in graph.get_topo_sorted_nodes() if isinstance(n, VirtualActivationWeightsNode)]
+    # BOPs KPI method considers non-configurable nodes, therefore, it doesn't need separate implementation
+    # for non-configurable nodes for setting a constraint (no need for separate implementation for len(mp_cfg) = 0).
 
-        mp_nodes = graph.get_configurable_sorted_nodes_names()
-        bops = [n.get_bops_count(fw_impl, fw_info, candidate_idx=_get_node_cfg_idx(n, mp_cfg, mp_nodes)) for n in virtual_bops_nodes]
+    virtual_bops_nodes = [n for n in graph.get_topo_sorted_nodes() if isinstance(n, VirtualActivationWeightsNode)]
+
+    mp_nodes = graph.get_configurable_sorted_nodes_names()
+    bops = [n.get_bops_count(fw_impl, fw_info, candidate_idx=_get_node_cfg_idx(n, mp_cfg, mp_nodes)) for n in virtual_bops_nodes]
 
     return np.array(bops)
 

--- a/tests/common_tests/function_tests/test_kpi_object.py
+++ b/tests/common_tests/function_tests/test_kpi_object.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import unittest
+import numpy as np
+from model_compression_toolkit import KPI
+from model_compression_toolkit.core.common.mixed_precision.kpi_tools.kpi import KPITarget
+
+default_kpi = KPI()
+custom_kpi = KPI(1, 2, 3, 4)
+
+
+class TestKPIObject(unittest.TestCase):
+
+    def test_default(self):
+        self.assertTrue(default_kpi.weights_memory, np.inf)
+        self.assertTrue(default_kpi.activation_memory, np.inf)
+        self.assertTrue(default_kpi.total_memory, np.inf)
+        self.assertTrue(default_kpi.bops, np.inf)
+
+        self.assertTrue(custom_kpi.weights_memory, 1)
+        self.assertTrue(custom_kpi.activation_memory, 2)
+        self.assertTrue(custom_kpi.total_memory, 3)
+        self.assertTrue(custom_kpi.bops, 4)
+
+    def test_representation(self):
+        self.assertEqual(repr(default_kpi), f"Weights_memory: {np.inf}, "
+                                            f"Activation_memory: {np.inf}, "
+                                            f"Total_memory: {np.inf}, "
+                                            f"BOPS: {np.inf}")
+
+        self.assertEqual(repr(custom_kpi), f"Weights_memory: {1}, "
+                                           f"Activation_memory: {2}, "
+                                           f"Total_memory: {3}, "
+                                           f"BOPS: {4}")
+
+    def test_kpi_hold_constraints(self):
+        self.assertTrue(default_kpi.holds_constraints(custom_kpi))
+        self.assertFalse(custom_kpi.holds_constraints(default_kpi))
+        self.assertFalse(custom_kpi.holds_constraints({KPITarget.WEIGHTS: 1,
+                                                       KPITarget.ACTIVATION: 1,
+                                                       KPITarget.TOTAL: 1,
+                                                       KPITarget.BOPS: 1}))


### PR DESCRIPTION
- kpi_data - removed unnecessary condition from total bops
- kpi_methods - removed unnecessary condition from BOPs KPI method - no need to check if mp_cfg is not empty because there is no separate behavior for this case
- kpi - added dedicated tests for KPI object