### PR TITLE
Fix issue of MP weights target KPI when layers are reused

### DIFF
--- a/model_compression_toolkit/core/common/graph/base_graph.py
+++ b/model_compression_toolkit/core/common/graph/base_graph.py
@@ -553,8 +553,7 @@ class Graph(nx.MultiDiGraph, GraphSearches):
         """
         return self._sort_nodes_in_list(self.get_weights_configurable_nodes(include_reused_nodes))
 
-    def get_activation_configurable_nodes(self,
-                                          include_reused_nodes: bool = False) -> List[BaseNode]:
+    def get_activation_configurable_nodes(self) -> List[BaseNode]:
         """
         Get a list of nodes that their activation can be configured (namely, has one or
         more activation qc candidate and their activation should be quantized).
@@ -563,8 +562,7 @@ class Graph(nx.MultiDiGraph, GraphSearches):
             A list of nodes that their activation can be configured (namely, has one or more activation qc candidate).
         """
         return list(filter(lambda n: n.is_activation_quantization_enabled()
-                                     and not n.is_all_activation_candidates_equal()
-                                     and (not n.reuse or include_reused_nodes), list(self)))
+                                     and not n.is_all_activation_candidates_equal(), list(self)))
 
     def get_sorted_activation_configurable_nodes(self) -> List[BaseNode]:
         """


### PR DESCRIPTION
When layers are reused, we should not consider them as part of the KPI weights target. This commit fixes this by adding a reuse check to the non configurable condition.