### PR TITLE
Fix Pytorch mixed precision with multiple inputs

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -489,3 +489,20 @@ class FrameworkImplementation(ABC):
         """
         raise NotImplemented(f'{self.__class__.__name__} have to implement the '
                              f'framework\'s apply_second_moment_correction method.')
+
+    @abstractmethod
+    def sensitivity_eval_inference(self,
+                                   model: Any,
+                                   inputs: Any):
+        """
+        Calls for a model inference for a specific framework during mixed precision sensitivity evaluation.
+
+        Args:
+            model: A model to run inference for.
+            inputs: Input tensors to run inference on.
+
+        Returns:
+            The output of the model inference on the given input.
+        """
+        raise NotImplemented(f'{self.__class__.__name__} have to implement the '
+                             f'framework\'s sensitivity_eval_inference method.')

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -157,7 +157,8 @@ class SensitivityEvaluation:
         Evaluates the baseline model on all images and saves the obtained lists of tensors in a list for later use.
         Initiates a class variable self.baseline_tensors_list
         """
-        self.baseline_tensors_list = [self.fw_impl.to_numpy(self.baseline_model(images))
+        self.baseline_tensors_list = [self.fw_impl.to_numpy(self.fw_impl.sensitivity_eval_inference(self.baseline_model,
+                                                                                                    images))
                                       for images in self.images_batches]
 
     def _build_models(self) -> Any:
@@ -295,7 +296,7 @@ class SensitivityEvaluation:
         # Compute the distance matrix for num_of_images images.
         for images, baseline_tensors in zip(self.images_batches, self.baseline_tensors_list):
             # when using model.predict(), it does not use the QuantizeWrapper functionality
-            mp_tensors = self.model_mp(images)
+            mp_tensors = self.fw_impl.sensitivity_eval_inference(self.model_mp, images)
             mp_tensors = self.fw_impl.to_numpy(mp_tensors)
 
             # Build distance matrix: similarity between the baseline model to the float model

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -595,3 +595,19 @@ class KerasImplementation(FrameworkImplementation):
         graph_after_second_moment_correction = keras_apply_second_moment_correction(quantized_model, core_config,
                                                                                     representative_data_gen, graph)
         return graph_after_second_moment_correction
+
+    def sensitivity_eval_inference(self,
+                                   model: Model,
+                                   inputs: Any):
+        """
+        Calls for a Keras model inference for a specific framework during mixed precision sensitivity evaluation.
+
+        Args:
+            model: A Keras model to run inference for.
+            inputs: Input tensors to run inference on.
+
+        Returns:
+            The output of the model inference on the given input.
+        """
+
+        return model(inputs)

--- a/model_compression_toolkit/core/pytorch/back2framework/mixed_precision_model_builder.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/mixed_precision_model_builder.py
@@ -74,8 +74,6 @@ class MixedPrecisionPyTorchModel(PytorchModel):
         """
         if node.is_all_activation_candidates_equal():
             # otherwise, we want to use the float tensor when building the model for MP search
-            if isinstance(input_tensors, list):
-                input_tensors = torch.cat(input_tensors, dim=0)
             input_tensors = node.candidates_quantization_cfg[0].activation_quantization_cfg.quantize_node_output(input_tensors)
         return input_tensors
 

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -543,3 +543,20 @@ class PytorchImplementation(FrameworkImplementation):
         graph_after_second_moment_correction = pytorch_apply_second_moment_correction(quantized_model, core_config,
                                                                                       representative_data_gen, graph)
         return graph_after_second_moment_correction
+
+    def sensitivity_eval_inference(self,
+                                   model: Module,
+                                   inputs: Any):
+        """
+        Calls for a Pytorch model inference for a specific framework during mixed precision sensitivity evaluation.
+        In Pytorch, we need to unfold the list of inputs before passing it to the model.
+
+        Args:
+            model: A Pytorch model to run inference for.
+            inputs: Input tensors to run inference on.
+
+        Returns:
+            The output of the model inference on the given input.
+        """
+
+        return model(*inputs)

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -15,7 +15,8 @@
 import torch
 import numpy as np
 
-from model_compression_toolkit import MixedPrecisionQuantizationConfig, KPI
+from model_compression_toolkit import MixedPrecisionQuantizationConfig, KPI, CoreConfig, \
+    MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.core.common.user_info import UserInformation
 from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_op_quantization_configs
 from tests.common_tests.helpers.activation_mp_tp_model import generate_tp_model_with_activation_mp
@@ -66,7 +67,6 @@ class MixedPercisionActivationBaseTest(BasePytorchTest):
         raise NotImplementedError
 
     def verify_config(self, result_config, expected_config):
-        # TODO: Add aditional test that maybe check the actual bitwidth (when refactoring MP tests)
         self.unit_test.assertTrue(all(result_config == expected_config))
 
 
@@ -79,7 +79,7 @@ class MixedPercisionActivationSearch8Bit(MixedPercisionActivationBaseTest):
         return KPI(np.inf, np.inf)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
-        self.verify_config(quantization_info.mixed_precision_cfg , self.expected_config)
+        self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
 class MixedPercisionActivationSearch2Bit(MixedPercisionActivationBaseTest):
@@ -91,7 +91,7 @@ class MixedPercisionActivationSearch2Bit(MixedPercisionActivationBaseTest):
         return KPI(96, 768)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
-        self.verify_config(quantization_info.mixed_precision_cfg , self.expected_config)
+        self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
 class MixedPercisionActivationSearch4Bit(MixedPercisionActivationBaseTest):
@@ -103,7 +103,7 @@ class MixedPercisionActivationSearch4Bit(MixedPercisionActivationBaseTest):
         return KPI(192, 1536)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
-        self.verify_config(quantization_info.mixed_precision_cfg , self.expected_config)
+        self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
 class MixedPercisionActivationSearch4BitFunctional(MixedPercisionActivationBaseTest):
@@ -118,16 +118,42 @@ class MixedPercisionActivationSearch4BitFunctional(MixedPercisionActivationBaseT
         return MixedPrecisionFunctionalNet(input_shape)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
-        self.verify_config(quantization_info.mixed_precision_cfg , self.expected_config)
+        self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
+
+
+class MixedPercisionActivationMultipleInputs(MixedPercisionActivationBaseTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.expected_config = [0 for _ in range(8)]
+        self.num_calibration_iter = 3
+        self.val_batch_size = 2
+
+    def get_kpi(self):
+        return KPI(np.inf, np.inf)
+
+    def get_core_config(self):
+        return CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2(num_of_images=4))
+
+    def create_feature_network(self, input_shape):
+        return MixedPrecisionMultipleInputsNet(input_shape)
+
+    def create_inputs_shape(self):
+        return [[self.val_batch_size, 1, 8, 8],
+                [self.val_batch_size, 1, 8, 8],
+                [self.val_batch_size, 1, 8, 8],
+                [self.val_batch_size, 1, 8, 8]]
+
+    def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
+        self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
 class MixedPrecisionNet(torch.nn.Module):
     def __init__(self, input_shape):
         super(MixedPrecisionNet, self).__init__()
         _, in_channels, _, _ = input_shape[0]
-        self.conv1 = torch.nn.Conv2d(in_channels, 3, kernel_size=3)
+        self.conv1 = torch.nn.Conv2d(in_channels, 3, kernel_size=(3, 3))
         self.bn1 = torch.nn.BatchNorm2d(3)
-        self.conv2 = torch.nn.Conv2d(3, 4, kernel_size=5)
+        self.conv2 = torch.nn.Conv2d(3, 4, kernel_size=(5, 5))
         self.relu = torch.nn.ReLU()
 
     def forward(self, inp):
@@ -142,11 +168,27 @@ class MixedPrecisionFunctionalNet(torch.nn.Module):
     def __init__(self, input_shape):
         super(MixedPrecisionFunctionalNet, self).__init__()
         _, in_channels, _, _ = input_shape[0]
-        self.conv1 = torch.nn.Conv2d(in_channels, 3, kernel_size=3)
-        self.conv2 = torch.nn.Conv2d(in_channels, 3, kernel_size=3)
+        self.conv1 = torch.nn.Conv2d(in_channels, 3, kernel_size=(3, 3))
+        self.conv2 = torch.nn.Conv2d(in_channels, 3, kernel_size=(3, 3))
 
     def forward(self, inp):
         x1 = self.conv1(inp)
         x2 = self.conv2(inp)
         output = x1 + x2
         return output
+
+
+class MixedPrecisionMultipleInputsNet(torch.nn.Module):
+    def __init__(self, input_shape):
+        super(MixedPrecisionMultipleInputsNet, self).__init__()
+        self.conv1 = torch.nn.Conv2d(1, 3, kernel_size=(3, 3))
+        self.conv2 = torch.nn.Conv2d(1, 3, kernel_size=(3, 3))
+        self.conv3 = torch.nn.Conv2d(1, 3, kernel_size=(3, 3))
+        self.conv4 = torch.nn.Conv2d(1, 3, kernel_size=(3, 3))
+
+    def forward(self, x, y, z, w):
+        x1 = self.conv1(x)
+        x2 = self.conv1(y)
+        x3 = self.conv1(z)
+        x4 = self.conv1(w)
+        return torch.concat([x1, x2, x3, x4])

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -188,7 +188,7 @@ class MixedPrecisionMultipleInputsNet(torch.nn.Module):
 
     def forward(self, x, y, z, w):
         x1 = self.conv1(x)
-        x2 = self.conv1(y)
-        x3 = self.conv1(z)
-        x4 = self.conv1(w)
-        return torch.concat([x1, x2, x3, x4])
+        x2 = self.conv2(y)
+        x3 = self.conv3(z)
+        x4 = self.conv4(w)
+        return torch.concat([x1, x2, x3, x4], dim=1)

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -32,7 +32,7 @@ from tests.pytorch_tests.model_tests.feature_models.residual_collapsing_test imp
 from tests.pytorch_tests.model_tests.feature_models.dynamic_size_inputs_test import ReshapeNetTest
 from tests.pytorch_tests.model_tests.feature_models.mixed_precision_activation_test import \
     MixedPercisionActivationSearch8Bit, MixedPercisionActivationSearch2Bit, MixedPercisionActivationSearch4Bit, \
-    MixedPercisionActivationSearch4BitFunctional
+    MixedPercisionActivationSearch4BitFunctional, MixedPercisionActivationMultipleInputs
 from tests.pytorch_tests.model_tests.feature_models.relu_bound_test import ReLUBoundToPOTNetTest, \
     HardtanhBoundToPOTNetTest
 from tests.pytorch_tests.model_tests.feature_models.second_moment_correction_test import ConvSecondMomentNetTest, \
@@ -383,6 +383,12 @@ class FeatureModelsTestRunner(unittest.TestCase):
         This test checks the activation Mixed Precision search with functional node.
         """
         MixedPercisionActivationSearch4BitFunctional(self).run_test()
+
+    def test_mixed_precision_multiple_inputs(self):
+        """
+        This test checks the activation Mixed Precision search with multiple inputs to model.
+        """
+        MixedPercisionActivationMultipleInputs(self).run_test(experimental_facade=True)
 
     def test_mixed_precision_bops_kpi(self):
         """


### PR DESCRIPTION
* Added framework-dependent inference method for mixed precision sensitivity evaluation.
* Added a test for Pytorch mixed precision with multiple inputs and concat layer.
* Small syntax refactor in Pytorch mixed precision tests.