### PR TITLE
Add support on PyTorch symbolic trace layers

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -59,6 +59,7 @@ class FrameworkImplementation(ABC):
         raise NotImplemented(f'{self.__class__.__name__} have to implement the '
                              f'framework\'s to_numpy method.')    \
 
+
     @abstractmethod
     def to_tensor(self, tensor: np.ndarray) -> Any:
         """
@@ -84,7 +85,8 @@ class FrameworkImplementation(ABC):
             representative_data_gen (Callable): Dataset used for calibration.
             model_leaf_layers (list): For PyTorch only!
             List of the module's custom layers, these layers shouldn't be divided into
-            their submodules and their quantization will not be optimized.
+            their submodules.
+            Please note that their quantization will not be optimized.
 
         Returns:
             Graph representing the input model.

--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -75,12 +75,16 @@ class FrameworkImplementation(ABC):
     @abstractmethod
     def model_reader(self,
                      model: Any,
-                     representative_data_gen: Callable) -> Graph:
+                     representative_data_gen: Callable,
+                     model_leaf_layers: list = None) -> Graph:
         """
         Convert a framework's model into a graph.
         Args:
             model: Framework's model.
             representative_data_gen (Callable): Dataset used for calibration.
+            model_leaf_layers (list): For PyTorch only!
+            List of the module's custom layers, these layers shouldn't be divided into
+            their submodules and their quantization will not be optimized.
 
         Returns:
             Graph representing the input model.

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -108,12 +108,16 @@ class KerasImplementation(FrameworkImplementation):
 
     def model_reader(self,
                      model: Model,
-                     representative_data_gen: Callable) -> Graph:
+                     representative_data_gen: Callable,
+                     model_leaf_layers: list = None) -> Graph:
         """
         Convert a framework's model into a graph.
         Args:
             model: Framework's model.
             representative_data_gen (Callable): Dataset used for calibration.
+            model_leaf_layers (list): For PyTorch only!
+            List of the module's custom layers, these layers shouldn't be divided into
+            their submodules and their quantization will not be optimized.
 
         Returns:
             Graph representing the input model.

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 from typing import List, Any, Tuple, Callable, Type, Dict
+from model_compression_toolkit.core.common import Logger
 
 import numpy as np
 import tensorflow as tf
@@ -115,13 +116,14 @@ class KerasImplementation(FrameworkImplementation):
         Args:
             model: Framework's model.
             representative_data_gen (Callable): Dataset used for calibration.
-            model_leaf_layers (list): For PyTorch only!
-            List of the module's custom layers, these layers shouldn't be divided into
-            their submodules and their quantization will not be optimized.
+            model_leaf_layers (list): For PyTorch only! Should be 'None' for Keras.
 
         Returns:
             Graph representing the input model.
         """
+        if model_leaf_layers is not None:
+            Logger.warning(f'You are using a PyTorch only attribute, please do not pass model_leaf_layers '
+                           f'attribute for a Keras model')
         return model_reader(model)
 
     def to_numpy(self, tensor: tf.Tensor) -> np.ndarray:

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -126,7 +126,8 @@ class PytorchImplementation(FrameworkImplementation):
             module: Framework's module.
             representative_data_gen (Callable): Dataset used for calibration.
             model_leaf_layers (list): List of the module's custom layers, these layers shouldn't be divided into
-            their submodules and their quantization will not be optimized.
+            their submodules.
+            Please note that their quantization will not be optimized.
         Returns:
             Graph representing the input module.
         """

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -65,8 +65,8 @@ from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.sh
     pytorch_apply_shift_negative_correction
 from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.softmax_shift import \
     pytorch_softmax_shift
-from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.virtual_activation_weights_composition import \
-    VirtualActivationWeightsComposition
+from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.virtual_activation_weights_composition \
+    import VirtualActivationWeightsComposition
 from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.weights_activation_split import \
     WeightsActivationSplit
 from model_compression_toolkit.core.pytorch.mixed_precision.set_layer_to_bitwidth import set_layer_to_bitwidth
@@ -118,16 +118,20 @@ class PytorchImplementation(FrameworkImplementation):
 
     def model_reader(self,
                      module: Module,
-                     representative_data_gen: Callable) -> Graph:
+                     representative_data_gen: Callable,
+                     model_leaf_layers: list = None) -> Graph:
         """
         Convert a framework's module into a graph.
         Args:
             module: Framework's module.
             representative_data_gen (Callable): Dataset used for calibration.
+            model_leaf_layers (list): List of the module's custom layers, these layers shouldn't be divided into
+            their submodules and their quantization will not be optimized.
         Returns:
             Graph representing the input module.
         """
-        return model_reader(module, representative_data_gen, self.to_numpy, self.to_tensor)
+        return model_reader(module, representative_data_gen, self.to_numpy, self.to_tensor,
+                            model_leaf_layers=model_leaf_layers)
 
     def model_builder(self,
                       graph: Graph,

--- a/model_compression_toolkit/core/runner.py
+++ b/model_compression_toolkit/core/runner.py
@@ -84,8 +84,9 @@ def core_runner(in_model: Any,
                                               the attached framework operator's information.
         target_kpi: KPI to constraint the search of the mixed-precision configuration for the model.
         tb_w: TensorboardWriter object for logging
-        model_leaf_layers (list): List of the module's custom layers, these layers shouldn't be divided into
-        their submodules and their quantization will not be optimized.
+        model_leaf_layers (list): For PyTorch Only.
+        List of the module's custom layers, these layers shouldn't be divided into their submodules.
+        Please note that their quantization will not be optimized.
 
     Returns:
         An internal graph representation of the input model.
@@ -287,14 +288,16 @@ def read_model_to_graph(in_model: Any,
         fw_info: Information needed for quantization about the specific framework (e.g.,
                 kernel channels indices, groups of layers by how they should be quantized, etc.)
         fw_impl: FrameworkImplementation object with a specific framework methods implementation.
-        model_leaf_layers (list): List of the module's custom layers, these layers shouldn't be divided into
-        their submodules and their quantization will not be optimized.
+        model_leaf_layers (list): For PyTorch Only.
+        List of the module's custom layers, these layers shouldn't be divided into their submodules.
+        Please note that their quantization will not be optimized.
 
     Returns:
         Graph object that represents the model.
     """
     graph = fw_impl.model_reader(in_model,
-                                 representative_data_gen, model_leaf_layers)
+                                 representative_data_gen,
+                                 model_leaf_layers)
     graph.set_fw_info(fw_info)
     graph.set_tpc(tpc)
     return graph

--- a/model_compression_toolkit/ptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/ptq/pytorch/quantization_facade.py
@@ -66,7 +66,8 @@ if FOUND_TORCH:
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the PyTorch model according to. `Default PyTorch TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/core/tpc_models/pytorch_tp_models/pytorch_default.py>`_
             new_experimental_exporter (bool): Whether exporting the quantized model using new exporter or not (in progress. Avoiding it for now is recommended).
             model_leaf_layers (list): List of the module's custom layers, these layers shouldn't be divided into their
-            submodules and their quantization will not be optimized.
+            submodules.
+            Please note that their quantization will not be optimized.
 
         Returns:
             A quantized module and information the user may need to handle the quantized module.

--- a/model_compression_toolkit/ptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/ptq/pytorch/quantization_facade.py
@@ -43,7 +43,8 @@ if FOUND_TORCH:
                                                         target_kpi: KPI = None,
                                                         core_config: CoreConfig = CoreConfig(),
                                                         target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_PYTORCH_TPC,
-                                                        new_experimental_exporter: bool = False):
+                                                        new_experimental_exporter: bool = False,
+                                                        model_leaf_layers: list = None):
         """
         Quantize a trained Pytorch module using post-training quantization.
         By default, the module is quantized using a symmetric constraint quantization thresholds
@@ -64,6 +65,8 @@ if FOUND_TORCH:
             core_config (CoreConfig): Configuration object containing parameters of how the model should be quantized, including mixed precision parameters.
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the PyTorch model according to. `Default PyTorch TPC <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/core/tpc_models/pytorch_tp_models/pytorch_default.py>`_
             new_experimental_exporter (bool): Whether exporting the quantized model using new exporter or not (in progress. Avoiding it for now is recommended).
+            model_leaf_layers (list): List of the module's custom layers, these layers shouldn't be divided into their
+            submodules and their quantization will not be optimized.
 
         Returns:
             A quantized module and information the user may need to handle the quantized module.
@@ -112,7 +115,8 @@ if FOUND_TORCH:
                                             fw_impl=fw_impl,
                                             tpc=target_platform_capabilities,
                                             target_kpi=target_kpi,
-                                            tb_w=tb_w)
+                                            tb_w=tb_w,
+                                            model_leaf_layers=model_leaf_layers)
 
         tg = ptq_runner(tg, representative_data_gen, core_config, DEFAULT_PYTORCH_INFO, fw_impl, tb_w)
 

--- a/tests/pytorch_tests/model_tests/feature_models/custom_layer_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/custom_layer_test.py
@@ -1,0 +1,166 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import random
+
+import numpy as np
+import torch
+
+import model_compression_toolkit as mct
+from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_pytorch_tpc_latest
+from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
+
+"""
+This tests checks that custom layers are passing the quantization procedure.
+"""
+
+
+class ConvCustomLayer(torch.nn.Module):
+    """
+    Custom layer of Conv2D
+    """
+
+    def __init__(
+            self):
+        super().__init__()
+
+        self.conv1 = torch.nn.Conv2d(3, 3, kernel_size=1, stride=1)
+        self.conv2 = torch.nn.Conv2d(3, 3, kernel_size=1, stride=2)
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        if H == W:
+            x = self.conv1(x)
+        else:
+            x = self.conv2(2)
+        return x
+
+
+class ConvBNCustomLayer(torch.nn.Module):
+    """
+    Custom layer of Conv2D and BatchNorm
+    """
+
+    def __init__(
+            self):
+        super().__init__()
+
+        self.conv1 = torch.nn.Conv2d(3, 3, kernel_size=1, stride=1)
+        self.bn1 = torch.nn.BatchNorm2d(3)
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        x = self.conv1(x)
+        if H == W:
+            x = self.bn1(x)
+        return x
+
+
+class ConvCustomLayerNet(torch.nn.Module):
+    def __init__(self):
+        super(ConvCustomLayerNet, self).__init__()
+        self.custom1 = ConvCustomLayer()
+        self.bn1 = torch.nn.BatchNorm2d(3)
+
+    def forward(self, x):
+        x = self.custom1(x)
+        x = self.bn1(x)
+        x = torch.relu(x)
+        return x
+
+
+class ConvBNCustomLayerNet(torch.nn.Module):
+    def __init__(self):
+        super(ConvBNCustomLayerNet, self).__init__()
+        self.custom1 = ConvCustomLayer()
+        self.bn1 = torch.nn.BatchNorm2d(3)
+        self.custom2 = ConvBNCustomLayer()
+
+    def forward(self, x):
+        x = self.custom1(x)
+        x = self.bn1(x)
+        x = torch.relu(x)
+        x = self.custom2(x)
+        x = torch.relu(x)
+        return x
+
+
+class CustomLayerNetBaseTest(BasePytorchTest):
+    """
+    This base test checks that custom layers are passing the quantization procedure.
+    """
+
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def run_test(self, seed=0, experimental_facade=False, model_leafs=None):
+        np.random.seed(seed)
+        random.seed(a=seed)
+        torch.random.manual_seed(seed)
+        input_shapes = self.create_inputs_shape()
+        x = self.generate_inputs(input_shapes)
+
+        def representative_data_gen_experimental():
+            for _ in range(self.num_calibration_iter):
+                yield x
+
+        model_float = self.create_feature_network(input_shapes)
+        core_config = self.get_core_config()
+        tpc = get_pytorch_tpc_latest()
+        for model_leaf in model_leafs:
+            try:
+                ptq_model, quantization_info = mct.pytorch_post_training_quantization_experimental(
+                    in_module=model_float,
+                    representative_data_gen=representative_data_gen_experimental,
+                    target_kpi=self.get_kpi(),
+                    core_config=core_config,
+                    target_platform_capabilities=tpc,
+                    new_experimental_exporter=self.experimental_exporter,
+                    model_leaf_layers=model_leaf
+                )
+                self.compare(ptq_model, model_float, model_leaf=model_leaf)
+            except Exception as e:
+                # Should crash if the user didn't mention the Symbolic traced custom layers
+                error_msg = e.message if hasattr(e, 'message') else str(e)
+                self.unit_test.assertTrue(model_leaf is None, error_msg)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None, model_leaf=None):
+
+        # check that the custom layer in the quantized model's layers
+        for leaf_layer in model_leaf:
+            self.unit_test.assertTrue(leaf_layer in [layer.__class__ for layer in quantized_model.modules()])
+
+
+class ConvCustomLayerNetTest(CustomLayerNetBaseTest):
+    """
+    This tests checks that custom layer is passing the quantization procedure.
+    """
+
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def create_feature_network(self, input_shape):
+        return ConvCustomLayerNet()
+
+
+class ConvBNCustomLayerNetTest(CustomLayerNetBaseTest):
+    """
+    This tests checks that 2 custom layers are passing the quantization procedure.
+    """
+
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def create_feature_network(self, input_shape):
+        return ConvBNCustomLayerNet()

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -17,7 +17,7 @@ import unittest
 from tests.pytorch_tests.model_tests.feature_models.add_net_test import AddNetTest
 from tests.pytorch_tests.model_tests.feature_models.conv2d_replacement_test import DwConv2dReplacementTest
 from tests.pytorch_tests.model_tests.feature_models.custom_layer_test import ConvCustomLayerNetTest, \
-    ConvBNCustomLayerNetTest, ConvCustomLayer, ConvBNCustomLayer
+    ConvBNCustomLayerNetTest, ConvLayerNetTest, ConvCustomLayer, ConvBNCustomLayer
 from tests.pytorch_tests.model_tests.feature_models.mixed_precision_bops_test import MixedPrecisionBopsBasicTest, \
     MixedPrecisionBopsAllWeightsLayersTest, MixedPrecisionWeightsOnlyBopsTest, MixedPrecisionActivationOnlyBopsTest, \
     MixedPrecisionBopsAndWeightsKPITest, MixedPrecisionBopsAndActivationKPITest, MixedPrecisionBopsAndTotalKPITest, \
@@ -151,9 +151,30 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         This tests checks that custom layers are passing the quantization procedure.
         """
-        ConvCustomLayerNetTest(self).run_test(experimental_facade=True, model_leafs=[None, [ConvCustomLayer]])
+        # Tests with model without custom layers, using inputs variables to control flow, in the model
+        # Mentioning custom layers without having them in the model should not affect the quantization procedure
+        ConvLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=None)
+        ConvLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=[ConvCustomLayer])
+        ConvLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=[ConvBNCustomLayer])
+        ConvLayerNetTest(self).run_test(experimental_facade=True,
+                                        model_leaf_layers=[ConvCustomLayer, ConvBNCustomLayer])
+
+        # Tests with model with one custom layer, using inputs variables to control flow, in the model
+        # Not mentioning the custom layer in the model should crash the quantization procedure
+        # Mentioning custom layers without having them in the model should not affect the quantization procedure
+        ConvCustomLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=None)
+        ConvCustomLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=[ConvCustomLayer])
+        ConvCustomLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=[ConvBNCustomLayer])
+        ConvCustomLayerNetTest(self).run_test(experimental_facade=True,
+                                              model_leaf_layers=[ConvCustomLayer, ConvBNCustomLayer])
+
+        # Tests with model with some custom layers, using inputs variables to control flow, in the model
+        # Not mentioning all the custom layers in the model should crash the quantization procedure
+        ConvBNCustomLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=None)
+        ConvBNCustomLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=[ConvCustomLayer])
+        ConvBNCustomLayerNetTest(self).run_test(experimental_facade=True, model_leaf_layers=[ConvBNCustomLayer])
         ConvBNCustomLayerNetTest(self).run_test(experimental_facade=True,
-                                                model_leafs=[None, [ConvCustomLayer, ConvBNCustomLayer]])
+                                                model_leaf_layers=[ConvCustomLayer, ConvBNCustomLayer])
 
     def test_linear_collapsing(self):
         """

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -16,6 +16,8 @@ import unittest
 
 from tests.pytorch_tests.model_tests.feature_models.add_net_test import AddNetTest
 from tests.pytorch_tests.model_tests.feature_models.conv2d_replacement_test import DwConv2dReplacementTest
+from tests.pytorch_tests.model_tests.feature_models.custom_layer_test import ConvCustomLayerNetTest, \
+    ConvBNCustomLayerNetTest, ConvCustomLayer, ConvBNCustomLayer
 from tests.pytorch_tests.model_tests.feature_models.mixed_precision_bops_test import MixedPrecisionBopsBasicTest, \
     MixedPrecisionBopsAllWeightsLayersTest, MixedPrecisionWeightsOnlyBopsTest, MixedPrecisionActivationOnlyBopsTest, \
     MixedPrecisionBopsAndWeightsKPITest, MixedPrecisionBopsAndActivationKPITest, MixedPrecisionBopsAndTotalKPITest, \
@@ -144,6 +146,14 @@ class FeatureModelsTestRunner(unittest.TestCase):
         removed from the graph during quantization.
         """
         BrokenNetTest(self).run_test()
+
+    def test_custom_layer_net(self):
+        """
+        This tests checks that custom layers are passing the quantization procedure.
+        """
+        ConvCustomLayerNetTest(self).run_test(experimental_facade=True, model_leafs=[None, [ConvCustomLayer]])
+        ConvBNCustomLayerNetTest(self).run_test(experimental_facade=True,
+                                                model_leafs=[None, [ConvCustomLayer, ConvBNCustomLayer]])
 
     def test_linear_collapsing(self):
         """


### PR DESCRIPTION
The user provides list of the model's symbolic traced custom layers these layers shouldn't be divided into their submodules and their quantization will not be optimized.
If the user doesn't provide the list of the symbolic traced custom layers of the model, the quantization procedure will crash.
If where are no symbolic traced custom layers in the model, the quantization procedure will continue normally.