### PR TITLE
Fixes in exporter

### DIFF
--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -55,4 +55,6 @@ from model_compression_toolkit.core.pytorch.kpi_data_facade import pytorch_kpi_d
 
 from model_compression_toolkit.quantizers_infrastructure.keras.load_model import keras_load_quantized_model
 
+from model_compression_toolkit.exporter.model_exporter import tflite_export_model, TFLiteExportMode, keras_export_model, KerasExportMode, pytorch_export_model, PyTorchExportMode
+
 __version__ = "1.7.1"

--- a/model_compression_toolkit/exporter/README.md
+++ b/model_compression_toolkit/exporter/README.md
@@ -19,7 +19,7 @@ import model_compression_toolkit as mct
 
 # Create a model
 float_model = ResNet50()
-# Quantize the model. In order to export the model new_experimental_exporter is True.
+# Quantize the model. In order to export the model set new_experimental_exporter to True.
 # Notice that here the representative dataset is random. 
 quantized_exportable_model, _ = mct.keras_post_training_quantization_experimental(float_model,
                                                                                   representative_data_gen=lambda: [np.random.random((1, 224, 224, 3))],
@@ -56,6 +56,7 @@ print(f'Compression ratio: {os.path.getsize(float_file_path)/os.path.getsize(tfl
 
 ### Fakely-Quantized TFLite 
 The model will be exported as a tflite model where weights and activations are quantized but represented as float.
+Notice that activation quantizers are implemented using [tf.quantization.fake_quant_with_min_max_vars](https://www.tensorflow.org/api_docs/python/tf/quantization/fake_quant_with_min_max_vars) operators. 
 
 #### Usage Example
 ```python
@@ -103,7 +104,7 @@ from torchvision.models.mobilenetv2 import mobilenet_v2
 
 # Create a model
 float_model = mobilenet_v2()
-# Quantize the model. In order to export the model new_experimental_exporter is True.
+# Quantize the model. In order to export the model set new_experimental_exporter to True.
 # Notice that here the representative dataset is random.
 def representative_data_gen():
     for i in range(1):

--- a/model_compression_toolkit/exporter/README.md
+++ b/model_compression_toolkit/exporter/README.md
@@ -2,15 +2,16 @@
 
 Export your quantized model in the following formats:
 * TensorFlow models can be exported as Tensorflow models (`.h5` extension) and TFLite models (`.tflite` extension).
-* PyTorch models can be exported as torch script models (`.pth` extension) and ONNX models (`.onnx` extension).
+* PyTorch models can be exported as torch script models and ONNX models (`.onnx` extension).
 
 ### Note
 This feature is **experimental and subject to future changes**.
 If you have any questions or issues, please [open an issue](https://github.com/sony/model_optimization/issues/new/choose) in this GitHub repository.
 
-## Export TensorFlow models
+## Export TensorFlow Models
 
-To export a TensorFlow models a quantized model from MCT should be quantized first:
+To export a TensorFlow model - a quantized model from MCT should be quantized first:
+
 ```python
 import numpy as np
 from keras.applications import ResNet50
@@ -90,3 +91,69 @@ mct.keras_export_model(model=quantized_exportable_model,
 
 Notice that the fakely-quantized model has the same size as the quantized exportable model as weights data types are float.
 
+## Export PyTorch models
+
+To export a PyTorch model - a quantized model from MCT should be quantized first:
+
+```python
+import model_compression_toolkit as mct
+import numpy as np
+import torch
+from torchvision.models.mobilenetv2 import mobilenet_v2
+
+# Create a model
+float_model = mobilenet_v2()
+# Quantize the model. In order to export the model new_experimental_exporter is True.
+# Notice that here the representative dataset is random.
+def representative_data_gen():
+    for i in range(1):
+        yield [np.random.random((1, 3, 224, 224))]
+
+quantized_exportable_model, _ = mct.pytorch_post_training_quantization_experimental(float_model,
+                                                                                    representative_data_gen=representative_data_gen,
+                                                                                    new_experimental_exporter=True)
+```
+
+### Fakely-Quantized ONNX 
+
+The model will be exported in ONNX format where weights and activations are quantized but represented as float.
+
+#### Usage Example
+```python
+import tempfile
+
+# Path of exported model
+_, onnx_file_path = tempfile.mkstemp('.onnx')
+
+# Use mode PyTorchExportMode.FAKELY_QUANT_ONNX for fakely-quantized weights and activations
+mct.pytorch_export_model(model=quantized_exportable_model,
+                         save_model_path=onnx_file_path,
+                         mode=mct.PyTorchExportMode.FAKELY_QUANT_ONNX,
+                         # A representative dataset is required
+                         repr_dataset=representative_data_gen)
+```
+
+Notice that the fakely-quantized model has the same size as the quantized exportable model as weights data types are float.
+
+
+
+### Fakely-Quantized TorchScript 
+
+The model will be exported in TorchScript format where weights and activations are quantized but represented as float.
+
+#### Usage Example
+```python
+import tempfile
+
+# Path of exported model
+_, torchscript_file_path = tempfile.mkstemp('.pt')
+
+# Use mode PyTorchExportMode.FAKELY_QUANT_TORCHSCRIPT for fakely-quantized weights and activations
+mct.pytorch_export_model(model=quantized_exportable_model,
+                         save_model_path=torchscript_file_path,
+                         mode=mct.PyTorchExportMode.FAKELY_QUANT_TORCHSCRIPT,
+                         # A representative dataset is required
+                         repr_dataset=representative_data_gen)
+```
+
+Notice that the fakely-quantized model has the same size as the quantized exportable model as weights data types are float.

--- a/model_compression_toolkit/exporter/README.md
+++ b/model_compression_toolkit/exporter/README.md
@@ -1,0 +1,92 @@
+## Introduction
+
+Export your quantized model in the following formats:
+* TensorFlow models can be exported as Tensorflow models (`.h5` extension) and TFLite models (`.tflite` extension).
+* PyTorch models can be exported as torch script models (`.pth` extension) and ONNX models (`.onnx` extension).
+
+### Note
+This feature is **experimental and subject to future changes**.
+If you have any questions or issues, please [open an issue](https://github.com/sony/model_optimization/issues/new/choose) in this GitHub repository.
+
+## Export TensorFlow models
+
+To export a TensorFlow models a quantized model from MCT should be quantized first:
+```python
+import numpy as np
+from keras.applications import ResNet50
+import model_compression_toolkit as mct
+
+# Create a model
+float_model = ResNet50()
+# Quantize the model. In order to export the model new_experimental_exporter is True.
+# Notice that here the representative dataset is random. 
+quantized_exportable_model, _ = mct.keras_post_training_quantization_experimental(float_model,
+                                                                                  representative_data_gen=lambda: [np.random.random((1, 224, 224, 3))],
+                                                                                  new_experimental_exporter=True)
+```
+
+### INT8 TFLite 
+The model will be exported as a tflite model where weights and activations are represented as 8bit integers.
+
+#### Usage Example
+```python
+import tempfile
+
+# Path of exported model
+_, tflite_file_path = tempfile.mkstemp('.tflite')
+
+# Use mode TFLiteExportMode.INT8 for INT8 data type.
+mct.tflite_export_model(model=quantized_exportable_model,
+                        save_model_path=tflite_file_path,
+                        mode=mct.TFLiteExportMode.INT8)
+```
+Compare size of float and quantized model:
+```python
+import os
+
+# Save float model to measure its size
+_, float_file_path = tempfile.mkstemp('.h5')
+float_model.save(float_file_path)
+
+print("Float model in Mb:", os.path.getsize(float_file_path) / float(2**20))
+print("Quantized model in Mb:", os.path.getsize(tflite_file_path) / float(2**20))
+print(f'Compression ratio: {os.path.getsize(float_file_path)/os.path.getsize(tflite_file_path)}')
+```
+
+### Fakely-Quantized TFLite 
+The model will be exported as a tflite model where weights and activations are quantized but represented as float.
+
+#### Usage Example
+```python
+import tempfile
+
+# Path of exported model
+_, tflite_file_path = tempfile.mkstemp('.tflite')
+
+# Use mode TFLiteExportMode.FAKELY_QUANT for fakely-quantized weights and activations
+mct.tflite_export_model(model=quantized_exportable_model,
+                        save_model_path=tflite_file_path,
+                        mode=mct.TFLiteExportMode.FAKELY_QUANT)
+```
+
+Notice that the fakely-quantized model has the same size as the quantized exportable model as weights data types are float.
+
+
+### Fakely-Quantized h5 
+The model will be exported as a tensorflow `.h5` model where weights and activations are quantized but represented as float.
+
+#### Usage Example
+```python
+import tempfile
+
+# Path of exported model
+_, h5_file_path = tempfile.mkstemp('.h5')
+
+# Use mode KerasExportMode.FAKELY_QUANT for fakely-quantized weights and activations
+mct.keras_export_model(model=quantized_exportable_model,
+                       save_model_path=h5_file_path,
+                       mode=mct.KerasExportMode.FAKELY_QUANT)
+```
+
+Notice that the fakely-quantized model has the same size as the quantized exportable model as weights data types are float.
+

--- a/model_compression_toolkit/exporter/model_exporter/__init__.py
+++ b/model_compression_toolkit/exporter/model_exporter/__init__.py
@@ -13,15 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from model_compression_toolkit.core.common.constants import FOUND_TF, FOUND_TORCH
-
-if FOUND_TF:
-    from model_compression_toolkit.exporter.model_exporter.keras.keras_export_facade import \
-        keras_export_model, KerasExportMode
-    from model_compression_toolkit.exporter.model_exporter.tflite.tflite_export_facade import tflite_export_model, \
-        TFLiteExportMode
-
-if FOUND_TORCH:
-    from model_compression_toolkit.exporter.model_exporter.pytorch.pytorch_export_facade import PyTorchExportMode, \
-        pytorch_export_model
-
+from model_compression_toolkit.exporter.model_exporter.keras.keras_export_facade import keras_export_model, KerasExportMode
+from model_compression_toolkit.exporter.model_exporter.pytorch.pytorch_export_facade import PyTorchExportMode, pytorch_export_model
+from model_compression_toolkit.exporter.model_exporter.tflite.tflite_export_facade import tflite_export_model, TFLiteExportMode

--- a/model_compression_toolkit/exporter/model_exporter/keras/keras_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/keras_export_facade.py
@@ -33,8 +33,11 @@ if FOUND_TF:
                            is_layer_exportable_fn: Callable = is_keras_layer_exportable,
                            mode: KerasExportMode = KerasExportMode.FAKELY_QUANT) -> Dict[str, type]:
         """
-        Prepare and return fully quantized model for export. Save exported model to
-        a path if passed.
+        Export a Keras quantized model to h5 model.
+        The model will be saved to the path in save_model_path.
+        Mode can be used for different exported files. Currently, keras_export_model
+        supports KerasExportMode.FAKELY_QUANT (where weights and activations are
+        float fakely-quantized values).
 
         Args:
             model: Model to export.

--- a/model_compression_toolkit/exporter/model_exporter/keras/keras_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/keras_export_facade.py
@@ -15,45 +15,53 @@
 from enum import Enum
 from typing import Callable, Dict
 
-import keras
 from model_compression_toolkit.core.common import Logger
-from model_compression_toolkit.exporter.model_exporter.keras.fakely_quant_keras_exporter import \
-    FakelyQuantKerasExporter
+from model_compression_toolkit.core.common.constants import FOUND_TF
 
 
 class KerasExportMode(Enum):
     FAKELY_QUANT = 0
 
 
-def keras_export_model(model: keras.models.Model,
-                       is_layer_exportable_fn: Callable,
-                       mode: KerasExportMode = KerasExportMode.FAKELY_QUANT,
-                       save_model_path: str = None) -> Dict[str, type]:
-    """
-    Prepare and return fully quantized model for export. Save exported model to
-    a path if passed.
+if FOUND_TF:
+    import keras
+    from model_compression_toolkit.exporter.model_wrapper.keras.validate_layer import is_keras_layer_exportable
+    from model_compression_toolkit.exporter.model_exporter.keras.fakely_quant_keras_exporter import FakelyQuantKerasExporter
 
-    Args:
-        model: Model to export.
-        is_layer_exportable_fn: Callable to check whether a layer can be exported or not.
-        mode: Mode to export the model according to.
-        save_model_path: Path to save the model.
+    def keras_export_model(model: keras.models.Model,
+                           save_model_path: str,
+                           is_layer_exportable_fn: Callable = is_keras_layer_exportable,
+                           mode: KerasExportMode = KerasExportMode.FAKELY_QUANT) -> Dict[str, type]:
+        """
+        Prepare and return fully quantized model for export. Save exported model to
+        a path if passed.
 
-    Returns:
-        Custom objects dictionary needed to load the model.
+        Args:
+            model: Model to export.
+            is_layer_exportable_fn: Callable to check whether a layer can be exported or not.
+            mode: Mode to export the model according to.
+            save_model_path: Path to save the model.
 
-    """
+        Returns:
+            Custom objects dictionary needed to load the model.
 
-    if mode == KerasExportMode.FAKELY_QUANT:
-        exporter = FakelyQuantKerasExporter(model,
-                                            is_layer_exportable_fn,
-                                            save_model_path)
+        """
 
-    else:
-        Logger.critical(
-            f'Unsupported mode was used {mode.name} to '
-            f'export Keras model. Please see API for supported modes.')  # pragma: no cover
+        if mode == KerasExportMode.FAKELY_QUANT:
+            exporter = FakelyQuantKerasExporter(model,
+                                                is_layer_exportable_fn,
+                                                save_model_path)
 
-    exporter.export()
+        else:
+            Logger.critical(
+                f'Unsupported mode was used {mode.name} to '
+                f'export Keras model. Please see API for supported modes.')  # pragma: no cover
 
-    return exporter.get_custom_objects()
+        exporter.export()
+
+        return exporter.get_custom_objects()
+else:
+    def keras_export_model(*args, **kwargs):
+        Logger.error('Installing tensorflow and tensorflow_model_optimization is mandatory '
+                     'when using keras_export_model. '
+                     'Could not find some or all of TensorFlow packages.')  # pragma: no cover

--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -63,7 +63,9 @@ class FakelyQuantONNXPyTorchExporter(BasePyTorchExporter):
         Returns:
             Fake-quant PyTorch model.
         """
-        # assert self.is_layer_exportable_fn(layer), f'Layer {layer.name} is not exportable.'
+        for layer in self.model.children():
+            assert self.is_layer_exportable_fn(layer), f'Layer {layer.name} is not exportable.'
+
         model_input = to_torch_tensor(next(self.repr_dataset())[0])
 
         Logger.info(f"Exporting PyTorch fake quant onnx model: {self.save_model_path}")

--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_torchscript_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_torchscript_pytorch_exporter.py
@@ -56,7 +56,8 @@ class FakelyQuantTorchScriptPyTorchExporter(BasePyTorchExporter):
         Returns:
             Fake-quant PyTorch model.
         """
-        # assert self.is_layer_exportable_fn(layer), f'Layer {layer.name} is not exportable.'
+        for layer in self.model.children():
+            assert self.is_layer_exportable_fn(layer), f'Layer {layer} is not exportable.'
 
         torch_traced = torch.jit.trace(self.model,
                                        to_torch_tensor(next(self.repr_dataset())),

--- a/model_compression_toolkit/exporter/model_exporter/pytorch/pytorch_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/pytorch_export_facade.py
@@ -36,8 +36,13 @@ if FOUND_TORCH:
                              is_layer_exportable_fn: Callable = is_pytorch_layer_exportable,
                              mode: PyTorchExportMode = PyTorchExportMode.FAKELY_QUANT_TORCHSCRIPT) -> None:
         """
-        Prepare and return fully quantized model for export. Save exported model to
-        a path if passed.
+        Export a PyTorch quantized model to a torchscript or onnx model.
+        The model will be saved to the path in save_model_path.
+        Mode can be used for different exported files. Currently, pytorch_export_model
+        supports PyTorchExportMode.FAKELY_QUANT_TORCHSCRIPT (where the exported model
+        is in a TorchScript format and its weights and activations are float fakely-quantized values),
+        and PyTorchExportMode.FakelyQuantONNX (where the exported model
+        is in an ONNX format and its weights and activations are float fakely-quantized values)
 
         Args:
             model: Model to export.

--- a/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
@@ -15,47 +15,55 @@
 from enum import Enum
 from typing import Callable
 
-import keras
-
 from model_compression_toolkit.core.common import Logger
-from model_compression_toolkit.exporter.model_exporter.tflite.fakely_quant_tflite_exporter import \
-    FakelyQuantTFLiteExporter
-from model_compression_toolkit.exporter.model_exporter.tflite.int8_tflite_exporter import INT8TFLiteExporter
+from model_compression_toolkit.core.common.constants import FOUND_TF
 
 
 class TFLiteExportMode(Enum):
     FAKELY_QUANT = 0
     INT8 = 1
 
+if FOUND_TF:
+    import keras
+    from model_compression_toolkit.exporter.model_exporter.tflite.fakely_quant_tflite_exporter import FakelyQuantTFLiteExporter
+    from model_compression_toolkit.exporter.model_exporter.tflite.int8_tflite_exporter import INT8TFLiteExporter
+    from model_compression_toolkit.exporter.model_wrapper.keras.validate_layer import is_keras_layer_exportable
 
-def tflite_export_model(model: keras.models.Model,
-                        is_layer_exportable_fn: Callable,
-                        mode: TFLiteExportMode = TFLiteExportMode.FAKELY_QUANT,
-                        save_model_path: str = None):
-    """
-    Prepare and return fully quantized model for export. Save exported model to
-    a path if passed.
+    def tflite_export_model(model: keras.models.Model,
+                            save_model_path: str,
+                            mode: TFLiteExportMode = TFLiteExportMode.FAKELY_QUANT,
+                            is_layer_exportable_fn: Callable = is_keras_layer_exportable
+                            ):
+        """
+        Prepare and return fully quantized model for export. Save exported model to
+        a path if passed.
 
-    Args:
-        model: Model to export.
-        is_layer_exportable_fn: Callable to check whether a layer can be exported or not.
-        mode: Mode to export the model according to.
-        save_model_path: Path to save the model.
+        Args:
+            model: Model to export.
+            is_layer_exportable_fn: Callable to check whether a layer can be exported or not.
+            mode: Mode to export the model according to.
+            save_model_path: Path to save the model.
 
-    """
+        """
 
-    if mode == TFLiteExportMode.FAKELY_QUANT:
-        exporter = FakelyQuantTFLiteExporter(model,
-                                             is_layer_exportable_fn,
-                                             save_model_path)
-    elif mode == TFLiteExportMode.INT8:
-        exporter = INT8TFLiteExporter(model,
-                                      is_layer_exportable_fn,
-                                      save_model_path)
+        if mode == TFLiteExportMode.FAKELY_QUANT:
+            exporter = FakelyQuantTFLiteExporter(model,
+                                                 is_layer_exportable_fn,
+                                                 save_model_path)
+        elif mode == TFLiteExportMode.INT8:
+            exporter = INT8TFLiteExporter(model,
+                                          is_layer_exportable_fn,
+                                          save_model_path)
 
-    else:
-        Logger.critical(
-            f'Unsupported mode was used {mode.name} to export TFLite model.'
-            f' Please see API for supported modes.')  # pragma: no cover
+        else:
+            Logger.critical(
+                f'Unsupported mode was used {mode.name} to export TFLite model.'
+                f' Please see API for supported modes.')  # pragma: no cover
 
-    exporter.export()
+        exporter.export()
+
+else:
+    def tflite_export_model(*args, **kwargs):
+        Logger.error('Installing tensorflow and tensorflow_model_optimization is mandatory '
+                     'when using tflite_export_model. '
+                     'Could not find some or all of TensorFlow packages.')  # pragma: no cover

--- a/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
+++ b/model_compression_toolkit/exporter/model_exporter/tflite/tflite_export_facade.py
@@ -35,8 +35,12 @@ if FOUND_TF:
                             is_layer_exportable_fn: Callable = is_keras_layer_exportable
                             ):
         """
-        Prepare and return fully quantized model for export. Save exported model to
-        a path if passed.
+        Export a Keras quantized model to a tflite model.
+        The model will be saved to the path in save_model_path.
+        Mode can be used for different exported files. Currently, tflite_export_model
+        supports TFLiteExportMode.FAKELY_QUANT (where weights and activations are
+        float fakely-quantized values), and TFLiteExportMode.INT8 (where weights
+        and activations are represented using 8bits integers).
 
         Args:
             model: Model to export.

--- a/model_compression_toolkit/exporter/model_wrapper/__init__.py
+++ b/model_compression_toolkit/exporter/model_wrapper/__init__.py
@@ -20,5 +20,5 @@ if FOUND_TF:
     from model_compression_toolkit.exporter.model_wrapper.keras.builder.fully_quantized_model_builder import get_exportable_keras_model
 
 if FOUND_TORCH:
-    # from model_compression_toolkit.exporter.model_wrapper.pytorch.validate_layer import is_pytorch_layer_exportable
+    from model_compression_toolkit.exporter.model_wrapper.pytorch.validate_layer import is_pytorch_layer_exportable
     from model_compression_toolkit.exporter.model_wrapper.pytorch.builder.fully_quantized_model_builder import get_exportable_pytorch_model

--- a/model_compression_toolkit/exporter/model_wrapper/pytorch/validate_layer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/pytorch/validate_layer.py
@@ -1,0 +1,36 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Any
+
+from model_compression_toolkit.quantizers_infrastructure import PytorchQuantizationWrapper, \
+    BasePyTorchInferableQuantizer
+
+
+def is_pytorch_layer_exportable(layer: Any) -> bool:
+    """
+    Check whether a torch Module is a valid exportable module or not.
+
+    Args:
+        layer: PyTorch module to check if considered to be valid for exporting.
+
+    Returns:
+        Check whether a PyTorch layer is a valid exportable layer or not.
+    """
+    if isinstance(layer, PytorchQuantizationWrapper):
+        quantizers = list(layer.weights_quantizers.values())
+        quantizers.extend(layer.activation_quantizers)
+        if all([isinstance(q, BasePyTorchInferableQuantizer) for q in quantizers]):
+            return True
+    return False

--- a/model_compression_toolkit/exporter/model_wrapper/pytorch/validate_layer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/pytorch/validate_layer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/keras_tests/exporter_tests/tflite_int8/tflite_int8_exporter_base_test.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/tflite_int8_exporter_base_test.py
@@ -58,7 +58,6 @@ class TFLiteINT8ExporterBaseTest:
         # Export model in INT8 format
         _, self.int8_model_file_path = tempfile.mkstemp('.tflite')
         tflite_export_model(model=self.exportable_model,
-                            is_layer_exportable_fn=is_keras_layer_exportable,
                             mode=TFLiteExportMode.INT8,
                             save_model_path=self.int8_model_file_path)
 

--- a/tests/pytorch_tests/function_tests/test_export_pytorch_fully_quantized_model.py
+++ b/tests/pytorch_tests/function_tests/test_export_pytorch_fully_quantized_model.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 import os
-import struct
 import tempfile
 import unittest
 
 import numpy as np
 import torch
 from torchvision.models.mobilenetv2 import mobilenet_v2
+
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.common.constants import FOUND_ONNX, FOUND_ONNXRUNTIME
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
@@ -27,7 +27,6 @@ from model_compression_toolkit.exporter.model_exporter import pytorch_export_mod
 
 _, SAVED_MODEL_PATH_PTH = tempfile.mkstemp('.pth')
 _, SAVED_MODEL_PATH_ONNX = tempfile.mkstemp('.onnx')
-
 
 if FOUND_ONNX:
     import onnx
@@ -46,17 +45,15 @@ if FOUND_ONNX:
             self.exportable_model = self.run_mct(self.model, new_experimental_exporter=True)
             self.exportable_model.eval()
             pytorch_export_model(model=self.exportable_model,
-                                 is_layer_exportable_fn=lambda x: x,
                                  mode=PyTorchExportMode.FAKELY_QUANT_TORCHSCRIPT,
                                  save_model_path=SAVED_MODEL_PATH_PTH,
                                  repr_dataset=self.repr_datagen)
             self.exported_model_pth = torch.load(SAVED_MODEL_PATH_PTH)
             self.exported_model_pth.eval()
             pytorch_export_model(model=self.exportable_model,
-                                                           is_layer_exportable_fn=lambda x: x,
-                                                           mode=PyTorchExportMode.FAKELY_QUANT_ONNX,
-                                                           save_model_path=SAVED_MODEL_PATH_ONNX,
-                                                           repr_dataset=self.repr_datagen)
+                                 mode=PyTorchExportMode.FAKELY_QUANT_ONNX,
+                                 save_model_path=SAVED_MODEL_PATH_ONNX,
+                                 repr_dataset=self.repr_datagen)
             self.exported_model_onnx = onnx.load(SAVED_MODEL_PATH_ONNX)
             # Check that the model is well formed
             onnx.checker.check_model(self.exported_model_onnx)
@@ -91,4 +88,3 @@ if FOUND_ONNX:
                 # compute ONNX Runtime output prediction
                 ort_inputs = {ort_session.get_inputs()[0].name: to_numpy(x)}
                 ort_session.run(None, ort_inputs)
-


### PR DESCRIPTION
Add exporter README (only keras examples for now)

Fix facades APIs in all frameworks:
- file path is mandatory
- validation function is optional

Add validation function to pytorch exporter.