### PR TITLE
Change PyTorch reshape and view operators batch size value

### DIFF
--- a/model_compression_toolkit/core/pytorch/constants.py
+++ b/model_compression_toolkit/core/pytorch/constants.py
@@ -92,3 +92,7 @@ IN_PROJ_WEIGHT = 'in_proj_weight'
 IN_PROJ_BIAS = 'in_proj_bias'
 BIAS_K = 'bias_k'
 BIAS_V = 'bias_v'
+
+# # Batch size value for 'reshape' and 'view' operators,
+# # the value is -1 so the batch size is inferred from the length of the array and remaining dimensions.
+BATCH_DIM_VALUE = -1

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/reshape_with_static_shapes.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/reshape_with_static_shapes.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 from torch import reshape
 import torch
+
+from model_compression_toolkit.core.common import Logger
 from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common.graph.base_graph import Graph
@@ -49,8 +51,10 @@ class ReshapeWithStaticShapes(common.BaseSubstitution):
             Graph after applying the substitution.
         """
         # we want the batch size value to infer from the length of the array and remaining dimensions
-        node.output_shape = [[BATCH_DIM_VALUE] + inner_output_shape[1:] if inner_output_shape else inner_output_shape
-                             for inner_output_shape in node.output_shape]
+        if len(node.output_shape) == 1:
+            node.output_shape[0][0] = BATCH_DIM_VALUE
+        else:
+            Logger.error('Reshape or view nodes should have a single output shape')  # pragma: no cover
 
         # configure the new static output shape attribute
         node.op_call_args = node.output_shape

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/reshape_with_static_shapes.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/reshape_with_static_shapes.py
@@ -18,6 +18,7 @@ from model_compression_toolkit.core.common.graph.graph_matchers import NodeOpera
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common.graph.base_graph import Graph
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
+from model_compression_toolkit.core.pytorch.constants import BATCH_DIM_VALUE
 
 
 class ReshapeWithStaticShapes(common.BaseSubstitution):
@@ -47,14 +48,23 @@ class ReshapeWithStaticShapes(common.BaseSubstitution):
         Returns:
             Graph after applying the substitution.
         """
+        # we want the batch size value to infer from the length of the array and remaining dimensions
+        node.output_shape = [[BATCH_DIM_VALUE] + inner_output_shape[1:] if inner_output_shape else inner_output_shape
+                             for inner_output_shape in node.output_shape]
+
         # configure the new static output shape attribute
         node.op_call_args = node.output_shape
 
         # modify the node input info
         node.input_shape = [node.input_shape[0]]
+
+        # the first input is the tensor to be reshaped, we want his batch size value to infer
+        # from the length of the array and remaining dimensions
+        node.input_shape[0][0] = BATCH_DIM_VALUE
+
         nodes_to_check = []
         for in_edge in graph.incoming_edges(node):
-            if in_edge.sink_index > 0: # the first input is the tensor to be reshaped
+            if in_edge.sink_index > 0:  # the first input is the tensor to be reshaped
                 nodes_to_check.append(in_edge.source_node)
                 graph.remove_edge(in_edge.source_node, node)
         for n in nodes_to_check:

--- a/tests/pytorch_tests/model_tests/feature_models/dynamic_size_inputs_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/dynamic_size_inputs_test.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import random
+
+import numpy as np
 import torch
+
+import model_compression_toolkit as mct
+from model_compression_toolkit import MixedPrecisionQuantizationConfig
+from model_compression_toolkit.core.common.target_platform import TargetPlatformCapabilities
+from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 
 """
@@ -20,6 +28,8 @@ This tests checks the 'reshape_with_static_shapes' substitution.
 We create a model with dynamic input shape attributes to the operators 'reshape' and 'view'.
 We check that the model after conversion replaces the attributes with static-list-of-ints attributes.
 """
+
+
 class ReshapeNet(torch.nn.Module):
     def __init__(self):
         super(ReshapeNet, self).__init__()
@@ -46,6 +56,7 @@ class ReshapeNetTest(BasePytorchTest):
     We create a model with dynamic input shape attributes to the operators 'reshape' and 'view'.
     We check that the model after conversion replaces the attributes with static-list-of-ints attributes.
     """
+
     def __init__(self, unit_test):
         super().__init__(unit_test, convert_to_fx=False)
 
@@ -72,4 +83,78 @@ class ReshapeNetTest(BasePytorchTest):
         ######################################################
         # check the all other comparisons:
         ######################################################
-        super(ReshapeNetTest, self).compare(quantized_models, float_model, input_x=input_x, quantization_info=quantization_info)
+        super(ReshapeNetTest, self).compare(quantized_models, float_model, input_x=input_x,
+                                            quantization_info=quantization_info)
+
+    def run_test(self, seed=0, experimental_facade=False):
+        np.random.seed(seed)
+        random.seed(a=seed)
+        torch.random.manual_seed(seed)
+        input_shapes = self.create_inputs_shape()
+        x = self.generate_inputs(input_shapes)
+
+        def representative_data_gen():
+            return x
+
+        def representative_data_gen_experimental():
+            for _ in range(self.num_calibration_iter):
+                yield x
+
+        ptq_models = {}
+        model_float = self.create_feature_network(input_shapes)
+        quant_config_dict = self.get_quantization_configs()
+        tpc_dict = self.get_tpc()
+        assert isinstance(tpc_dict, dict), "Pytorch tests get_tpc should return a dictionary " \
+                                           "mapping the test model name to a TPC object."
+        for model_name in tpc_dict.keys():
+            tpc = tpc_dict[model_name]
+            assert isinstance(tpc, TargetPlatformCapabilities)
+
+            quant_config = quant_config_dict.get(model_name)
+            assert quant_config is not None, f"Model name {model_name} does not exists in the test's " \
+                                             f"quantization configs dictionary keys"
+            core_config = self.get_core_config()
+            core_config.quantization_config = quant_config
+
+            if experimental_facade:
+                ptq_model, quantization_info = mct.pytorch_post_training_quantization_experimental(
+                    in_module=model_float,
+                    representative_data_gen=representative_data_gen_experimental,
+                    target_kpi=self.get_kpi(),
+                    core_config=core_config,
+                    target_platform_capabilities=tpc,
+                    new_experimental_exporter=self.experimental_exporter
+                )
+            else:
+                if isinstance(quant_config, MixedPrecisionQuantizationConfig):
+                    ptq_model, quantization_info = \
+                        mct.pytorch_post_training_quantization_mixed_precision(model_float,
+                                                                               representative_data_gen,
+                                                                               n_iter=self.num_calibration_iter,
+                                                                               quant_config=quant_config,
+                                                                               fw_info=DEFAULT_PYTORCH_INFO,
+                                                                               network_editor=self.get_network_editor(),
+                                                                               gptq_config=self.get_gptq_config(),
+                                                                               target_kpi=self.get_kpi(),
+                                                                               target_platform_capabilities=tpc)
+
+                else:
+                    ptq_model, quantization_info = \
+                        mct.pytorch_post_training_quantization(model_float,
+                                                               representative_data_gen,
+                                                               n_iter=self.num_calibration_iter,
+                                                               quant_config=quant_config,
+                                                               fw_info=DEFAULT_PYTORCH_INFO,
+                                                               network_editor=self.get_network_editor(),
+                                                               target_platform_capabilities=tpc)
+
+            ptq_models.update({model_name: ptq_model})
+
+        # We want to test that the quantized model accepts inputs with different batch size than the
+        # input representative_data_gen
+        test_batch_size = [self.val_batch_size, 1, 13, 20, 50]
+        for batch_size in test_batch_size:
+            self.val_batch_size = batch_size
+            input_shapes = self.create_inputs_shape()
+            x = self.generate_inputs(input_shapes)
+            self.compare(ptq_models, model_float, input_x=x, quantization_info=quantization_info)


### PR DESCRIPTION
After the fix the batch size would infer from the length of the array and remaining dimensions of the input to the reshape and view operators.