### PR TITLE
Fix cfg creation in weights quantization granularity

### DIFF
--- a/model_compression_toolkit/core/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/node_quantization_config.py
@@ -256,7 +256,7 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
         self.weights_n_bits = op_cfg.weights_n_bits
         self.weights_bias_correction = qc.weights_bias_correction
         self.weights_second_moment_correction = qc.weights_second_moment_correction
-        self.weights_per_channel_threshold = qc.weights_per_channel_threshold
+        self.weights_per_channel_threshold = op_cfg.weights_per_channel_threshold
         self.enable_weights_quantization = op_cfg.enable_weights_quantization
         self.min_threshold = qc.min_threshold
         self.l_p_value = qc.l_p_value

--- a/tests/keras_tests/feature_networks_tests/feature_networks/per_tensor_weight_quantization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/per_tensor_weight_quantization_test.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import tensorflow as tf
+
+from model_compression_toolkit.core.common.constants import THRESHOLD
+from model_compression_toolkit.core.keras.constants import KERNEL
+from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
+from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
+
+keras = tf.keras
+layers = keras.layers
+
+
+class PerTensorWeightQuantizationTest(BaseKerasFeatureNetworkTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test, experimental_exporter=True)
+
+    def get_tpc(self):
+        tp = generate_test_tp_model({'weights_per_channel_threshold': False})
+        return generate_keras_tpc(name="per_tensor_weight_quantization", tp_model=tp)
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = layers.Conv2D(6, 7)(inputs)
+        return keras.Model(inputs=inputs, outputs=x)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        self.unit_test.assertTrue(
+            len(quantized_model.layers[2].weights_quantizers[KERNEL].get_config()[THRESHOLD]) == 1,
+            f'Expected in per-tensor quantization to have a single threshold but found '
+            f'{len(quantized_model.layers[2].weights_quantizers[KERNEL].get_config()[THRESHOLD])}')

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -88,6 +88,8 @@ from tests.keras_tests.feature_networks_tests.feature_networks.network_editor.ed
 from tests.keras_tests.feature_networks_tests.feature_networks.network_editor.node_filter_test import NameFilterTest, \
     ScopeFilterTest, TypeFilterTest
 from tests.keras_tests.feature_networks_tests.feature_networks.output_in_middle_test import OutputInMiddleTest
+from tests.keras_tests.feature_networks_tests.feature_networks.per_tensor_weight_quantization_test import \
+    PerTensorWeightQuantizationTest
 from tests.keras_tests.feature_networks_tests.feature_networks.qat.qat_test import QATWrappersTest, \
     QuantizationAwareTrainingQuantizersTest, QATWrappersMixedPrecisionCfgTest
 from tests.keras_tests.feature_networks_tests.feature_networks.relu_replacement_test import ReluReplacementTest, \
@@ -127,6 +129,9 @@ layers = tf.keras.layers
 
 
 class FeatureNetworkTest(unittest.TestCase):
+
+    def test_per_tensor_weight_quantization(self):
+        PerTensorWeightQuantizationTest(self).run_test()
 
     def test_single_relu_replacement(self):
         SingleReluReplacementTest(self).run_test()


### PR DESCRIPTION
When creating quantization configuration for weights the per-tensor/per-channel information was taken from the global quantization configuration instead of TPC. This commit fixes this.