### PR TITLE
Fix issue in onnx exporter

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -19,8 +19,13 @@ import torch.nn
 from model_compression_toolkit.core.common import Logger
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
 from model_compression_toolkit.exporter.model_exporter.pytorch.base_pytorch_exporter import BasePyTorchExporter
+from packaging import version
 
-OPSET_VERSION = 16
+# ONNX opset version 16 is supported from PyTorch 1.12
+if version.parse(torch.__version__) < version.parse("1.12"):
+    OPSET_VERSION = 15
+else:
+    OPSET_VERSION = 16
 
 class FakelyQuantONNXPyTorchExporter(BasePyTorchExporter):
     """


### PR DESCRIPTION
ONNX opset version 16 is not supported in torch 1.11. This commit adds a fix that sets the correct opset version according to the torch version.