### PR TITLE
Move TF tests to test new inferable model

### DIFF
--- a/tests/common_tests/base_layer_test.py
+++ b/tests/common_tests/base_layer_test.py
@@ -60,7 +60,8 @@ class BaseLayerTest(BaseTest):
                 ptq_model, quantization_info = self.get_ptq_facade()(model_float,
                                                                      self.representative_data_gen_experimental,
                                                                      core_config=core_config,
-                                                                     target_platform_capabilities=self.get_tpc())
+                                                                     target_platform_capabilities=self.get_tpc(),
+                                                                     new_experimental_exporter=True)
 
                 self.compare(ptq_model, model_float, input_x=self.representative_data_gen(),
                              quantization_info=quantization_info)

--- a/tests/common_tests/base_layer_test.py
+++ b/tests/common_tests/base_layer_test.py
@@ -22,13 +22,15 @@ class BaseLayerTest(BaseTest):
                  input_shape=(8, 8, 3),
                  quantization_modes: List[LayerTestMode] = [LayerTestMode.QUANTIZED_8_BITS, LayerTestMode.FLOAT],
                  is_inputs_a_list=False,
-                 use_cpu=False):
+                 use_cpu=False,
+                 experimental_exporter=False):
 
         super().__init__(unit_test,
                          val_batch_size=val_batch_size,
                          num_calibration_iter=num_calibration_iter,
                          num_of_inputs=num_of_inputs,
-                         input_shape=input_shape)
+                         input_shape=input_shape,
+                         experimental_exporter=experimental_exporter)
 
         self.use_cpu = use_cpu
         self.is_inputs_a_list = is_inputs_a_list
@@ -61,7 +63,7 @@ class BaseLayerTest(BaseTest):
                                                                      self.representative_data_gen_experimental,
                                                                      core_config=core_config,
                                                                      target_platform_capabilities=self.get_tpc(),
-                                                                     new_experimental_exporter=True)
+                                                                     new_experimental_exporter=self.experimental_exporter)
 
                 self.compare(ptq_model, model_float, input_x=self.representative_data_gen(),
                              quantization_info=quantization_info)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq/gptq_test.py
@@ -59,7 +59,7 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
                  quantizer_config=GPTQQuantizerConfig(), per_channel=True, input_shape=(1, 16, 16, 3),
                  hessian_weights=True, log_norm_weights=True):
         super().__init__(unit_test,
-                         input_shape=input_shape)
+                         input_shape=input_shape, experimental_exporter=True)
 
         self.quant_method = quant_method
         self.rounding_type = rounding_type
@@ -98,7 +98,7 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
     def compare(self, ptq_model, model_float, input_x=None, quantization_info: UserInformation = None):
         raise NotImplementedError(f'{self.__class__} did not implement compare')
 
-    def run_test(self, experimental_exporter=False):
+    def run_test(self):
         x = self.generate_inputs()
 
         def representative_data_gen():
@@ -115,7 +115,7 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
             target_kpi=self.get_kpi(),
             core_config=core_config,
             target_platform_capabilities=tpc,
-            new_experimental_exporter=experimental_exporter
+            new_experimental_exporter=self.experimental_exporter
         )
         ptq_gptq_model, quantization_info = mct.keras_gradient_post_training_quantization_experimental(
             model_float,
@@ -124,7 +124,7 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
             target_kpi=self.get_kpi(),
             core_config=core_config,
             target_platform_capabilities=tpc,
-            new_experimental_exporter=experimental_exporter
+            new_experimental_exporter=self.experimental_exporter
         )
 
         self.compare(ptq_model, ptq_gptq_model, input_x=x, quantization_info=quantization_info)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -49,7 +49,7 @@ class LUTWeightsQuantizerTest(BaseKerasFeatureNetworkTest):
         self.kernel = 3
         self.conv_w = get_uniform_weights(self.kernel, self.num_conv_channels, self.num_conv_channels)
         self.is_symmetric = is_symmetric
-        super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
+        super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32, experimental_exporter=False)
 
     def get_tpc(self):
         qmethod = tp.QuantizationMethod.LUT_SYM_QUANTIZER if self.is_symmetric else tp.QuantizationMethod.LUT_POT_QUANTIZER
@@ -102,7 +102,7 @@ class LUTActivationQuantizerTest(BaseKerasFeatureNetworkTest):
         self.activation_n_bits = activation_n_bits
         self.num_conv_channels = 4
         self.kernel = 3
-        super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
+        super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32, experimental_exporter=False)
 
     def get_tpc(self):
         qco = tp.QuantizationConfigOptions(

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
@@ -16,6 +16,8 @@
 
 import numpy as np
 import tensorflow as tf
+
+from model_compression_toolkit import CoreConfig
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from keras import backend as K
 
@@ -53,7 +55,7 @@ def get_base_mp_nbits_candidates():
 
 class MixedPrecisionActivationBaseTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, activation_layers_idx, num_calibration_iter=1):
-        super().__init__(unit_test, num_calibration_iter=num_calibration_iter)
+        super().__init__(unit_test, num_calibration_iter=num_calibration_iter, experimental_exporter=True)
 
         self.activation_layers_idx = activation_layers_idx
 
@@ -102,7 +104,7 @@ class MixedPrecisionActivationBaseTest(BaseKerasFeatureNetworkTest):
         for i in range(len(weights_layers_idx)):
             for j in range(weights_layers_channels_size[i]):  # quantized per channel
                 self.unit_test.assertTrue(
-                    np.unique(quantized_model.layers[weights_layers_idx[i]].weights[0][:, :, :, j]).flatten().shape[
+                    np.unique(quantized_model.layers[weights_layers_idx[i]].get_quantized_weights()['kernel'][:, :, :, j]).flatten().shape[
                         0] <= unique_tensor_values)
 
         # verify activation quantization
@@ -117,7 +119,7 @@ class MixedPrecisionActivationBaseTest(BaseKerasFeatureNetworkTest):
 
 class MixedPrecisionActivationSearchTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[1, 3, 6])
+        super().__init__(unit_test, activation_layers_idx=[1, 2, 4])
 
     def get_kpi(self):
         # kpi is infinity -> should give best model - 8bits on all layers for both weights and activations
@@ -126,11 +128,11 @@ class MixedPrecisionActivationSearchTest(MixedPrecisionActivationBaseTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [8, 8, 8]))
 
         self.verify_quantization(quantized_model, input_x,
-                                 weights_layers_idx=[2, 4],
+                                 weights_layers_idx=[2, 3],
                                  weights_layers_channels_size=[32, 32],
                                  activation_layers_idx=self.activation_layers_idx,
                                  unique_tensor_values=256)
@@ -138,7 +140,7 @@ class MixedPrecisionActivationSearchTest(MixedPrecisionActivationBaseTest):
 
 class MixedPrecisionActivationSearchKPI4BitsAvgTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[3, 6])
+        super().__init__(unit_test, activation_layers_idx=[2,4])
 
     def get_kpi(self):
         # kpi is for 4 bits on average
@@ -156,7 +158,7 @@ class MixedPrecisionActivationSearchKPI4BitsAvgTest(MixedPrecisionActivationBase
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is 4 bit average
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         # Note that since we're using default max aggregation for activation KPI, then there is no guarantee that the
         # activation bitwidth for each layer would be 4-bit, this assertion tests the expected result for this specific
         # test with its current setup (therefore, we don't check the input layer's bitwidth)
@@ -172,7 +174,7 @@ class MixedPrecisionActivationSearchKPI4BitsAvgTest(MixedPrecisionActivationBase
 
 class MixedPrecisionActivationSearchKPI2BitsAvgTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[3, 6])
+        super().__init__(unit_test, activation_layers_idx=[2, 4])
 
     def get_kpi(self):
         # kpi is for 2 bits on average
@@ -184,11 +186,11 @@ class MixedPrecisionActivationSearchKPI2BitsAvgTest(MixedPrecisionActivationBase
         # Note that since we're using default max aggregation for activation KPI, then there is no guarantee that the
         # activation bitwidth for each layer would be 2-bit, this assertion tests the expected result for this specific
         # test with its current setup (therefore, we don't check the input layer's bitwidth)
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [2, 2]))
 
         self.verify_quantization(quantized_model, input_x,
-                                 weights_layers_idx=[2, 4],
+                                 weights_layers_idx=[2, 3],
                                  weights_layers_channels_size=[32, 32],
                                  activation_layers_idx=self.activation_layers_idx,
                                  unique_tensor_values=4)
@@ -203,7 +205,7 @@ class MixedPrecisionActivationSearchKPI2BitsAvgTest(MixedPrecisionActivationBase
 
 class MixedPrecisionActivationDepthwiseTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[1, 4])
+        super().__init__(unit_test, activation_layers_idx=[1, 3])
 
     def get_kpi(self):
         return KPI(np.inf, np.inf)
@@ -219,7 +221,7 @@ class MixedPrecisionActivationDepthwiseTest(MixedPrecisionActivationBaseTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [8, 8]))
 
 
@@ -254,13 +256,13 @@ class MixedPrecisionActivationDepthwise4BitTest(MixedPrecisionActivationBaseTest
         # Note that since we're using default max aggregation for activation KPI, then there is no guarantee that the
         # activation bitwidth for each layer would be 4-bit, this assertion tests the expected result for this specific
         # test with its current setup (therefore, we don't check the relu layer's bitwidth)
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [4]))
 
 
 class MixedPrecisionActivationSplitLayerTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[1, 5, 6])
+        super().__init__(unit_test, activation_layers_idx=[1, 3, 4])
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -277,7 +279,7 @@ class MixedPrecisionActivationSplitLayerTest(MixedPrecisionActivationBaseTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [8, 8, 8]))
 
         self.verify_quantization(quantized_model, input_x,
@@ -289,7 +291,7 @@ class MixedPrecisionActivationSplitLayerTest(MixedPrecisionActivationBaseTest):
 
 class MixedPrecisionActivationOnlyTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[1, 4, 6])
+        super().__init__(unit_test, activation_layers_idx=[1, 3, 4])
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -315,7 +317,7 @@ class MixedPrecisionActivationOnlyTest(MixedPrecisionActivationBaseTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [8, 8, 8]))
 
         self.verify_quantization(quantized_model, input_x,
@@ -334,7 +336,7 @@ class MixedPrecisionActivationOnlyTest(MixedPrecisionActivationBaseTest):
 
 class MixedPrecisionActivationOnlyWeightsDisabledTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[1, 3, 5])
+        super().__init__(unit_test, activation_layers_idx=[1, 2, 3])
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -361,7 +363,7 @@ class MixedPrecisionActivationOnlyWeightsDisabledTest(MixedPrecisionActivationBa
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [8, 8, 8]))
 
         self.verify_quantization(quantized_model, input_x,
@@ -373,7 +375,7 @@ class MixedPrecisionActivationOnlyWeightsDisabledTest(MixedPrecisionActivationBa
 
 class MixedPrecisionActivationAddLayerTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[1, 3, 5])
+        super().__init__(unit_test, activation_layers_idx=[1, 2, 3])
 
     def get_kpi(self):
         return KPI(np.inf, np.inf)
@@ -388,7 +390,7 @@ class MixedPrecisionActivationAddLayerTest(MixedPrecisionActivationBaseTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [8, 8, 8]))
 
         self.verify_quantization(quantized_model, input_x,
@@ -400,7 +402,7 @@ class MixedPrecisionActivationAddLayerTest(MixedPrecisionActivationBaseTest):
 
 class MixedPrecisionActivationMultipleInputsTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, num_calibration_iter=3, activation_layers_idx=[4, 5, 6, 7, 12, 13, 14, 15])
+        super().__init__(unit_test, num_calibration_iter=3, activation_layers_idx=[4, 5, 6, 7, 8, 9, 10, 11, 12])
         self.num_of_inputs = 4
         self.val_batch_size = 2
 
@@ -438,8 +440,8 @@ class MixedPrecisionActivationMultipleInputsTest(MixedPrecisionActivationBaseTes
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify chosen activation bitwidth config
         # kpi is infinity -> should give best model - 8bits
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in self.activation_layers_idx]
-        self.unit_test.assertTrue((activation_bits == [8, 8, 8, 8, 8, 8, 8, 8]))
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in self.activation_layers_idx]
+        self.unit_test.assertTrue((activation_bits == [8, 8, 8, 8, 8, 8, 8, 8, 8]))
 
         self.verify_quantization(quantized_model, input_x,
                                  weights_layers_idx=[],
@@ -450,19 +452,19 @@ class MixedPrecisionActivationMultipleInputsTest(MixedPrecisionActivationBaseTes
 
 class MixedPrecisionTotalKPISearchTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[3, 6])
+        super().__init__(unit_test, activation_layers_idx=[2, 4])
 
     def get_kpi(self):
         return KPI(np.inf, np.inf, total_memory=(17920 + 5408) * 4 / 8)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info: UserInformation = None):
         # verify chosen activation bitwidth config
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in
                            self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [4, 4]))
 
         self.verify_quantization(quantized_model, input_x,
-                                 weights_layers_idx=[2, 4],
+                                 weights_layers_idx=[2, 3],
                                  weights_layers_channels_size=[32, 32],
                                  activation_layers_idx=self.activation_layers_idx,
                                  unique_tensor_values=16)
@@ -477,7 +479,7 @@ class MixedPrecisionTotalKPISearchTest(MixedPrecisionActivationBaseTest):
 
 class MixedPrecisionMultipleKPIsTightSearchTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[3, 6])
+        super().__init__(unit_test, activation_layers_idx=[2, 4])
 
     def get_kpi(self):
         weights = 17920 * 4 / 8
@@ -486,12 +488,12 @@ class MixedPrecisionMultipleKPIsTightSearchTest(MixedPrecisionActivationBaseTest
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info: UserInformation = None):
         # verify chosen activation bitwidth config
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in
                            self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [4, 4]))
 
         self.verify_quantization(quantized_model, input_x,
-                                 weights_layers_idx=[2, 4],
+                                 weights_layers_idx=[2, 3],
                                  weights_layers_channels_size=[32, 32],
                                  activation_layers_idx=self.activation_layers_idx,
                                  unique_tensor_values=16)
@@ -506,7 +508,7 @@ class MixedPrecisionMultipleKPIsTightSearchTest(MixedPrecisionActivationBaseTest
 
 class MixedPrecisionReducedTotalKPISearchTest(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, activation_layers_idx=[3, 6])
+        super().__init__(unit_test, activation_layers_idx=[2, 4])
 
     def get_kpi(self):
         weights = 17920 * 4 / 8
@@ -515,12 +517,12 @@ class MixedPrecisionReducedTotalKPISearchTest(MixedPrecisionActivationBaseTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info: UserInformation = None):
         # verify chosen activation bitwidth config
-        activation_bits = [quantized_model.layers[i].inbound_nodes[0].call_kwargs.get('num_bits') for i in
+        activation_bits = [quantized_model.layers[i].activation_quantizers[0].get_config()['num_bits'] for i in
                            self.activation_layers_idx]
         self.unit_test.assertTrue((activation_bits == [2, 2]))
 
         self.verify_quantization(quantized_model, input_x,
-                                 weights_layers_idx=[2, 4],
+                                 weights_layers_idx=[2, 3],
                                  weights_layers_channels_size=[32, 32],
                                  activation_layers_idx=self.activation_layers_idx,
                                  unique_tensor_values=16)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_head_attention_test.py
@@ -29,7 +29,7 @@ layers = keras.layers
 class MultiHeadAttentionTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, input_shapes, num_heads, query_key_dim, value_dim,
                  attention_axes=None, separate_key_value=False, output_dim=None):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
         self.num_calibration_iter = 100
 
         query_input_shape, key_input_shape, value_input_shape = input_shapes

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multi_inputs_to_node_test.py
@@ -26,7 +26,7 @@ layers = keras.layers
 
 class MultiInputsToNodeTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         return get_16bit_tpc("multi_input_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_model_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_model_test.py
@@ -27,7 +27,7 @@ layers = keras.layers
 
 class MultipleInputsModelTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, num_of_inputs=3)
+        super().__init__(unit_test, num_of_inputs=3, experimental_exporter=True)
 
     def create_networks(self):
         inputs_1 = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_inputs_node_tests.py
@@ -27,7 +27,7 @@ layers = keras.layers
 
 class MultipleInputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         return get_16bit_tpc("multiple_inputs_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_outputs_node_tests.py
@@ -29,7 +29,7 @@ layers = keras.layers
 
 class MultipleOutputsNodeTests(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         return get_quantization_disabled_keras_tpc("multiple_outputs_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -36,7 +36,7 @@ layers = keras.layers
 
 class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         return get_16bit_tpc("nested_multi_inputs_test")
@@ -76,7 +76,7 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
             else:
                 self.unit_test.assertFalse(isinstance(l, Functional) or isinstance(l, Sequential))
         num_layers = 8
-        num_fq_layers = 7
+        num_fq_layers = 1
         self.unit_test.assertTrue(len(quantized_model.layers) == (num_layers+num_fq_layers))
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -36,7 +36,7 @@ layers = keras.layers
 
 class NestedModelMultipleOutputsTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test, val_batch_size=10)
+        super().__init__(unit_test, val_batch_size=10, experimental_exporter=True)
 
     def get_tpc(self):
         return get_16bit_tpc("nested_multi_outputs_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -38,7 +38,7 @@ class NestedModelUnusedInputsOutputsTest(BaseKerasFeatureNetworkTest):
     """
 
     def __init__(self, unit_test):
-        super().__init__(unit_test, input_shape=(16,16,3))
+        super().__init__(unit_test, input_shape=(16,16,3), experimental_exporter=True)
 
     def get_tpc(self):
         return get_quantization_disabled_keras_tpc("nested_model_unused_inputs_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -39,7 +39,8 @@ class NestedTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, is_inner_functional=True):
         self.is_inner_functional = is_inner_functional
         super().__init__(unit_test,
-                         input_shape=(16,16,3))
+                         input_shape=(16,16,3),
+                         experimental_exporter=True)
 
     def get_tpc(self):
         return get_quantization_disabled_keras_tpc("nested_test")
@@ -86,9 +87,9 @@ class NestedTest(BaseKerasFeatureNetworkTest):
             else:
                 self.unit_test.assertFalse(isinstance(l, Functional) or isinstance(l, Sequential))
         if self.is_inner_functional:
-            num_layers = 8
+            num_layers = 9
         else:
-            num_layers = 5
+            num_layers = 6
         self.unit_test.assertTrue(len(quantized_model.layers) == num_layers)
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
@@ -36,7 +36,8 @@ class EditActivationErrorMethod(BaseKerasFeatureNetworkTest):
 
     def __init__(self, unit_test):
         super().__init__(unit_test=unit_test,
-                         input_shape=(224, 224, 3))
+                         input_shape=(224, 224, 3),
+                         experimental_exporter=True)
 
     def generate_inputs(self):
         input_data = [np.full(shape=in_shape, fill_value=0.2) for in_shape in self.get_input_shapes()]
@@ -55,9 +56,8 @@ class EditActivationErrorMethod(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        input_q_params = quantized_model.layers[1].inbound_nodes[0].call_kwargs
-        threshold = input_q_params['max'] + (input_q_params['max'] - input_q_params['min']) / (
-                    2 ** input_q_params['num_bits'] - 1)
+        input_q_params = quantized_model.layers[1].activation_quantizers[0].get_config()
+        threshold = input_q_params['threshold']
         self.unit_test.assertTrue(threshold == 2,
                                   f'After editing input layer to no clipping error method,'
                                   f'threshold should be 2, but is {threshold}')

--- a/tests/keras_tests/feature_networks_tests/feature_networks/output_in_middle_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/output_in_middle_test.py
@@ -27,7 +27,7 @@ layers = keras.layers
 
 class OutputInMiddleTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -39,5 +39,5 @@ class OutputInMiddleTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         self.unit_test.assertTrue(len(quantized_model.outputs) == 2)
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
         self.unit_test.assertTrue(quantized_model.layers[2].output.ref() in [t.ref() for t in quantized_model.outputs])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/relu_replacement_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/relu_replacement_test.py
@@ -55,7 +55,7 @@ class SingleReluReplacementTest(BaseKerasFeatureNetworkTest):
     Test1: replacing a single Relu layer with identity layer
     """
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         return get_quantization_disabled_keras_tpc("single_relu_replacement_test")
@@ -67,8 +67,8 @@ class SingleReluReplacementTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[1], Identity))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.ReLU))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, Identity))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.ReLU))
 
     def get_debug_config(self):
         return mct.DebugConfig(network_editor=[EditRule(filter=NodeNameFilter('ReLU_1'),
@@ -85,8 +85,8 @@ class ReluReplacementTest(SingleReluReplacementTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         self.unit_test.assertTrue(np.isclose(0, np.mean(quantized_model.predict(input_x) - input_x)))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[1], Identity))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], Identity))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, Identity))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, Identity))
 
     def get_debug_config(self):
         #   replace all Relu's with identity custom layer
@@ -132,10 +132,10 @@ class ReluReplacementWithAddBiasTest(SingleReluReplacementTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         self.unit_test.assertTrue(np.isclose(6, np.mean(quantized_model.predict(input_x) - input_x)))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[1], AddBias))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], AddBias))
-        self.unit_test.assertTrue(quantized_model.layers[1].bias == 0)
-        self.unit_test.assertTrue(quantized_model.layers[2].bias == 6)
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, AddBias))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, AddBias))
+        self.unit_test.assertTrue(quantized_model.layers[2].layer.bias == 0)
+        self.unit_test.assertTrue(quantized_model.layers[3].layer.bias == 6)
 
     def get_debug_config(self):
         return mct.DebugConfig(network_editor=[EditRule(filter=NodeTypeFilter(layers.ReLU),

--- a/tests/keras_tests/feature_networks_tests/feature_networks/residual_collapsing_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/residual_collapsing_test.py
@@ -28,7 +28,9 @@ tp = mct.target_platform
 class BaseResidualCollapsingTest(BaseKerasFeatureNetworkTest):
 
     def __init__(self, unit_test):
-        super(BaseResidualCollapsingTest, self).__init__(unit_test=unit_test, input_shape=(16,16,3))
+        super(BaseResidualCollapsingTest, self).__init__(unit_test=unit_test,
+                                                         input_shape=(16,16,3),
+                                                         experimental_exporter=True)
 
     def get_tpc(self):
         tp = generate_test_tp_model({'weights_n_bits': 32,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
@@ -30,7 +30,7 @@ layers = keras.layers
 
 class ReusedLayerMixedPrecisionTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         base_config, _ = get_op_quantization_configs()
@@ -66,13 +66,13 @@ class ReusedLayerMixedPrecisionTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         if isinstance(float_model.layers[1], layers.Conv2D):
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
+            self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
             self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
         if isinstance(float_model.layers[1], layers.SeparableConv2D):
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.DepthwiseConv2D))
+            self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
             self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[4], layers.Conv2D))
-            self.unit_test.assertFalse(hasattr(quantized_model.layers[4], 'input_shape'))  # assert it's reused
+            self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.Conv2D))
+            self.unit_test.assertFalse(hasattr(quantized_model.layers[3].layer, 'input_shape'))  # assert it's reused
 
 
 class ReusedSeparableMixedPrecisionTest(ReusedLayerMixedPrecisionTest):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_test.py
@@ -27,7 +27,7 @@ layers = keras.layers
 
 class ReusedLayerTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def create_networks(self):
         conv_layer = layers.Conv2D(3, 4)
@@ -38,5 +38,6 @@ class ReusedLayerTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.Conv2D))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
         self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
+        self.unit_test.assertFalse(hasattr(quantized_model.layers[2].layer, 'input_shape'))  # assert it's reused

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_separable_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_separable_test.py
@@ -27,7 +27,7 @@ layers = keras.layers
 
 class ReusedSeparableTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def create_networks(self):
         reused_layer = layers.SeparableConv2D(3, 3)
@@ -38,8 +38,8 @@ class ReusedSeparableTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        assert len(quantized_model.layers) == 8  # input, fq_input, dw, fq1_dw, fq2_dw, pw, fq1_pw, fq2_pw,
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], layers.DepthwiseConv2D))
+        assert len(quantized_model.layers) == 4  # input, fq_input, dw, pw
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
         self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[4], layers.Conv2D))
-        self.unit_test.assertFalse(hasattr(quantized_model.layers[4], 'input_shape'))  # assert it's reused
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.Conv2D))
+        self.unit_test.assertFalse(hasattr(quantized_model.layers[3], 'input_shape'))  # assert it's reused

--- a/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/scale_equalization_test.py
@@ -46,7 +46,9 @@ class ScaleEqualizationTest(BaseKerasFeatureNetworkTest):
         self.second_op2d.kernel_initializer = w_init()
         self.zero_pad = zero_pad
         super().__init__(unit_test,
-                         input_shape=(16, 16, 3))
+                         input_shape=(16, 16, 3),
+                         # TODO: fix with new_experimental_exporter
+                         experimental_exporter=False)
 
     def get_tpc(self):
         return get_16bit_tpc("scale_equalization_bound_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 
 from model_compression_toolkit.core.common.constants import SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS
 from model_compression_toolkit.core.common.network_editors import EditRule, node_filters, actions
+from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.core.tpc_models.default_tpc.latest import get_keras_tpc_latest
 from tests.keras_tests.tpc_keras import get_16bit_tpc
 from packaging import version
@@ -41,7 +42,7 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
         self.use_pad_layer = use_pad_layer
         self.bypass_op_list = bypass_op_list
         self.param_search = param_search
-        super().__init__(unit_test, input_shape=input_shape, num_calibration_iter=100)
+        super().__init__(unit_test, input_shape=input_shape, num_calibration_iter=100, experimental_exporter=True)
 
     def get_tpc(self):
         return get_16bit_tpc("shift_negative_test")
@@ -71,24 +72,22 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
             _, w, b = float_model.get_weights()
         else:
             w, b = float_model.get_weights()
-        linear_op_index = 3 + (4 if self.use_pad_layer else 3)
+        linear_op_index = 3 + (2 if self.use_pad_layer else 1)
         if self.bypass_op_list:
             for bypass_op in self.bypass_op_list:
                 # add bypass nodes
                 linear_op_index = linear_op_index + 1
                 if isinstance(bypass_op, layers.GlobalAveragePooling2D):
-                    fq_layer = quantized_model.layers[linear_op_index]
-                    self.unit_test.assertTrue(isinstance(fq_layer, TFOpLambda) and
-                                              fq_layer.function is tf.quantization.fake_quant_with_min_max_vars)
-                    self.unit_test.assertTrue(fq_layer.inbound_nodes[0].call_kwargs['min'] == 0)
-                    linear_op_index = linear_op_index + 1
+                    avg_layer = quantized_model.layers[linear_op_index-1]
+                    self.unit_test.assertTrue(avg_layer.activation_quantizers[0].get_config()['signed'] == False)
 
         linear_op_index = linear_op_index + int(self.linear_op_to_test.get_config().get('padding') == 'same')
-        q_w, q_b = quantized_model.layers[linear_op_index].weights[0].numpy(), \
-                   quantized_model.layers[linear_op_index].weights[1].numpy()
+        attr = DEFAULT_KERAS_INFO.get_kernel_op_attributes(quantized_model.layers[linear_op_index].layer.__class__)[0]
+        q_w, q_b = quantized_model.layers[linear_op_index].get_quantized_weights()[attr].numpy(), \
+                   quantized_model.layers[linear_op_index].layer.bias.numpy()
         # Take the ACTUAL value the activations were shifted by, from the Add layer the substitution needs to insert
-        add_layer_index = 4  # should be always the fourth layer (input, fq, swish, add)
-        shift_nl_out = quantized_model.layers[add_layer_index].inbound_nodes[0].call_args[1]
+        add_layer_index = 3  # should be always the fourth layer (input, fq, swish, add)
+        shift_nl_out = quantized_model.layers[add_layer_index].layer.inbound_nodes[0].call_args[1]
         if isinstance(self.linear_op_to_test, layers.DepthwiseConv2D):
             self.unit_test.assertTrue(np.allclose(b - q_b, shift_nl_out * np.sum(w, axis=(0, 1)).flatten()))
         elif isinstance(self.linear_op_to_test, layers.Conv2D):
@@ -124,14 +123,14 @@ class ShiftNegActivationPostAddTest(ShiftNegActivationTest):
         self.unit_test.assertTrue(float_model.output.shape.as_list() == quantized_model.output.shape.as_list(),
                                   msg=f'Outputs shape mismatch: {float_model.output.shape} != {quantized_model.output.shape}')
 
-        non_linear_layer_fake_quant = quantized_model.layers[3]
-        non_linear_nbits = non_linear_layer_fake_quant.inbound_nodes[0].call_kwargs.get('num_bits')
+        non_linear_layer_fake_quant = quantized_model.layers[2]
+        non_linear_nbits = non_linear_layer_fake_quant.activation_quantizers[0].get_config()['num_bits']
         self.unit_test.assertTrue(non_linear_nbits == SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS,
                                   f"The non-linear node's activation_n_bits after applying snc should be "
                                   f"{SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS}, but activation_n_bits is {non_linear_nbits}")
 
-        post_add_layer_fake_quant = quantized_model.layers[5]
-        post_add_nbits = post_add_layer_fake_quant.inbound_nodes[0].call_kwargs.get('num_bits')
+        post_add_layer_fake_quant = quantized_model.layers[3]
+        post_add_nbits = post_add_layer_fake_quant.activation_quantizers[0].get_config()['num_bits']
         self.unit_test.assertTrue(post_add_nbits == self.post_add_nbits,
                                   f"The post_add layer that's added after the non-linear node "
                                   f"should be quantized with {self.post_add_nbits}, "

--- a/tests/keras_tests/feature_networks_tests/feature_networks/softmax_shift_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/softmax_shift_test.py
@@ -32,7 +32,7 @@ class SoftmaxShiftTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, kernel_op_layer, activation_function):
         self.activation_function = activation_function
         self.kernel_op_layer = kernel_op_layer
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -49,13 +49,13 @@ class SoftmaxShiftTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         if self.kernel_op_layer.__getattribute__('activation') == keras_softmax:
-            quant_bias = quantized_model.layers[-4].bias
+            quant_bias = quantized_model.layers[2].layer.bias
             float_bias = float_model.layers[-1].bias
             diff_bias = float_bias - quant_bias
             mean_diff_bias = np.mean(diff_bias)
             self.unit_test.assertTrue(np.allclose(diff_bias, mean_diff_bias, atol=1e-1))
         else:
-            quant_bias = quantized_model.layers[-5].bias
+            quant_bias = quantized_model.layers[2].layer.bias
             float_bias = float_model.layers[1].bias
             diff_bias = float_bias - quant_bias
             mean_diff_bias = np.mean(diff_bias)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_concatenate_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_concatenate_test.py
@@ -24,7 +24,7 @@ layers = keras.layers
 
 class SplitConcatenateTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -36,16 +36,16 @@ class SplitConcatenateTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(quantized_model.layers[4].function == tf.split)
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[5], layers.Conv2D))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[6], layers.Conv2D))
-        self.unit_test.assertTrue(quantized_model.layers[7].function == tf.quantization.fake_quant_with_min_max_vars)
-        self.unit_test.assertTrue(quantized_model.layers[8].function == tf.quantization.fake_quant_with_min_max_vars)
+        self.unit_test.assertTrue(quantized_model.layers[3].layer.function == tf.split)
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[4].layer, layers.Conv2D))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[5].layer, layers.Conv2D))
+        self.unit_test.assertTrue(quantized_model.layers[4].activation_quantizers[0].get_config()['num_bits'] == 8)
+        self.unit_test.assertTrue(quantized_model.layers[5].activation_quantizers[0].get_config()['num_bits'] == 8)
 
-        self.unit_test.assertTrue(quantized_model.layers[4].output[1].ref() == quantized_model.layers[5].input.ref())
-        self.unit_test.assertTrue(quantized_model.layers[4].output[3].ref() == quantized_model.layers[6].input.ref())
+        self.unit_test.assertTrue(quantized_model.layers[3].output[1].ref() == quantized_model.layers[4].input.ref())
+        self.unit_test.assertTrue(quantized_model.layers[3].output[3].ref() == quantized_model.layers[5].input.ref())
 
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[9], layers.Concatenate))
-        self.unit_test.assertTrue(len(quantized_model.layers[9].input) == 2)
-        self.unit_test.assertTrue(quantized_model.layers[9].input[0].ref() == quantized_model.layers[7].output.ref())
-        self.unit_test.assertTrue(quantized_model.layers[9].input[1].ref() == quantized_model.layers[8].output.ref())
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[6].layer, layers.Concatenate))
+        self.unit_test.assertTrue(len(quantized_model.layers[6].input) == 2)
+        self.unit_test.assertTrue(quantized_model.layers[6].input[0].ref() == quantized_model.layers[4].output.ref())
+        self.unit_test.assertTrue(quantized_model.layers[6].input[1].ref() == quantized_model.layers[5].output.ref())

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_conv_bug_test.py
@@ -27,7 +27,7 @@ layers = keras.layers
 
 class SplitConvBugTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
 
     def get_tpc(self):
         return get_16bit_tpc("split_conv_bug_test")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -29,7 +29,7 @@ layers = keras.layers
 
 class SymmetricThresholdSelectionActivationTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, activation_threshold_method):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
         self.activation_threshold_method = activation_threshold_method
 
     def generate_inputs(self):
@@ -52,33 +52,29 @@ class SymmetricThresholdSelectionActivationTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify threshold not power of 2 and unsigned symmetric range for first two layers' activations
-        fake_layer_input_args = quantized_model.layers[1].inbound_nodes[0].call_kwargs
-        fake_layer_relu_args = quantized_model.layers[3].inbound_nodes[0].call_kwargs
+        fake_layer_input_args = quantized_model.layers[1].activation_quantizers[0].get_config()
+        fake_layer_relu_args = quantized_model.layers[2].activation_quantizers[0].get_config()
 
-        threshold_input = fake_layer_input_args['max'] / (2 ** fake_layer_input_args['num_bits'] - 1) \
-                          + fake_layer_input_args['max']
-        threshold_relu = fake_layer_relu_args['max'] / (2 ** fake_layer_relu_args['num_bits'] - 1) \
-                         + fake_layer_relu_args['max']
+        threshold_input = fake_layer_input_args['threshold'][0]
+        threshold_relu = fake_layer_relu_args['threshold'][0]
 
         self.unit_test.assertFalse(
             np.log2(threshold_input).is_integer(), msg=f"Input layer threshold {threshold_input} is a power of 2")
         self.unit_test.assertFalse(
             np.log2(threshold_relu).is_integer(), msg=f"ReLU layer threshold {threshold_relu} is a power of 2")
 
-        self.unit_test.assertTrue(fake_layer_relu_args['min'] == 0,
-                                  msg=f"Lower bound of ReLU layer unsigned symmetric range is "
-                                      f"{fake_layer_relu_args['min']} (expected: 0)")
+        self.unit_test.assertTrue(fake_layer_relu_args['signed'] == False,
+                                  msg=f"ReLU expected to have unsigned symmetric quantization param but is signed")
 
         # verify threshold not power of 2 and signed symmetric range for first Add activation layer
-        fake_layer_add_args = quantized_model.layers[5].inbound_nodes[0].call_kwargs
+        fake_layer_add_args = quantized_model.layers[3].activation_quantizers[0].get_config()
 
-        threshold_add = fake_layer_add_args['max'] / (2 ** fake_layer_add_args['num_bits'] - 1) \
-                        + fake_layer_add_args['max']
+        threshold_add = fake_layer_add_args['threshold'][0]
+
         self.unit_test.assertFalse(
             np.log2(threshold_input).is_integer(), msg=f"Add layer threshold {threshold_add} is a power of 2")
-        self.unit_test.assertTrue(fake_layer_add_args['min'] < 0,
-                                  msg=f"Lower bound of Add layer signed symmetric range "
-                                      f"{fake_layer_add_args['min']} is not negative")
+        self.unit_test.assertTrue(fake_layer_add_args['signed'] == True,
+                                  msg=f"Add expected to have signed quantization range but is unsigned")
 
 
 class SymmetricThresholdSelectionBoundedActivationTest(SymmetricThresholdSelectionActivationTest):
@@ -92,13 +88,11 @@ class SymmetricThresholdSelectionBoundedActivationTest(SymmetricThresholdSelecti
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        fake_layer_input_args = quantized_model.layers[1].inbound_nodes[0].call_kwargs
-        fake_layer_softmax_args = quantized_model.layers[3].inbound_nodes[0].call_kwargs
+        fake_layer_input_args = quantized_model.layers[1].activation_quantizers[0].get_config()
+        fake_layer_softmax_args = quantized_model.layers[2].activation_quantizers[0].get_config()
 
-        threshold_input = ((2 ** fake_layer_input_args['num_bits'] - 1) *
-                           fake_layer_input_args['max']) / ((2 ** fake_layer_input_args['num_bits']) - 2)
-        threshold_softmax = ((2 ** fake_layer_softmax_args['num_bits']) *
-                             fake_layer_softmax_args['max']) / ((2 ** fake_layer_softmax_args['num_bits']) - 1)
+        threshold_input = fake_layer_input_args['threshold'][0]
+        threshold_softmax = fake_layer_softmax_args['threshold'][0]
 
         # Verify threshold not power of 2
         self.unit_test.assertFalse(
@@ -109,9 +103,7 @@ class SymmetricThresholdSelectionBoundedActivationTest(SymmetricThresholdSelecti
                                   msg=f"Threshold of Softmax layer is {threshold_softmax} (expected: 1)")
 
         # Verify min/max is bounded by 0 and 1
-        self.unit_test.assertTrue(fake_layer_softmax_args['min'] == 0,
-                                  msg=f"Lower bound of Softmax layer unsigned symmetric range is "
-                                      f"{fake_layer_softmax_args['min']} (expected: 0)")
-        self.unit_test.assertTrue(fake_layer_softmax_args['max'] == 1.0 - 1/(2 ** fake_layer_softmax_args['num_bits']),
-                                  msg=f"Upper bound of Softmax layer is {fake_layer_softmax_args['max']} "
-                                      f"(expected: 1 - delta)")
+        self.unit_test.assertTrue(fake_layer_softmax_args['signed'] == False,
+                                  msg=f"Softmax layer symmetric range is signed. Expected to be unsigned")
+        self.unit_test.assertTrue(fake_layer_softmax_args['threshold'] == 1.0,
+                                  msg=f"Softmax layer threshold is {fake_layer_softmax_args['threshold']}. Expected to be 1")

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -58,7 +58,7 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
         self.num_conv_channels = 4
         self.kernel = 3
         self.conv_w = weight_fn(self.kernel, self.num_conv_channels, self.num_conv_channels)
-        super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32)
+        super().__init__(unit_test, num_calibration_iter=5, val_batch_size=32, experimental_exporter=False)
 
     def get_tpc(self):
         tp = generate_test_tp_model({'weights_quantization_method': self.quantization_method,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -29,7 +29,7 @@ tp = mct.target_platform
 
 class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, activation_threshold_method):
-        super().__init__(unit_test)
+        super().__init__(unit_test, experimental_exporter=True)
         self.activation_threshold_method = activation_threshold_method
 
     def generate_inputs(self):
@@ -52,11 +52,11 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify quantization range contains zero
-        fake_layer_input_args = quantized_model.layers[1].inbound_nodes[0].call_kwargs
-        fake_layer_add_args = quantized_model.layers[5].inbound_nodes[0].call_kwargs
+        fake_layer_input_args = quantized_model.layers[1].activation_quantizers[0].get_config()
+        fake_layer_add_args = quantized_model.layers[3].activation_quantizers[0].get_config()
 
-        input_layer_min, input_layer_max = fake_layer_input_args['min'], fake_layer_input_args['max']
-        add_layer_min, add_layer_max = fake_layer_add_args['min'], fake_layer_add_args['max']
+        input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
+        add_layer_min, add_layer_max = fake_layer_add_args['min_range'], fake_layer_add_args['max_range']
 
         self.unit_test.assertTrue(input_layer_min <= 0.0 <= input_layer_max,
                                   msg=f"0.0 is not within the quantization range ({input_layer_min}, {input_layer_max}) "
@@ -77,11 +77,11 @@ class UniformRangeSelectionBoundedActivationTest(UniformRangeSelectionActivation
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        fake_layer_input_args = quantized_model.layers[1].inbound_nodes[0].call_kwargs
-        fake_layer_softmax_args = quantized_model.layers[3].inbound_nodes[0].call_kwargs
+        fake_layer_input_args = quantized_model.layers[1].activation_quantizers[0].get_config()
+        fake_layer_softmax_args = quantized_model.layers[2].activation_quantizers[0].get_config()
 
-        input_layer_min, input_layer_max = fake_layer_input_args['min'], fake_layer_input_args['max']
-        softmax_layer_min, softmax_layer_max = fake_layer_softmax_args['min'], fake_layer_softmax_args['max']
+        input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
+        softmax_layer_min, softmax_layer_max = fake_layer_softmax_args['min_range'], fake_layer_softmax_args['max_range']
 
         # Verify quantization range contains zero
         self.unit_test.assertTrue(input_layer_min <= 0.0 <= input_layer_max,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
@@ -34,7 +34,7 @@ tp = mct.target_platform
 
 class MixedPercisionBaseTest(BaseKerasFeatureNetworkTest):
     def __init__(self, unit_test, val_batch_size=1):
-        super().__init__(unit_test, val_batch_size=val_batch_size)
+        super().__init__(unit_test, val_batch_size=val_batch_size, experimental_exporter=True)
 
     def get_quantization_config(self):
         return mct.QuantizationConfig(mct.QuantizationErrorMethod.MSE,
@@ -109,10 +109,10 @@ class MixedPercisionSearchTest(MixedPercisionBaseTest):
                                                           0]).all()  # kpi is infinity -> should give best model - 8bits
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[2].weights[0][:, :, :, i]).flatten().shape[0] <= 256)
+                np.unique(quantized_model.layers[2].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[4].weights[0][:, :, :, i]).flatten().shape[0] <= 256)
+                np.unique(quantized_model.layers[3].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
 
         # Verify final KPI
         self.unit_test.assertTrue(
@@ -134,10 +134,10 @@ class MixedPercisionSearchKPI4BitsAvgTest(MixedPercisionBaseTest):
         assert (quantization_info.mixed_precision_cfg == [1, 1]).all()
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[2].weights[0][:, :, :, i]).flatten().shape[0] <= 16)
+                np.unique(quantized_model.layers[2].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 16)
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[4].weights[0][:, :, :, i]).flatten().shape[0] <= 16)
+                np.unique(quantized_model.layers[3].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 16)
 
         # Verify final KPI
         self.unit_test.assertTrue(
@@ -159,10 +159,10 @@ class MixedPercisionSearchKPI2BitsAvgTest(MixedPercisionBaseTest):
         assert (quantization_info.mixed_precision_cfg == [2, 2]).all()
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[2].weights[0][:, :, :, i]).flatten().shape[0] <= 4)
+                np.unique(quantized_model.layers[2].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 4)
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[4].weights[0][:, :, :, i]).flatten().shape[0] <= 4)
+                np.unique(quantized_model.layers[3].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 4)
 
         # Verify final KPI
         self.unit_test.assertTrue(
@@ -230,10 +230,10 @@ class MixedPercisionDepthwiseTest(MixedPercisionBaseTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], DepthwiseConv2D))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, DepthwiseConv2D))
         self.unit_test.assertTrue(len(quantization_info.mixed_precision_cfg) == 1)
         self.unit_test.assertTrue(quantization_info.mixed_precision_cfg[0] == 0) # Assert model is quantized using 16 bits as KPI is inf
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[3], ReLU))
+        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, ReLU))
 
     def get_tpc(self):
         base_config, _ = get_op_quantization_configs()
@@ -290,10 +290,10 @@ class MixedPrecisionActivationDisabled(MixedPercisionBaseTest):
                                                           0]).all()  # kpi is infinity -> should give best model - 8bits
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[1].weights[0][:, :, :, i]).flatten().shape[0] <= 256)
+                np.unique(quantized_model.layers[2].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[2].weights[0][:, :, :, i]).flatten().shape[0] <= 256)
+                np.unique(quantized_model.layers[3].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
 
 
 class MixedPercisionSearchLastLayerDistanceTest(MixedPercisionBaseTest):
@@ -314,10 +314,10 @@ class MixedPercisionSearchLastLayerDistanceTest(MixedPercisionBaseTest):
                                                           0]).all()  # kpi is infinity -> should give best model - 8bits
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[2].weights[0][:, :, :, i]).flatten().shape[0] <= 256)
+                np.unique(quantized_model.layers[2].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
-                np.unique(quantized_model.layers[4].weights[0][:, :, :, i]).flatten().shape[0] <= 256)
+                np.unique(quantized_model.layers[3].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
 
         # Verify final KPI
         self.unit_test.assertTrue(

--- a/tests/keras_tests/function_tests/test_get_gptq_config.py
+++ b/tests/keras_tests/function_tests/test_get_gptq_config.py
@@ -126,7 +126,8 @@ class TestGetGPTQConfig(unittest.TestCase):
                                                                    representative_data_gen=random_datagen_experimental,
                                                                    core_config=self.cc,
                                                                    gptq_config=gptq_config,
-                                                                   target_platform_capabilities=self.pot_weights_tpc)
+                                                                   target_platform_capabilities=self.pot_weights_tpc,
+                                                                   new_experimental_exporter=True)
 
         tf.config.run_functions_eagerly(False)
 
@@ -140,7 +141,8 @@ class TestGetGPTQConfig(unittest.TestCase):
                                                                    representative_data_gen=random_datagen_experimental,
                                                                    core_config=self.cc,
                                                                    gptq_config=gptq_config,
-                                                                   target_platform_capabilities=self.symmetric_weights_tpc)
+                                                                   target_platform_capabilities=self.symmetric_weights_tpc,
+                                                                   new_experimental_exporter=True)
 
         tf.config.run_functions_eagerly(False)
 

--- a/tests/keras_tests/function_tests/test_keras_tp_model.py
+++ b/tests/keras_tests/function_tests/test_keras_tp_model.py
@@ -234,14 +234,16 @@ class TestGetKerasTPC(unittest.TestCase):
 
         quantized_model, _ = mct.keras_post_training_quantization_experimental(model,
                                                                                rep_data,
-                                                                               target_platform_capabilities=tpc)
+                                                                               target_platform_capabilities=tpc,
+                                                                               new_experimental_exporter=True)
 
         core_config = mct.CoreConfig(mixed_precision_config=mct.MixedPrecisionQuantizationConfigV2(num_of_images=1))
         quantized_model, _ = mct.keras_post_training_quantization_experimental(model,
                                                                                rep_data,
                                                                                core_config=core_config,
                                                                                target_kpi=mct.KPI(np.inf),
-                                                                               target_platform_capabilities=tpc)
+                                                                               target_platform_capabilities=tpc,
+                                                                               new_experimental_exporter=True)
 
     def test_get_keras_supported_version(self):
         tpc = mct.get_target_platform_capabilities(TENSORFLOW, DEFAULT_TP_MODEL)  # Latest

--- a/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_kl_error_quantization_configurations.py
@@ -72,7 +72,8 @@ class TestQuantizationConfigurations(unittest.TestCase):
             q_model, quantization_info = mct.keras_post_training_quantization_experimental(model,
                                                                                            representative_data_gen,
                                                                                            core_config=core_config,
-                                                                                           target_platform_capabilities=tpc)
+                                                                                           target_platform_capabilities=tpc,
+                                                                                           new_experimental_exporter=True)
 
         model = model_gen()
         for quantize_method, error_method, relu_bound_to_power_of_2 in activation_test_combinations:
@@ -91,7 +92,8 @@ class TestQuantizationConfigurations(unittest.TestCase):
             q_model, quantization_info = mct.keras_post_training_quantization_experimental(model,
                                                                                            representative_data_gen,
                                                                                            core_config=core_config,
-                                                                                           target_platform_capabilities=tpc)
+                                                                                           target_platform_capabilities=tpc,
+                                                                                           new_experimental_exporter=True)
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/function_tests/test_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_quantization_configurations.py
@@ -81,7 +81,8 @@ class TestQuantizationConfigurations(unittest.TestCase):
             q_model, quantization_info = mct.keras_post_training_quantization_experimental(model,
                                                                                            representative_data_gen,
                                                                                            core_config=core_config,
-                                                                                           target_platform_capabilities=tpc)
+                                                                                           target_platform_capabilities=tpc,
+                                                                                           new_experimental_exporter=True)
 
         model = model_gen()
         for quantize_method, error_method, relu_bound_to_power_of_2, shift_negative_correction in activation_test_combinations:
@@ -102,7 +103,8 @@ class TestQuantizationConfigurations(unittest.TestCase):
             q_model, quantization_info = mct.keras_post_training_quantization_experimental(model,
                                                                                            representative_data_gen,
                                                                                            core_config=core_config,
-                                                                                           target_platform_capabilities=tpc)
+                                                                                           target_platform_capabilities=tpc,
+                                                                                           new_experimental_exporter=True)
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/function_tests/test_tensorboard_writer.py
+++ b/tests/keras_tests/function_tests/test_tensorboard_writer.py
@@ -139,7 +139,8 @@ class TestFileLogger(unittest.TestCase):
                                                                                rep_data,
                                                                                target_kpi=mct.KPI(np.inf),
                                                                                core_config=core_config,
-                                                                               target_platform_capabilities=tpc)
+                                                                               target_platform_capabilities=tpc,
+                                                                               new_experimental_exporter=True)
 
         self.tensorboard_initial_graph_num_of_nodes(num_event_files=1, event_to_test=0)
 
@@ -152,7 +153,8 @@ class TestFileLogger(unittest.TestCase):
                                                                                rep_data,
                                                                                target_kpi=mct.KPI(np.inf),
                                                                                core_config=core_config,
-                                                                               target_platform_capabilities=tpc)
+                                                                               target_platform_capabilities=tpc,
+                                                                               new_experimental_exporter=True)
 
         # Test tensor size plotting
         self.plot_tensor_sizes()

--- a/tests/keras_tests/graph_tests/test_graph_quantization_and_export.py
+++ b/tests/keras_tests/graph_tests/test_graph_quantization_and_export.py
@@ -29,7 +29,7 @@ class TestTFLiteExport(unittest.TestCase):
         def rep_data():
             yield [np.random.randn(1, 224, 224, 3)]
 
-        quantized_model, _ = mct.keras_post_training_quantization_experimental(model, rep_data)
+        quantized_model, _ = mct.keras_post_training_quantization_experimental(model, rep_data, new_experimental_exporter=True)
 
         converter = tf.lite.TFLiteConverter.from_keras_model(quantized_model)
         quantized_tflite_model = converter.convert()

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -62,7 +62,8 @@ class BaseKerasLayerTest(BaseLayerTest):
                  input_shape: Tuple[int, int, int] = (8, 8, 3),
                  quantization_modes: List[LayerTestMode] = [LayerTestMode.FLOAT, LayerTestMode.QUANTIZED_8_BITS],
                  is_inputs_a_list: bool = False,
-                 use_cpu: bool = False):
+                 use_cpu: bool = False,
+                 experimental_exporter: bool = True):
 
         super().__init__(unit_test=unit_test,
                          layers=layers,
@@ -72,7 +73,8 @@ class BaseKerasLayerTest(BaseLayerTest):
                          input_shape=input_shape,
                          quantization_modes=quantization_modes,
                          is_inputs_a_list=is_inputs_a_list,
-                         use_cpu=use_cpu)
+                         use_cpu=use_cpu,
+                         experimental_exporter=experimental_exporter)
 
     def get_tpc(self):
         if self.current_mode == LayerTestMode.FLOAT:

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -1,12 +1,14 @@
 from typing import List, Any, Tuple
 
+import keras.layers
 import tensorflow as tf
-
+from keras.engine.base_layer import Layer
 
 from model_compression_toolkit.core.tpc_models.default_tpc.latest import generate_keras_tpc
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from tests.keras_tests.tpc_keras import get_quantization_disabled_keras_tpc
 from packaging import version
+import model_compression_toolkit as mct
 
 if version.parse(tf.__version__) < version.parse("2.6"):
     from tensorflow.python.keras.layers.core import TFOpLambda
@@ -140,44 +142,52 @@ class BaseKerasLayerTest(BaseLayerTest):
     def __compare_8bits_quantization_mode(self, float_model, quantized_model):
         fw_info = self.get_fw_info()
         for layer in quantized_model.layers:
-            op = layer.function if isinstance(layer, TFOpLambda) else type(layer)
-            if op in KERAS_LAYER_TEST_OPS['kernel_ops']:
-                for attr in fw_info.get_kernel_op_attributes(type(layer)):
-                    self.unit_test.assertTrue(np.sum(np.abs(
-                        getattr(layer, attr) - getattr(float_model.get_layer(layer.name), attr))) > 0.0)
-                for next_layer in [node.layer for node in layer.outbound_nodes]:
-                    self.unit_test.assertTrue(is_layer_fake_quant(next_layer))
+            if not isinstance(layer, InputLayer):
+                assert isinstance(layer, mct.quantizers_infrastructure.KerasQuantizationWrapper)
+                internal_layer = layer.layer
+                op = internal_layer.function if isinstance(internal_layer, TFOpLambda) else type(internal_layer)
+                if op in KERAS_LAYER_TEST_OPS['kernel_ops']:
+                    assert len(layer.activation_quantizers) > 0
+                    for q in layer.activation_quantizers:
+                        assert q.get_config()['num_bits'] == 8
+                    for attr in fw_info.get_kernel_op_attributes(type(internal_layer)):
+                        self.unit_test.assertTrue(np.sum(np.abs(
+                            layer.get_quantized_weights()[attr] - getattr(float_model.get_layer(internal_layer.name), attr))) > 0.0)
 
-            elif op in KERAS_LAYER_TEST_OPS['activation']:
-                for next_layer in [node.layer for node in layer.outbound_nodes]:
-                    self.unit_test.assertTrue(is_layer_fake_quant(next_layer))
+                elif op in KERAS_LAYER_TEST_OPS['no_quantization']:
+                    assert len(layer.activation_quantizers) == 0
 
-            elif op in KERAS_LAYER_TEST_OPS['no_quantization']:
-                for next_layer in [node.layer for node in layer.outbound_nodes]:
-                    self.unit_test.assertFalse(is_layer_fake_quant(next_layer))
+                elif op in KERAS_LAYER_TEST_OPS['activation'] or type(internal_layer)==Layer:
+                    assert len(layer.activation_quantizers) > 0
+                    for q in layer.activation_quantizers:
+                        assert q.get_config()['num_bits'] == 8
 
-            else:
-                raise Exception('Layer is not in framework info')
+                else:
+                    raise Exception('Layer is not in framework info')
 
     def __compare_float_mode(self, float_model, quantized_model):
         for layer_index, layer in enumerate(quantized_model.layers):
             # Check there are no fake-quant layers
             self.unit_test.assertFalse(is_layer_fake_quant(layer))
-            # check unchanged weights
-            if hasattr(layer, 'weights') and len(layer.weights) > 0:
-                for i, w in enumerate(layer.weights):
-                    self.unit_test.assertTrue(np.sum(np.abs(w - float_model.layers[layer_index].weights[i])) == 0.0)
+            if not isinstance(layer, InputLayer):
+                assert isinstance(layer, mct.quantizers_infrastructure.KerasQuantizationWrapper)
+                assert len(layer.activation_quantizers) == 0
+                assert len(layer.weights_quantizers.keys()) == 0
+                # check unchanged weights
+                if hasattr(layer.layer, 'weights') and len(layer.layer.weights) > 0:
+                    for i, w in enumerate(layer.layer.weights):
+                        self.unit_test.assertTrue(np.sum(np.abs(w - float_model.layers[layer_index-1].weights[i])) == 0.0)
 
-            input_tensors = self.generate_inputs()
-            y = self.predict(float_model, input_tensors)
-            y_hat = self.predict(quantized_model, input_tensors)
-            if isinstance(y, list):
-                for fo, qo in zip(y, y_hat):
-                    distance = np.sum(np.abs(fo - qo))
-                    self.unit_test.assertTrue(distance == 0,
-                                              msg=f'Outputs should be identical. Observed distance: {distance}')
-
-            else:
-                distance = np.sum(np.abs(y - y_hat))
+        input_tensors = self.generate_inputs()
+        y = self.predict(float_model, input_tensors)
+        y_hat = self.predict(quantized_model, input_tensors)
+        if isinstance(y, list):
+            for fo, qo in zip(y, y_hat):
+                distance = np.sum(np.abs(fo - qo))
                 self.unit_test.assertTrue(distance == 0,
                                           msg=f'Outputs should be identical. Observed distance: {distance}')
+
+        else:
+            distance = np.sum(np.abs(y - y_hat))
+            self.unit_test.assertTrue(distance == 0,
+                                      msg=f'Outputs should be identical. Observed distance: {distance}')

--- a/tests/keras_tests/models_tests/test_networks_runner.py
+++ b/tests/keras_tests/models_tests/test_networks_runner.py
@@ -109,12 +109,14 @@ class NetworkTest:
                                                                                                       core_config=core_config,
                                                                                                       fw_info=DEFAULT_KERAS_INFO,
                                                                                                       gptq_config=arc2,
-                                                                                                      target_platform_capabilities=tpc)
+                                                                                                      target_platform_capabilities=tpc,
+                                                                                                      new_experimental_exporter=True)
         else:
             ptq_model, quantization_info = mct.keras_post_training_quantization_experimental(self.model_float,
                                                                                              representative_data_gen,
                                                                                              core_config=core_config,
-                                                                                             target_platform_capabilities=tpc)
+                                                                                             target_platform_capabilities=tpc,
+                                                                                             new_experimental_exporter=True)
         self.compare(inputs_list, ptq_model, qc, tpc)
 
 


### PR DESCRIPTION
Move all tests (except for some feature tests that are currently not supported using the new experimental exporter).