### PR TITLE
Fix bug with parameters learning in GPTQ soft quantizers

### DIFF
--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -111,10 +111,8 @@ class GradientPTQConfig:
         self.regularization_factor = regularization_factor
         self.hessian_weights_config = hessian_weights_config
 
-        # Since the default quantizer is soft quantizer, we initialize the gptq_quantizer_params_override dictionary
-        # with its extended params
-        self.gptq_quantizer_params_override = {QUANT_PARAM_LEARNING_STR: False} \
-            if gptq_quantizer_params_override is None else gptq_quantizer_params_override
+        self.gptq_quantizer_params_override = {} if gptq_quantizer_params_override is None \
+            else gptq_quantizer_params_override
 
 
 class GradientPTQConfigV2(GradientPTQConfig):

--- a/model_compression_toolkit/gptq/keras/quantizer/soft_rounding/symmetric_soft_quantizer.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/soft_rounding/symmetric_soft_quantizer.py
@@ -221,7 +221,7 @@ class SymmetricSoftRoundingGPTQ(BaseKerasGPTQTrainableQuantizer):
 
         else:
             q_tensor = soft_rounding_symmetric_quantizer(input_tensor=inputs,
-                                                         auxvar_tensor=self.get_quantizer_variable(AUXVAR),
+                                                         auxvar_tensor=aux_var,
                                                          threshold_tensor=ptq_threshold_tensor.value(),
                                                          num_bits=self.num_bits,
                                                          signed=True,

--- a/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
+++ b/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
@@ -1,0 +1,62 @@
+import keras
+import unittest
+
+from keras.models import clone_model
+from tensorflow.keras.layers import Conv2D, Input
+import numpy as np
+import model_compression_toolkit as mct
+from model_compression_toolkit.core.common.constants import THRESHOLD
+from model_compression_toolkit.core.common.target_platform import QuantizationMethod
+from model_compression_toolkit.core.keras.constants import KERNEL
+from model_compression_toolkit.gptq.keras.quantizer.soft_rounding.symmetric_soft_quantizer import \
+    SymmetricSoftRoundingGPTQ
+from model_compression_toolkit.quantizers_infrastructure import TrainableQuantizerWeightsConfig, \
+    KerasQuantizationWrapper
+
+tp = mct.target_platform
+
+
+def model_test(input_shape, per_channel, num_channels=3, kernel_size=1):
+    inputs = Input(shape=input_shape)
+    outputs = Conv2D(num_channels, kernel_size, use_bias=False)(inputs)
+    model = keras.Model(inputs=inputs, outputs=outputs)
+
+    return wrap_test_model(model, per_channel)
+
+
+def generate_input():
+    return [np.ones([1, 2, 2, 2]).astype(np.float32)]
+
+
+def wrap_test_model(model, per_channel=False):
+    tqwc = TrainableQuantizerWeightsConfig(weights_quantization_method=QuantizationMethod.SYMMETRIC,
+                                           weights_n_bits=8,
+                                           weights_quantization_params={THRESHOLD: 2.0},
+                                           enable_weights_quantization=True,
+                                           weights_channels_axis=3,
+                                           weights_per_channel_threshold=per_channel,
+                                           min_threshold=0)
+
+    sq = SymmetricSoftRoundingGPTQ(quantization_config=tqwc,
+                                   quantization_parameter_learning=False)
+
+    def _wrap(layer):
+        if isinstance(layer, Conv2D):
+            return KerasQuantizationWrapper(layer, weights_quantizers={'kernel': sq})
+        else:
+            return layer
+    return clone_model(model, clone_function=_wrap)
+
+
+class TestGPTQSoftQuantizer(unittest.TestCase):
+
+    def test_soft_targets_symmetric_per_tensor(self):
+        input_shape = (1, 1, 1)
+        in_model = model_test(input_shape, per_channel=False)
+
+        float_weights = [x[1] for x in in_model.layers[1]._weights_vars if x[0] == KERNEL][0]
+        out = in_model(generate_input())
+        self.assertTrue(np.any(float_weights != out))
+
+        out_t = in_model(generate_input(), training=True)
+        self.assertTrue(np.all(float_weights == out_t))

--- a/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
+++ b/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
@@ -24,10 +24,6 @@ def model_test(input_shape, per_channel, num_channels=3, kernel_size=1):
     return wrap_test_model(model, per_channel)
 
 
-def generate_input():
-    return [np.ones([1, 2, 2, 2]).astype(np.float32)]
-
-
 def wrap_test_model(model, per_channel=False):
     tqwc = TrainableQuantizerWeightsConfig(weights_quantization_method=QuantizationMethod.SYMMETRIC,
                                            weights_n_bits=8,
@@ -54,9 +50,26 @@ class TestGPTQSoftQuantizer(unittest.TestCase):
         input_shape = (1, 1, 1)
         in_model = model_test(input_shape, per_channel=False)
 
+        def _generate_input():
+            return [np.ones([1, 1, 1, 1]).astype(np.float32)]
+
         float_weights = [x[1] for x in in_model.layers[1]._weights_vars if x[0] == KERNEL][0]
-        out = in_model(generate_input())
+        out = in_model(_generate_input())
         self.assertTrue(np.any(float_weights != out))
 
-        out_t = in_model(generate_input(), training=True)
+        out_t = in_model(_generate_input(), training=True)
         self.assertTrue(np.all(float_weights == out_t))
+
+    def test_soft_targets_symmetric_per_channel(self):
+        input_shape = (2, 2, 2)
+        in_model = model_test(input_shape, per_channel=True, num_channels=1, kernel_size=2)
+
+        def _generate_input():
+            return [np.ones([1, 2, 2, 2]).astype(np.float32)]
+
+        float_weights = [x[1] for x in in_model.layers[1]._weights_vars if x[0] == KERNEL][0]
+        out = in_model(_generate_input())
+        self.assertFalse(np.isclose(np.sum(float_weights), out))
+
+        out_t = in_model(_generate_input(), training=True)
+        self.assertTrue(np.isclose(np.sum(float_weights), out_t))

--- a/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
+++ b/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
@@ -50,26 +50,22 @@ class TestGPTQSoftQuantizer(unittest.TestCase):
         input_shape = (1, 1, 1)
         in_model = model_test(input_shape, per_channel=False)
 
-        def _generate_input():
-            return [np.ones([1, 1, 1, 1]).astype(np.float32)]
-
+        input = [np.ones([1, 1, 1, 1]).astype(np.float32)]
         float_weights = [x[1] for x in in_model.layers[1]._weights_vars if x[0] == KERNEL][0]
-        out = in_model(_generate_input())
+        out = in_model(input)
         self.assertTrue(np.any(float_weights != out))
 
-        out_t = in_model(_generate_input(), training=True)
+        out_t = in_model(input, training=True)
         self.assertTrue(np.all(float_weights == out_t))
 
     def test_soft_targets_symmetric_per_channel(self):
         input_shape = (2, 2, 2)
         in_model = model_test(input_shape, per_channel=True, num_channels=1, kernel_size=2)
 
-        def _generate_input():
-            return [np.ones([1, 2, 2, 2]).astype(np.float32)]
-
+        input = [np.ones([1, 2, 2, 2]).astype(np.float32)]
         float_weights = [x[1] for x in in_model.layers[1]._weights_vars if x[0] == KERNEL][0]
-        out = in_model(_generate_input())
+        out = in_model(input)
         self.assertFalse(np.isclose(np.sum(float_weights), out))
 
-        out_t = in_model(_generate_input(), training=True)
+        out_t = in_model(input, training=True)
         self.assertTrue(np.isclose(np.sum(float_weights), out_t))

--- a/tests/pytorch_tests/function_tests/test_gptq_soft_quantizer.py
+++ b/tests/pytorch_tests/function_tests/test_gptq_soft_quantizer.py
@@ -1,0 +1,67 @@
+import unittest
+
+import torch
+from torch.nn import Conv2d
+
+import model_compression_toolkit as mct
+from model_compression_toolkit.core.common.constants import THRESHOLD
+from model_compression_toolkit.core.common.target_platform import QuantizationMethod
+from model_compression_toolkit.core.pytorch.constants import KERNEL
+from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
+from model_compression_toolkit.gptq.pytorch.quantizer.soft_rounding.symmetric_soft_quantizer import \
+    SymmetricSoftRoundingGPTQ
+
+from model_compression_toolkit.quantizers_infrastructure import TrainableQuantizerWeightsConfig, \
+    PytorchQuantizationWrapper
+
+tp = mct.target_platform
+
+
+class model_test(torch.nn.Module):
+    def __init__(self):
+        super(model_test, self).__init__()
+        self.conv = Conv2d(1, 3, kernel_size=1, bias=False)
+
+    def forward(self, inp):
+        x = self.conv(inp)
+        return x
+
+
+def generate_input():
+    return to_torch_tensor(torch.ones([1, 1, 1, 1]))
+
+
+def wrap_test_model(model, sq):
+
+
+    setattr(model, 'conv', PytorchQuantizationWrapper(model.conv, {KERNEL: sq}))
+
+
+class TestGPTQSoftQuantizer(unittest.TestCase):
+
+    def test_soft_targets_symmetric_per_tensor(self):
+        input = generate_input()
+        in_model = model_test().to(input.device)
+
+        tqwc = TrainableQuantizerWeightsConfig(weights_quantization_method=QuantizationMethod.SYMMETRIC,
+                                               weights_n_bits=8,
+                                               weights_quantization_params={THRESHOLD: 2.0},
+                                               enable_weights_quantization=True,
+                                               weights_channels_axis=1,
+                                               weights_per_channel_threshold=False,
+                                               min_threshold=0)
+
+        sq = SymmetricSoftRoundingGPTQ(quantization_config=tqwc,
+                                       quantization_parameter_learning=False)
+        wrap_test_model(in_model, sq)
+
+        conv_wrap_layer = [m for m in in_model.modules() if isinstance(m, PytorchQuantizationWrapper)][0]
+        float_weights = [x[1] for x in conv_wrap_layer._weights_vars if x[0] == KERNEL][0]
+
+        in_model.eval()
+        out = in_model(input)
+        self.assertTrue(torch.any(float_weights != out.reshape(float_weights.shape)))
+
+        in_model.train()
+        out_t = in_model(input)
+        self.assertTrue(torch.all(float_weights == out_t.reshape(float_weights.shape)))

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -458,7 +458,10 @@ class FeatureModelsTestRunner(unittest.TestCase):
         GPTQLearnRateZeroTest(self).run_test()
 
         GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer).run_test()
-        GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer, per_channel=False, params_learning=False).run_test()
+        GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer, per_channel=False,
+                         params_learning=False).run_test()
+        GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer, per_channel=False,
+                         params_learning=True).run_test()
         GPTQAccuracyTest(self, rounding_type=RoundingType.SoftQuantizer,
                          per_channel=True, hessian_weights=True, log_norm_weights=True, scaled_log_norm=True).run_test()
         GPTQWeightsUpdateTest(self, rounding_type=RoundingType.SoftQuantizer).run_test()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -29,6 +29,7 @@ from tests.common_tests.function_tests.test_kpi_object import TestKPIObject
 from tests.common_tests.function_tests.test_threshold_selection import TestThresholdSelection
 from tests.common_tests.test_doc_examples import TestCommonDocsExamples
 from tests.common_tests.test_tp_model import TargetPlatformModelingTest, OpsetTest, QCOptionsTest, FusingTest
+from tests.pytorch_tests.function_tests.test_gptq_soft_quantizer import TestGPTQSoftQuantizer
 
 if FOUND_ONNX:
     from tests.pytorch_tests.function_tests.test_export_pytorch_fully_quantized_model import TestPyTorchFakeQuantExporter
@@ -152,6 +153,7 @@ if __name__ == '__main__':
         # suiteList.append(unittest.TestLoader().loadTestsFromName('test_resnet18', ModelTest))
         # suiteList.append(unittest.TestLoader().loadTestsFromName('test_shufflenet_v2_x1_0', ModelTest))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestPytorchTPModel))
+        suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestGPTQSoftQuantizer))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(PytorchInferableInfrastructureTestRunner))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(PytorchTrainableInfrastructureTestRunner))
     # ----------------   Join them together and run them


### PR DESCRIPTION
Fixing two issues:
* In both Pytorch and Keras Soft quantizers - parameters learning wasn't applied for per-tensor quantization.
* In Keras Soft quantizer - per-tensor quantization did not use the soft targets. 