### PR TITLE
Additions to Gumbel Rounding

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -201,6 +201,7 @@ class SensitivityEvaluation:
         for images in self.images_batches:
             batch_ip_gradients = []
             for i in range(1, images[0].shape[0] + 1):
+                Logger.info(f"Computing Jacobian-based weights approximation for image sample {i} out of {images.shape[0]}...")
                 image_ip_gradients = self.fw_impl.model_grad(self.graph,
                                                              {inode: images[0][i - 1:i] for inode in
                                                               self.graph.get_inputs()},

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -201,7 +201,7 @@ class SensitivityEvaluation:
         for images in self.images_batches:
             batch_ip_gradients = []
             for i in range(1, images[0].shape[0] + 1):
-                Logger.info(f"Computing Jacobian-based weights approximation for image sample {i} out of {images.shape[0]}...")
+                Logger.info(f"Computing Jacobian-based weights approximation for image sample {i} out of {images[0].shape[0]}...")
                 image_ip_gradients = self.fw_impl.model_grad(self.graph,
                                                              {inode: images[0][i - 1:i] for inode in
                                                               self.graph.get_inputs()},

--- a/model_compression_toolkit/core/keras/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/keras/back2framework/model_gradients.py
@@ -17,6 +17,8 @@ import tensorflow as tf
 from packaging import version
 
 # As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
+from tqdm import tqdm
+
 if version.parse(tf.__version__) < version.parse("2.6"):
     from tensorflow.python.keras.layers import Layer
 else:
@@ -139,7 +141,7 @@ def keras_iterative_approx_jacobian_trace(graph_float: common.Graph,
             output = tf.reshape(output, shape=[output.shape[0], -1])
 
             ipts_jac_trace_approx = []
-            for ipt in interest_points_tensors:  # Per Interest point activation tensor
+            for ipt in tqdm(interest_points_tensors):  # Per Interest point activation tensor
                 trace_jv = []
                 for j in range(n_iter):  # Approximation iterations
                     # Getting a random vector with normal distribution

--- a/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/model_gradients.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List
 import torch
 import torch.autograd as autograd
 from networkx import topological_sort
+from tqdm import tqdm
 
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common import BaseNode, Graph
@@ -237,7 +238,7 @@ def pytorch_iterative_approx_jacobian_trace(graph_float: common.Graph,
         output = torch.reshape(output, shape=[output.shape[0], -1])
 
         ipts_jac_trace_approx = []
-        for ipt in model_grads_net.interest_points_tensors:  # Per Interest point activation tensor
+        for ipt in tqdm(model_grads_net.interest_points_tensors):  # Per Interest point activation tensor
             trace_jv = []
             for j in range(n_iter):  # Approximation iterations
                 # Getting a random vector with normal distribution

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -92,7 +92,7 @@ class GradientPTQConfig:
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
                  gumbel_scale: float = GUMBEL_SCALE,
-                 log_norm: bool = False,
+                 log_norm: bool = True,
                  weights_n_iter: int = 50):
         """
         Initialize a GradientPTQConfig.
@@ -180,7 +180,9 @@ class GradientPTQConfigV2(GradientPTQConfig):
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
-                 gumbel_scale: float = GUMBEL_SCALE):
+                 gumbel_scale: float = GUMBEL_SCALE,
+                 log_norm: bool = True,
+                 weights_n_iter: int = 50):
         """
         Initialize a GradientPTQConfigV2.
 
@@ -206,6 +208,8 @@ class GradientPTQConfigV2(GradientPTQConfig):
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
             gumbel_scale (float): A normalization factor for the gumbel tensor values.
+            log_norm (bool): Whether to use log normalization to the GPTQ Jacobian-based weights.
+            weights_n_iter (int): Number of random iterations to run Jacobian approximation for GPTQ weights.
 
         """
 
@@ -227,7 +231,9 @@ class GradientPTQConfigV2(GradientPTQConfig):
                          quantizer_config=quantizer_config,
                          optimizer_quantization_parameter=optimizer_quantization_parameter,
                          optimizer_bias=optimizer_bias,
-                         gumbel_scale=gumbel_scale)
+                         gumbel_scale=gumbel_scale,
+                         log_norm=log_norm,
+                         weights_n_iter=weights_n_iter)
         self.n_epochs = n_epochs
 
     @classmethod

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 from enum import Enum
-from typing import Callable, Any
+from typing import Callable, Any, Dict
 from model_compression_toolkit.core.common.defaultdict import DefaultDict
 from model_compression_toolkit.core import common
 
@@ -91,7 +91,9 @@ class GradientPTQConfig:
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
-                 gumbel_scale: float = GUMBEL_SCALE):
+                 gumbel_scale: float = GUMBEL_SCALE,
+                 log_norm: bool = False,
+                 weights_n_iter: int = 50):
         """
         Initialize a GradientPTQConfig.
 
@@ -117,6 +119,8 @@ class GradientPTQConfig:
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
             gumbel_scale (float): A normalization factor for the gumbel tensor values.
+            log_norm (bool): Whether to use log normalization to the GPTQ Jacobian-based weights.
+            weights_n_iter (int): Number of random iterations to run Jacobian approximation for GPTQ weights.
 
         """
         self.n_iter = n_iter
@@ -140,6 +144,8 @@ class GradientPTQConfig:
         self.optimizer_quantization_parameter = optimizer_quantization_parameter
         self.optimizer_bias = optimizer_bias
         self.gumbel_scale = gumbel_scale
+        self.log_norm = log_norm
+        self.weights_n_iter = weights_n_iter
 
     @property
     def is_gumbel(self) -> bool:

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -48,7 +48,9 @@ class GumbelConfig(object):
                  n_cycles: int = N_CYCLES,
                  minimal_temp: float = MIM_TEMP,
                  maximal_temp: float = MAX_TEMP,
-                 gumbel_entropy_regularization: float = GAMMA_TEMPERATURE):
+                 gumbel_entropy_regularization: float = GAMMA_TEMPERATURE,
+                 gumbel_scale: float = GUMBEL_SCALE,
+                 gumbel_scale_per_bitwidth: Dict[int, float] = None):
         """
         Initialize a GumbelConfig.
 
@@ -59,12 +61,16 @@ class GumbelConfig(object):
             n_cycles (int): A floating point number that defines the gumbel entropy regularization factor.
             minimal_temp (float): A floating point number that defines the gumbel entropy regularization factor.
             maximal_temp (float): A floating point number that defines the gumbel entropy regularization factor.
+            gumbel_scale (float): A normalization factor for the gumbel tensor values.
+            gumbel_scale_per_bitwidth (dict): An optional mapping between a bit-width and a gumbel scale value for Gumbel Rounding,
         """
         self.gumbel_entropy_regularization = gumbel_entropy_regularization
         self.temperature_learning = temperature_learning
         self.n_cycles = n_cycles
         self.minimal_temp = minimal_temp
         self.maximal_temp = maximal_temp
+        self.gumbel_scale = gumbel_scale
+        self.gumbel_scale_per_bitwidth = gumbel_scale_per_bitwidth
 
 
 class GradientPTQConfig:
@@ -91,7 +97,6 @@ class GradientPTQConfig:
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
-                 gumbel_scale: float = GUMBEL_SCALE,
                  log_norm: bool = True,
                  weights_n_iter: int = 50):
         """
@@ -118,7 +123,6 @@ class GradientPTQConfig:
             quantizer_config (Any): A class the contins the quantizer specific config.
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
-            gumbel_scale (float): A normalization factor for the gumbel tensor values.
             log_norm (bool): Whether to use log normalization to the GPTQ Jacobian-based weights.
             weights_n_iter (int): Number of random iterations to run Jacobian approximation for GPTQ weights.
 
@@ -143,7 +147,6 @@ class GradientPTQConfig:
         self.quantizer_config = quantizer_config
         self.optimizer_quantization_parameter = optimizer_quantization_parameter
         self.optimizer_bias = optimizer_bias
-        self.gumbel_scale = gumbel_scale
         self.log_norm = log_norm
         self.weights_n_iter = weights_n_iter
 
@@ -180,7 +183,6 @@ class GradientPTQConfigV2(GradientPTQConfig):
                  quantizer_config: GumbelConfig = GumbelConfig(),
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
-                 gumbel_scale: float = GUMBEL_SCALE,
                  log_norm: bool = True,
                  weights_n_iter: int = 50):
         """
@@ -207,7 +209,6 @@ class GradientPTQConfigV2(GradientPTQConfig):
             quantizer_config (Any): A class the contins the quantizer specific config.
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
-            gumbel_scale (float): A normalization factor for the gumbel tensor values.
             log_norm (bool): Whether to use log normalization to the GPTQ Jacobian-based weights.
             weights_n_iter (int): Number of random iterations to run Jacobian approximation for GPTQ weights.
 
@@ -231,7 +232,6 @@ class GradientPTQConfigV2(GradientPTQConfig):
                          quantizer_config=quantizer_config,
                          optimizer_quantization_parameter=optimizer_quantization_parameter,
                          optimizer_bias=optimizer_bias,
-                         gumbel_scale=gumbel_scale,
                          log_norm=log_norm,
                          weights_n_iter=weights_n_iter)
         self.n_epochs = n_epochs

--- a/model_compression_toolkit/gptq/common/gptq_training.py
+++ b/model_compression_toolkit/gptq/common/gptq_training.py
@@ -130,6 +130,7 @@ class GPTQTrainer(ABC):
 
             points_apprx_jacobians_weights = []
             for i in range(1, images.shape[0] + 1):
+                Logger.info(f"Computing Jacobian-based weights approximation for image sample {i} out of {images.shape[0]}...")
                 # Note that in GPTQ loss weights computation we assume that there aren't replacement output nodes,
                 # therefore, output_list is just the graph outputs, and we don't need the tuning factor for
                 # defining the output weights (since the output layer is not a compare point).

--- a/model_compression_toolkit/gptq/keras/gptq_training.py
+++ b/model_compression_toolkit/gptq/keras/gptq_training.py
@@ -234,7 +234,7 @@ class KerasGPTQTrainer(GPTQTrainer):
 
         """
         for _ in tqdm(range(n_epochs)):
-            for data in data_function():
+            for data in tqdm(data_function()):
                 input_data = [d * self.input_scale for d in data]
 
                 loss_value_step, grads = self.nano_training_step(input_data, in_compute_gradients, in_optimizer_with_param, is_training)

--- a/model_compression_toolkit/gptq/keras/quantizer/configs/weight_quantizer_gptq_config.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/configs/weight_quantizer_gptq_config.py
@@ -91,8 +91,7 @@ class WeightQuantizeConfig(BaseQuantizeConfig):
                                                                 quantization_axis=weight_channel_axis,
                                                                 max_lsbs_change_map=max_lsbs_change_map,
                                                                 max_iteration=gptq_config.n_epochs,
-                                                                gumbel_config=gptq_config.quantizer_config,
-                                                                gumbel_scale=gptq_config.gumbel_scale)
+                                                                gumbel_config=gptq_config.quantizer_config)
             else:
                 common.Logger.error(
                     f"For quantization method {final_weights_quantization_cfg.weights_quantization_method}, GPTQ Rounding type {gptq_config.rounding_type} is not supported")

--- a/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/base_gumbel_rounding.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/gumbel_rounding/base_gumbel_rounding.py
@@ -124,6 +124,9 @@ class GumbelRoundingBase(BaseTrainableQuantizer):
         self.p_t = None
         scale = self.cycle_iterations / (-2 * np.log(0.001))
 
+        self.gumbel_scale = gumbel_config.gumbel_scale
+        self.gumbel_scale_per_bitwidth = gumbel_config.gumbel_scale_per_bitwidth
+
         def tau_function(i):
             """
             A function the generate the gumbel temperature.

--- a/model_compression_toolkit/gptq/pytorch/gptq_training.py
+++ b/model_compression_toolkit/gptq/pytorch/gptq_training.py
@@ -175,7 +175,7 @@ class PytorchGPTQTrainer(GPTQTrainer):
             n_epochs: Number of update iterations of representative dataset.
         """
         for _ in tqdm(range(n_epochs)):
-            for data in data_function():
+            for data in tqdm(data_function()):
                 input_data = [d * self.input_scale for d in data]
                 input_tensor = to_torch_tensor(input_data)
                 y_float = self.float_model(input_tensor)  # running float model

--- a/model_compression_toolkit/gptq/pytorch/quantizer/gumbel_rounding/base_gumbel_weights_quantizer.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/gumbel_rounding/base_gumbel_weights_quantizer.py
@@ -106,6 +106,9 @@ class BaseGumbelWeightQuantizer(BaseWeightQuantizer):
         self.update_gumbel_param = True
         scale = self.cycle_iterations / (-2 * np.log(0.001))
 
+        self.gumbel_scale = gptq_config.quantizer_config.gumbel_scale
+        self.gumbel_scale_per_bitwidth = gptq_config.quantizer_config.gumbel_scale_per_bitwidth
+
         def tau_function(i: int) -> float:
             """
             A function that generates the gumbel temperature.

--- a/model_compression_toolkit/gptq/pytorch/quantizer/gumbel_rounding/base_gumbel_weights_quantizer.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/gumbel_rounding/base_gumbel_weights_quantizer.py
@@ -99,7 +99,6 @@ class BaseGumbelWeightQuantizer(BaseWeightQuantizer):
         self.temperature_learning = gptq_config.quantizer_config.temperature_learning
         self.cycle_iterations = max(1, int(gptq_config.n_epochs / gptq_config.quantizer_config.n_cycles))
         self.shift_tensor = to_torch_tensor(init_shift_var(self.m))
-        self.gumbel_scale = gptq_config.gumbel_scale
         self.tau = None
         self.g_t = 0
         self.p_t = None

--- a/model_compression_toolkit/gptq/pytorch/quantizer/gumbel_rounding/sym_gumbel_weights_quantizer.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/gumbel_rounding/sym_gumbel_weights_quantizer.py
@@ -124,7 +124,9 @@ class SymmetricGumbelWeightQuantizer(BaseGumbelWeightQuantizer):
         # Gumbel Softmax
         #####################################################
         if training:
-            self.p_t = gumbel_softmax(self.aux_tensor, self.tau, self.g_t, gumbel_scale=self.gumbel_scale)
+            gumbel_scale = self.gumbel_scale if self.gumbel_scale_per_bitwidth is None \
+                else self.gumbel_scale_per_bitwidth.get(self.num_bits, self.gumbel_scale)
+            self.p_t = gumbel_softmax(self.aux_tensor, self.tau, self.g_t, gumbel_scale=gumbel_scale)
         else:
             self.p_t = ste_gumbel(gumbel_softmax(self.aux_tensor, self.minimal_temp, 0))
 

--- a/model_compression_toolkit/qunatizers_infrastructure/keras/quantize_wrapper.py
+++ b/model_compression_toolkit/qunatizers_infrastructure/keras/quantize_wrapper.py
@@ -21,9 +21,6 @@ from model_compression_toolkit.qunatizers_infrastructure.common.node_quantizatio
 
 if FOUND_TF:
     import tensorflow as tf
-
-    keras = tf.keras
-
     from tensorflow.python.util import tf_inspect
     from tensorflow_model_optimization.python.core.keras import utils
 

--- a/model_compression_toolkit/qunatizers_infrastructure/keras/quantize_wrapper.py
+++ b/model_compression_toolkit/qunatizers_infrastructure/keras/quantize_wrapper.py
@@ -21,6 +21,9 @@ from model_compression_toolkit.qunatizers_infrastructure.common.node_quantizatio
 
 if FOUND_TF:
     import tensorflow as tf
+
+    keras = tf.keras
+
     from tensorflow.python.util import tf_inspect
     from tensorflow_model_optimization.python.core.keras import utils
     from keras.utils import deserialize_keras_object, serialize_keras_object


### PR DESCRIPTION
The following additions to Gumbel Rounding, GPTQ, and Jacobian weights computation:
* Normalization to weights using log scale.
* Added option for different gumbel scale values per bit-width.
* Moved gumbel_scale parameter to GumbelConfig instead of GradientPTQConvifg.
* Added tqdm to model_gradients random interest points and GPTQ training loops.