### PR TITLE
Override parameters for GPTQ config and fix regularization

### DIFF
--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -63,21 +63,19 @@ class GradientPTQConfig:
     Configuration to use for quantization with GradientPTQ (experimental).
     """
 
-    def __init__(self,
-                 n_iter: int,
+    def __init__(self, n_iter: int,
                  optimizer: Any,
                  optimizer_rest: Any = None,
                  loss: Callable = None,
                  log_function: Callable = None,
                  train_bias: bool = True,
-                 quantization_parameters_learning: bool = False,
                  rounding_type: RoundingType = RoundingType.SoftQuantizer,
-                 lsb_change_per_bit_width: dict = DefaultDict({}, lambda: 1),
                  use_hessian_based_weights: bool = True,
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
                  regularization_factor: float = REG_DEFAULT,
-                 hessian_weights_config: GPTQHessianWeightsConfig = GPTQHessianWeightsConfig()):
+                 hessian_weights_config: GPTQHessianWeightsConfig = GPTQHessianWeightsConfig(),
+                 gptq_quantizer_params_override: Dict[str, Any] = None):
         """
         Initialize a GradientPTQConfig.
 
@@ -90,14 +88,13 @@ class GradientPTQConfig:
              accordingly. see example in multiple_tensors_mse_loss
             log_function (Callable): Function to log information about the GPTQ process.
             train_bias (bool): Whether to update the bias during the training or not.
-            quantization_parameters_learning (bool): Whether to update the quantization param during the training or not.
             rounding_type (RoundingType): An enum that defines the rounding type.
-            lsb_change_per_bit_width (dict): Whether to update the bias during the training or not.
             use_hessian_based_weights (bool): Whether to use Hessian-based weights for weighted average loss.
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizer for bias.
             regularization_factor (float): A floating point number that defines the regularization factor.
             hessian_weights_config (GPTQHessianWeightsConfig): A configuration that include all necessary arguments to run a computation of Hessian weights for the GPTQ loss.
+            gptq_quantizer_params_override (dict): A dictionary of parameters to override in GPTQ quantizer instantiation. Defaults to None (no parameters).
 
         """
         self.n_iter = n_iter
@@ -107,38 +104,36 @@ class GradientPTQConfig:
         self.log_function = log_function
         self.train_bias = train_bias
 
-        if quantization_parameters_learning and rounding_type == RoundingType.STE:
-            common.Logger.error("Quantization parameters learning is not supported with STE rounding.")
-
-        self.quantization_parameters_learning = quantization_parameters_learning
         self.rounding_type = rounding_type
-        self.lsb_change_per_bit_width = lsb_change_per_bit_width
         self.use_hessian_based_weights = use_hessian_based_weights
         self.optimizer_quantization_parameter = optimizer_quantization_parameter
         self.optimizer_bias = optimizer_bias
         self.regularization_factor = regularization_factor
         self.hessian_weights_config = hessian_weights_config
 
+        # Since the default quantizer is soft quantizer, we initialize the gptq_quantizer_params_override dictionary
+        # with its extended params
+        self.gptq_quantizer_params_override = {QUANT_PARAM_LEARNING_STR: False} \
+            if gptq_quantizer_params_override is None else gptq_quantizer_params_override
+
 
 class GradientPTQConfigV2(GradientPTQConfig):
     """
     Configuration to use for quantization with GradientPTQV2 (experimental).
     """
-    def __init__(self,
-                 n_epochs: int,
+    def __init__(self, n_epochs: int,
                  optimizer: Any,
                  optimizer_rest: Any = None,
                  loss: Callable = None,
                  log_function: Callable = None,
                  train_bias: bool = True,
-                 quantization_parameters_learning: bool = False,
                  rounding_type: RoundingType = RoundingType.SoftQuantizer,
-                 lsb_change_per_bit_width: dict = DefaultDict({}, lambda: 1),
                  use_hessian_based_weights: bool = True,
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
                  regularization_factor: float = REG_DEFAULT,
-                 hessian_weights_config: GPTQHessianWeightsConfig = GPTQHessianWeightsConfig()):
+                 hessian_weights_config: GPTQHessianWeightsConfig = GPTQHessianWeightsConfig(),
+                 gptq_quantizer_params_override: Dict[str, Any] = None):
         """
         Initialize a GradientPTQConfigV2.
 
@@ -151,14 +146,13 @@ class GradientPTQConfigV2(GradientPTQConfig):
              accordingly. see example in multiple_tensors_mse_loss
             log_function (Callable): Function to log information about the GPTQ process.
             train_bias (bool): Whether to update the bias during the training or not.
-            quantization_parameters_learning (bool): Whether to update the quantization param during the training or not.
             rounding_type (RoundingType): An enum that defines the rounding type.
-            lsb_change_per_bit_width (dict): Whether to update the bias during the training or not.
             use_hessian_based_weights (bool): Whether to use Hessian-based weights for weighted average loss.
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
             regularization_factor (float): A floating point number that defines the regularization factor.
             hessian_weights_config (GPTQHessianWeightsConfig): A configuration that include all necessary arguments to run a computation of Hessian weights for the GPTQ loss.
+            gptq_quantizer_params_override (dict): A dictionary of parameters to override in GPTQ quantizer instantiation. Defaults to None (no parameters).
 
         """
 
@@ -168,14 +162,13 @@ class GradientPTQConfigV2(GradientPTQConfig):
                          loss=loss,
                          log_function=log_function,
                          train_bias=train_bias,
-                         quantization_parameters_learning=quantization_parameters_learning,
                          rounding_type=rounding_type,
-                         lsb_change_per_bit_width=lsb_change_per_bit_width,
                          use_hessian_based_weights=use_hessian_based_weights,
                          optimizer_quantization_parameter=optimizer_quantization_parameter,
                          optimizer_bias=optimizer_bias,
                          regularization_factor=regularization_factor,
-                         hessian_weights_config=hessian_weights_config)
+                         hessian_weights_config=hessian_weights_config,
+                         gptq_quantizer_params_override=gptq_quantizer_params_override)
         self.n_epochs = n_epochs
 
     @classmethod
@@ -192,20 +185,3 @@ class GradientPTQConfigV2(GradientPTQConfig):
         v1_params = config_v1.__dict__
         v1_params = {k: v for k, v in v1_params.items() if k != 'n_iter'}
         return cls(n_epochs, **v1_params)
-
-    def get_extended_quantizer_parametes(self) -> Dict[str, Any]:
-        """
-        Return a dictionary with a mapping to necessary additional parameters for initializing the GPTQ quantizer.
-
-        Returns: A dictionary with parameters for initializing a quantizer.
-
-        """
-
-        if self.rounding_type == RoundingType.SoftQuantizer:
-            return {QUANT_PARAM_LEARNING_STR: self.quantization_parameters_learning}
-        elif self.rounding_type == RoundingType.STE:
-            return {MAX_LSB_STR: self.lsb_change_per_bit_width}
-
-        return {}
-
-

--- a/model_compression_toolkit/gptq/common/gptq_constants.py
+++ b/model_compression_toolkit/gptq/common/gptq_constants.py
@@ -2,7 +2,6 @@
 AUXVAR = 'auxvar_tensor'
 ITERVAR = 'iteration_variable'
 SCALE_TENSOR = "scale_ptq_tensor"
-GPTQ_ITER = "gptq_iter"
 AUXSHIFT = 'shift'
 WEIGHTS_QUANTIZATION_PARAMS = 'weights_quantization_params'
 PTQ_MIN_RANGE = "min_range"

--- a/model_compression_toolkit/gptq/common/gptq_training.py
+++ b/model_compression_toolkit/gptq/common/gptq_training.py
@@ -20,6 +20,7 @@ from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig
 from model_compression_toolkit.core.common import Graph, Logger, BaseNode
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
+from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEARNING_STR
 from model_compression_toolkit.gptq.common.gptq_graph import get_compare_points
 from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
 
@@ -82,8 +83,10 @@ class GPTQTrainer(ABC):
 
         w2train = [*flattened_trainable_weights]
 
+        quant_params_learning = self.gptq_config.gptq_quantizer_params_override.get(QUANT_PARAM_LEARNING_STR, False)
+
         optimizer_with_param = [(self.gptq_config.optimizer, w2train)]
-        if self.gptq_config.train_bias or self.gptq_config.quantization_parameters_learning:
+        if self.gptq_config.train_bias or quant_params_learning:
             w2train_res = []
             if self.gptq_config.train_bias:
                 if self.gptq_config.optimizer_bias is not None:
@@ -93,7 +96,7 @@ class GPTQTrainer(ABC):
                     if self.gptq_config.optimizer_rest is None:
                         Logger.error(  # pragma: no cover
                             "To enable bias micro training an additional optimizer is required, please define the optimizer_rest")
-            if self.gptq_config.quantization_parameters_learning:
+            if quant_params_learning:
                 if self.gptq_config.optimizer_quantization_parameter is not None:  # Ability to override optimizer
                     optimizer_with_param.append((self.gptq_config.optimizer_quantization_parameter,
                                                  trainable_quantization_parameters))

--- a/model_compression_toolkit/gptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/gptq/keras/quantization_facade.py
@@ -95,14 +95,8 @@ if common.constants.FOUND_TF:
 
         """
         bias_optimizer = tf.keras.optimizers.SGD(learning_rate=LR_BIAS_DEFAULT, momentum=GPTQ_MOMENTUM)
-        return GradientPTQConfigV2(n_epochs,
-                                   optimizer,
-                                   optimizer_rest=optimizer_rest,
-                                   loss=loss,
-                                   log_function=log_function,
-                                   train_bias=True,
-                                   quantization_parameters_learning=True,
-                                   optimizer_bias=bias_optimizer)
+        return GradientPTQConfigV2(n_epochs, optimizer, optimizer_rest=optimizer_rest, loss=loss,
+                                   log_function=log_function, train_bias=True, optimizer_bias=bias_optimizer)
 
 
     def keras_gradient_post_training_quantization_experimental(in_model: Model,

--- a/model_compression_toolkit/gptq/keras/quantizer/quantization_builder.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/quantization_builder.py
@@ -61,7 +61,7 @@ def quantization_builder(n: common.BaseNode,
                                                               fw_info=DEFAULT_KERAS_INFO)
 
         weights_quantizers.update({kernel_attribute: quantizer_class(get_trainable_quantizer_weights_config(n),
-                                                                     **gptq_config.get_extended_quantizer_parametes())})
+                                                                     **gptq_config.gptq_quantizer_params_override)})
 
     activation_quantizers = []
     if n.is_activation_quantization_enabled():

--- a/model_compression_toolkit/gptq/keras/quantizer/regularization_factory.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/regularization_factory.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from functools import partial
 from typing import Callable
 
 from model_compression_toolkit.gptq import RoundingType, GradientPTQConfigV2, GradientPTQConfig
 from model_compression_toolkit.gptq.keras.quantizer.soft_rounding.soft_quantizer_reg import \
-    soft_quantizer_regularization
+    SoftQuantizerRegularization
 
 
 def get_regularization(gptq_config: GradientPTQConfig, representative_data_gen: Callable) -> Callable:
@@ -41,6 +40,6 @@ def get_regularization(gptq_config: GradientPTQConfig, representative_data_gen: 
 
         n_epochs = GradientPTQConfigV2.from_v1(n_ptq_iter=num_batches, config_v1=gptq_config).n_epochs if \
             not type(gptq_config) == GradientPTQConfigV2 else gptq_config.n_epochs
-        return partial(soft_quantizer_regularization, total_gradient_steps=num_batches * n_epochs)
+        return SoftQuantizerRegularization(total_gradient_steps=num_batches * n_epochs)
     else:
         return lambda m, e_reg: 0

--- a/model_compression_toolkit/gptq/keras/quantizer/ste_rounding/symmetric_ste.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/ste_rounding/symmetric_ste.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 from model_compression_toolkit.gptq import RoundingType
 from model_compression_toolkit import quantizers_infrastructure as qi
 from model_compression_toolkit.core.common.target_platform import QuantizationMethod
-from model_compression_toolkit.gptq.common.gptq_constants import GPTQ_ITER, AUXVAR, PTQ_THRESHOLD
+from model_compression_toolkit.gptq.common.gptq_constants import AUXVAR, PTQ_THRESHOLD
 from model_compression_toolkit.gptq.keras.quantizer import quant_utils as qutils
 from model_compression_toolkit.core.common.constants import THRESHOLD
 from model_compression_toolkit.core.common.defaultdict import DefaultDict
@@ -111,12 +111,6 @@ class STEWeightGPTQQuantizer(BaseKerasGPTQTrainableQuantizer):
             layer: Layer to quantize.
         """
 
-        ar_iter = layer.add_weight(
-            f"{name}_{GPTQ_ITER}",
-            shape=(),
-            initializer=tf.keras.initializers.Constant(0.0),
-            trainable=False)
-
         ptq_threshold_tensor = layer.add_weight(
             f"{name}_{PTQ_THRESHOLD}",
             shape=len(self.threshold_values) if self.per_channel else (),
@@ -134,8 +128,6 @@ class STEWeightGPTQQuantizer(BaseKerasGPTQTrainableQuantizer):
         # save the quantizer added parameters for later calculations
         self.add_quantizer_variable(PTQ_THRESHOLD, ptq_threshold_tensor, VariableGroup.QPARAMS)
         self.add_quantizer_variable(AUXVAR, auxvar_tensor, VariableGroup.WEIGHTS)
-        self.add_quantizer_variable(GPTQ_ITER, ar_iter, VariableGroup.QPARAMS)
-
 
     def __call__(self,
                  inputs: tf.Tensor,

--- a/model_compression_toolkit/gptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/gptq/pytorch/quantization_facade.py
@@ -83,14 +83,8 @@ if FOUND_TORCH:
 
         """
         bias_optimizer = torch.optim.SGD([torch.Tensor([])], lr=LR_BIAS_DEFAULT, momentum=GPTQ_MOMENTUM)
-        return GradientPTQConfigV2(n_epochs,
-                                   optimizer,
-                                   optimizer_rest=optimizer_rest,
-                                   loss=loss,
-                                   log_function=log_function,
-                                   train_bias=True,
-                                   quantization_parameters_learning=True,
-                                   optimizer_bias=bias_optimizer)
+        return GradientPTQConfigV2(n_epochs, optimizer, optimizer_rest=optimizer_rest, loss=loss,
+                                   log_function=log_function, train_bias=True, optimizer_bias=bias_optimizer)
 
 
     def pytorch_gradient_post_training_quantization_experimental(model: Module,

--- a/model_compression_toolkit/gptq/pytorch/quantizer/quantization_builder.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/quantization_builder.py
@@ -59,7 +59,7 @@ def quantization_builder(n: common.BaseNode,
                                                         quant_method=quant_method,
                                                         quantizer_base_class=BasePytorchGPTQTrainableQuantizer)
         weights_quantizers.update({KERNEL: quantizer_class(get_trainable_quantizer_weights_config(n),
-                                                           **gptq_config.get_extended_quantizer_parametes())})
+                                                           **gptq_config.gptq_quantizer_params_override)})
     activation_quantizers = []
     if n.is_activation_quantization_enabled():
         quant_method = n.final_activation_quantization_cfg.activation_quantization_method

--- a/model_compression_toolkit/gptq/pytorch/quantizer/regularization_factory.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/regularization_factory.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from functools import partial
 from typing import Callable
 
 from model_compression_toolkit.gptq import RoundingType, GradientPTQConfigV2, GradientPTQConfig
 from model_compression_toolkit.gptq.pytorch.quantizer.soft_rounding.soft_quantizer_reg import \
-    soft_quantizer_regularization
+    SoftQuantizerRegularization
 
 
 def get_regularization(gptq_config: GradientPTQConfig, representative_data_gen: Callable) -> Callable:
@@ -41,6 +40,6 @@ def get_regularization(gptq_config: GradientPTQConfig, representative_data_gen: 
 
         n_epochs = GradientPTQConfigV2.from_v1(n_ptq_iter=num_batches, config_v1=gptq_config).n_epochs if \
             not type(gptq_config) == GradientPTQConfigV2 else gptq_config.n_epochs
-        return partial(soft_quantizer_regularization, total_gradient_steps=num_batches * n_epochs)
+        return SoftQuantizerRegularization(total_gradient_steps=num_batches * n_epochs)
     else:
         return lambda m, e_reg: 0

--- a/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/soft_quantizer_reg.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/soft_quantizer_reg.py
@@ -20,7 +20,6 @@ from torch import nn
 
 from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
-from model_compression_toolkit.gptq.common.gptq_constants import GPTQ_ITER
 from model_compression_toolkit.gptq.common.gptq_graph import get_kernel_attribute_name_for_gptq
 from model_compression_toolkit.quantizers_infrastructure import PytorchQuantizationWrapper
 
@@ -46,7 +45,7 @@ class LinearTempDecay:
         self.start_b = start_b
         self.end_b = end_b
 
-    def __call__(self, t: nn.Parameter) -> float:
+    def __call__(self, t: float) -> float:
         """
         Cosine annealing scheduler for soft quantizer regularization temperature term.
 
@@ -56,13 +55,14 @@ class LinearTempDecay:
         Returns: Scheduled temperature.
         """
 
-        is_before_start_decay = (t < self.start_decay).to(torch.float32)
+        is_before_start_decay = (t < self.start_decay)
 
         rel_t = (t - self.start_decay) / (self.t_max - self.start_decay)
 
         return self.start_b * is_before_start_decay + \
                (1 - is_before_start_decay) * \
-               (self.end_b + (self.start_b - self.end_b) * torch.maximum(to_torch_tensor(np.array([0.0])), (1 - rel_t)))
+               (self.end_b + (self.start_b - self.end_b) * torch.maximum(to_torch_tensor(np.array([0.0])),
+                                                                         to_torch_tensor(np.array((1 - rel_t)))))
 
 
 class SoftQuantizerRegularization:
@@ -80,6 +80,8 @@ class SoftQuantizerRegularization:
 
         # Initializing the temperature decay according to the number of expected gradient steps
         self.linear_decay = LinearTempDecay(total_gradient_steps)
+
+        self.count_iter = 0
 
     def __call__(self, model: nn.Module, entropy_reg: float):
         """
@@ -99,7 +101,7 @@ class SoftQuantizerRegularization:
                                                                       fw_info=DEFAULT_PYTORCH_INFO)
 
                 st = layer.weights_quantizers[kernel_attribute].get_soft_targets()
-                b = self.linear_decay(layer.weights_quantizers[kernel_attribute].get_quantizer_variable(GPTQ_ITER))
+                b = self.linear_decay(self.count_iter)
 
                 soft_reg_aux.append((1 - torch.pow(torch.abs(st - .5) * 2, b)).sum())
 
@@ -107,5 +109,7 @@ class SoftQuantizerRegularization:
 
         for sq in soft_reg_aux:
             reg += sq
+
+        self.count_iter += 1
 
         return entropy_reg * reg

--- a/tests/keras_tests/models_tests/test_networks_runner.py
+++ b/tests/keras_tests/models_tests/test_networks_runner.py
@@ -101,12 +101,9 @@ class NetworkTest:
 
         core_config = mct.CoreConfig(quantization_config=qc)
         if self.gptq:
-            arc = mct.gptq.GradientPTQConfig(n_iter=2,
-                                        optimizer=tf.keras.optimizers.Adam(
-                                            learning_rate=0.0001),
-                                        optimizer_rest=tf.keras.optimizers.Adam(
-                                            learning_rate=0.0001),
-                                                                                      loss=multiple_tensors_mse_loss)
+            arc = mct.gptq.GradientPTQConfig(n_iter=2, optimizer=tf.keras.optimizers.Adam(
+                learning_rate=0.0001), optimizer_rest=tf.keras.optimizers.Adam(
+                learning_rate=0.0001), loss=multiple_tensors_mse_loss)
             arc2 = mct.gptq.GradientPTQConfigV2.from_v1(self.num_calibration_iter, arc)
 
             ptq_model, quantization_info = mct.gptq.keras_gradient_post_training_quantization_experimental(self.model_float,

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -457,7 +457,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
         GPTQLearnRateZeroTest(self).run_test()
 
         GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer).run_test()
-        GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer, per_channel=False).run_test()
+        GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer, per_channel=False, params_learning=False).run_test()
         GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer,
                          per_channel=True, hessian_weights=True, log_norm_weights=True, scaled_log_norm=True).run_test()
         GPTQWeightsUpdateTest(self, rounding_type=RoundingType.SoftQuantizer).run_test()


### PR DESCRIPTION
Two main modifications:
* Removed quantization_parameters_learning and lsb_change_per_bit_width arguments from GPTQ config and replaced them with gptq_quantizer_params_override dictionary.
* Changed GPTQ soft quantizer regularization from function to class and fixed linear decay initialization.