### PR TITLE
Add TFLite fake quant exporter

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -155,4 +155,5 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
         """
         if self.exported_model is None:
             Logger.critical(f'Exporter can not save model as it is not exported')
+        Logger.info(f'Exporting FQ Keras model to: {save_model_path}')
         keras.models.save_model(self.exported_model, save_model_path)

--- a/model_compression_toolkit/exporter/model_exporter/tflite/__init__.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/__init__.py
@@ -12,11 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-from model_compression_toolkit.core.common.constants import FOUND_TF
-
-if FOUND_TF:
-    from model_compression_toolkit.exporter.model_exporter.keras.keras_export_facade import \
-        keras_export_model, KerasExportMode
-    from model_compression_toolkit.exporter.model_exporter.tflite.tflite_export_facade import tflite_export_model, \
-        TFLiteExportMode

--- a/model_compression_toolkit/exporter/model_exporter/tflite/fakely_quant_tflite_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/fakely_quant_tflite_exporter.py
@@ -38,13 +38,13 @@ class FakelyQuantTFLiteExporter(FakelyQuantKerasExporter):
                          is_layer_exportable_fn)
         self.exported_model = None
 
-    def export(self) -> keras.models.Model:
+    def export(self) -> bytes:
         """
-        Convert an exportable (fully-quantized) Keras model to a fakely-quant model
+        Convert an exportable (fully-quantized) Keras model to a fakely-quant TFLite model
         (namely, weights that are in fake-quant format) and fake-quant layers for the activations.
 
         Returns:
-            Fake-quant Keras model.
+            Fake-quant TFLite model.
         """
         model = super(FakelyQuantTFLiteExporter, self).export()
         self.exported_model = tf.lite.TFLiteConverter.from_keras_model(model).convert()

--- a/model_compression_toolkit/exporter/model_exporter/tflite/fakely_quant_tflite_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/fakely_quant_tflite_exporter.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Callable
+
+import keras.models
+import tensorflow as tf
+
+from model_compression_toolkit.core.common import Logger
+from model_compression_toolkit.exporter.model_exporter.keras.base_keras_exporter import BaseKerasExporter
+from model_compression_toolkit.exporter.model_exporter.keras.fakely_quant_keras_exporter import FakelyQuantKerasExporter
+
+
+class FakelyQuantTFLiteExporter(FakelyQuantKerasExporter):
+    """
+    Exporter for fakely-quant TFLite models.
+    The exporter expects to receive an exportable model (where each layer's full quantization parameters
+    can be retrieved), and convert it into a fakely-quant model (namely, weights that are in fake-quant
+    format) and fake-quant layers for the activations.
+    """
+
+    def __init__(self,
+                 model: keras.models.Model,
+                 is_layer_exportable_fn: Callable):
+
+        super().__init__(model,
+                         is_layer_exportable_fn)
+        self.exported_model = None
+
+    def export(self) -> keras.models.Model:
+        """
+        Convert an exportable (fully-quantized) Keras model to a fakely-quant model
+        (namely, weights that are in fake-quant format) and fake-quant layers for the activations.
+
+        Returns:
+            Fake-quant Keras model.
+        """
+        model = super(FakelyQuantTFLiteExporter, self).export()
+        self.exported_model = tf.lite.TFLiteConverter.from_keras_model(model).convert()
+        return self.exported_model
+
+    def save_model(self, save_model_path: str) -> None:
+        """
+        Save exported model to a given path.
+        Args:
+            save_model_path: Path to save the model.
+
+        Returns:
+            None.
+        """
+        if self.exported_model is None:
+            Logger.critical(f'Exporter can not save model as it is not exported')
+        Logger.info(f'Exporting FQ tflite model to: {save_model_path}')
+        with open(save_model_path, 'wb') as f:
+            f.write(self.exported_model)

--- a/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
@@ -29,7 +29,7 @@ class TFLiteExportMode(Enum):
 def tflite_export_model(model: keras.models.Model,
                        is_layer_exportable_fn: Callable,
                        mode: TFLiteExportMode = TFLiteExportMode.FAKELY_QUANT,
-                       save_model_path: str = None):
+                       save_model_path: str = None) -> bytes:
     """
     Prepare and return fully quantized model for export. Save exported model to
     a path if passed.
@@ -52,8 +52,8 @@ def tflite_export_model(model: keras.models.Model,
             f'Unsupported mode was used {mode.name} to export TFLite model.'
             f' Please see API for supported modes.')
 
-    model = exporter.export()
+    exported_model = exporter.export()
     if save_model_path is not None:
         exporter.save_model(save_model_path)
 
-    return model, exporter.get_custom_objects()
+    return exported_model

--- a/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
@@ -1,0 +1,59 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from enum import Enum
+from typing import Callable
+
+from model_compression_toolkit.core.common import Logger
+import keras
+
+from model_compression_toolkit.exporter.model_exporter.tflite.fakely_quant_tflite_exporter import \
+    FakelyQuantTFLiteExporter
+
+
+class TFLiteExportMode(Enum):
+    FAKELY_QUANT = 0
+
+
+def tflite_export_model(model: keras.models.Model,
+                       is_layer_exportable_fn: Callable,
+                       mode: TFLiteExportMode = TFLiteExportMode.FAKELY_QUANT,
+                       save_model_path: str = None):
+    """
+    Prepare and return fully quantized model for export. Save exported model to
+    a path if passed.
+
+    Args:
+        model: Model to export.
+        is_layer_exportable_fn: Callable to check whether a layer can be exported or not.
+        mode: Mode to export the model according to.
+        save_model_path: Path to save the model.
+
+    Returns:
+        Exported model.
+    """
+
+    if mode == TFLiteExportMode.FAKELY_QUANT:
+        exporter = FakelyQuantTFLiteExporter(model, is_layer_exportable_fn)
+
+    else:
+        Logger.critical(
+            f'Unsupported mode was used {mode.name} to export TFLite model.'
+            f' Please see API for supported modes.')
+
+    model = exporter.export()
+    if save_model_path is not None:
+        exporter.save_model(save_model_path)
+
+    return model, exporter.get_custom_objects()

--- a/model_compression_toolkit/exporter/model_wrapper/keras/validate_layer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/keras/validate_layer.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 from typing import Any
 
+from keras.engine.input_layer import InputLayer
+from tensorflow_model_optimization.python.core.quantization.keras.quantize_wrapper import QuantizeWrapperV2
+
 from model_compression_toolkit.core.common import Logger
 from model_compression_toolkit.exporter.model_wrapper.keras.builder.quantize_config_to_node import \
     SUPPORTED_QUANTIZATION_CONFIG
@@ -30,6 +33,10 @@ def is_keras_layer_exportable(layer: Any) -> bool:
     Returns:
         Check whether a Keras layer is a valid exportable layer or not.
     """
+    # Keras Input layers are not wrapped
+    if isinstance(layer, InputLayer):
+        return True
+
     valid_layer = isinstance(layer, ExtendedQuantizeWrapper)
     if not valid_layer:
         Logger.error(f'Exportable layer must be wrapped using ExtendedQuantizeWrapper, but layer {layer.name} is of type {type(layer)}')

--- a/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
+++ b/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
@@ -63,10 +63,10 @@ class TestKerasFakeQuantExporter(unittest.TestCase):
                                                                             mode=KerasExportMode.FAKELY_QUANT,
                                                                             save_model_path=SAVED_MODEL_PATH_TF)
         self.tf_exported_model.trainable = False
-        self.tflite_exported_model, self.tflite_custom_objects = tflite_export_model(model=self.exportable_model,
-                                                                                     is_layer_exportable_fn=is_keras_layer_exportable,
-                                                                                     mode=TFLiteExportMode.FAKELY_QUANT,
-                                                                                     save_model_path=SAVED_MODEL_PATH_TFLITE)
+        self.tflite_exported_model = tflite_export_model(model=self.exportable_model,
+                                                         is_layer_exportable_fn=is_keras_layer_exportable,
+                                                         mode=TFLiteExportMode.FAKELY_QUANT,
+                                                         save_model_path=SAVED_MODEL_PATH_TFLITE)
 
     def run_mct(self, model, new_experimental_exporter):
         core_config = mct.CoreConfig()


### PR DESCRIPTION
Add TFLite exporter for fake-quant models.
The exporter uses the TF exporter first to convert the weights to FQ, and then convert it to TFLite using TFLite converter.
