### PR TITLE
Change exporter API

### DIFF
--- a/model_compression_toolkit/exporter/__init__.py
+++ b/model_compression_toolkit/exporter/__init__.py
@@ -12,11 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-from model_compression_toolkit.core.common.constants import FOUND_TF
-
-if FOUND_TF:
-    from model_compression_toolkit.exporter.model_wrapper.keras.builder.fully_quantized_model_builder import \
-        get_exportable_keras_model
-    from model_compression_toolkit.exporter.model_exporter.keras.keras_export_facade import keras_export_model
-

--- a/model_compression_toolkit/exporter/model_exporter/__init__.py
+++ b/model_compression_toolkit/exporter/model_exporter/__init__.py
@@ -12,3 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
+from model_compression_toolkit.core.common.constants import FOUND_TF
+
+if FOUND_TF:
+    from model_compression_toolkit.exporter.model_exporter.keras.keras_export_facade import \
+        keras_export_model, KerasExportMode

--- a/model_compression_toolkit/exporter/model_exporter/keras/__init__.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/__init__.py
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.exporter.model_exporter.keras.keras_export_facade import \
-    keras_export_model, KerasExportMode
 
 

--- a/model_compression_toolkit/exporter/model_wrapper/__init__.py
+++ b/model_compression_toolkit/exporter/model_wrapper/__init__.py
@@ -17,3 +17,4 @@ from model_compression_toolkit.core.common.constants import FOUND_TF
 
 if FOUND_TF:
     from model_compression_toolkit.exporter.model_wrapper.keras.validate_layer import is_keras_layer_exportable
+    from model_compression_toolkit.exporter.model_wrapper.keras.builder.fully_quantized_model_builder import get_exportable_keras_model

--- a/model_compression_toolkit/gptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/gptq/keras/quantization_facade.py
@@ -46,7 +46,7 @@ if common.constants.FOUND_TF:
     from tensorflow.keras.models import Model
     from model_compression_toolkit.gptq.keras.gptq_loss import GPTQMultipleTensorsLoss
     from model_compression_toolkit.core.keras.constants import DEFAULT_TP_MODEL
-    from model_compression_toolkit.exporter import get_exportable_keras_model
+    from model_compression_toolkit.exporter.model_wrapper import get_exportable_keras_model
     from model_compression_toolkit import get_target_platform_capabilities
 
     # As from TF2.9 optimizers package is changed

--- a/model_compression_toolkit/ptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/ptq/keras/quantization_facade.py
@@ -34,7 +34,7 @@ if FOUND_TF:
     from model_compression_toolkit.core.keras.keras_model_validation import KerasModelValidation
     from tensorflow.keras.models import Model
     from model_compression_toolkit.core.keras.constants import DEFAULT_TP_MODEL
-    from model_compression_toolkit.exporter import get_exportable_keras_model
+    from model_compression_toolkit.exporter.model_wrapper import get_exportable_keras_model
 
     from model_compression_toolkit import get_target_platform_capabilities
     DEFAULT_KERAS_TPC = get_target_platform_capabilities(TENSORFLOW, DEFAULT_TP_MODEL)

--- a/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
+++ b/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
@@ -22,8 +22,7 @@ from keras import Input
 from keras.layers import Conv2D, BatchNormalization, ReLU, Dropout, Dense
 
 import model_compression_toolkit as mct
-from model_compression_toolkit.exporter.model_exporter.keras import keras_export_model, \
-    KerasExportMode
+from model_compression_toolkit.exporter.model_exporter import keras_export_model, KerasExportMode
 from model_compression_toolkit.exporter.model_wrapper import is_keras_layer_exportable
 
 SAVED_MODEL_PATH = '/tmp/exported_tf_fakelyquant.h5'


### PR DESCRIPTION
Set new API to exporter package:
for model_wrapper - two functions are used: get_exportable_keras_model and is_keras_layer_exportable. for model_exporter - the function keras_export_model and mode KerasExportMode are used.