### PR TITLE
Rearrange QAT imports

### DIFF
--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -24,7 +24,7 @@ from model_compression_toolkit.target_platform_capabilities.tpc_models.get_targe
 from model_compression_toolkit.core.common.mixed_precision.kpi_tools.kpi import KPI
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
     MixedPrecisionQuantizationConfig, MixedPrecisionQuantizationConfigV2
-from model_compression_toolkit.qat.common.qat_config import QATConfig, TrainingMethod
+
 from model_compression_toolkit.core.common.logger import set_log_folder
 from model_compression_toolkit.core.common.data_loader import FolderImageLoader
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo, ChannelAxis
@@ -34,8 +34,7 @@ from model_compression_toolkit.core.common import network_editors as network_edi
 from model_compression_toolkit.core.keras.quantization_facade import keras_post_training_quantization, \
     keras_post_training_quantization_mixed_precision
 from model_compression_toolkit.ptq.keras.quantization_facade import keras_post_training_quantization_experimental
-from model_compression_toolkit.qat.keras.quantization_facade import keras_quantization_aware_training_init, keras_quantization_aware_training_finalize
-from model_compression_toolkit.qat.pytorch.quantization_facade import pytorch_quantization_aware_training_init, pytorch_quantization_aware_training_finalize
+
 from model_compression_toolkit.core.pytorch.quantization_facade import pytorch_post_training_quantization, pytorch_post_training_quantization_mixed_precision
 from model_compression_toolkit.ptq.pytorch.quantization_facade import pytorch_post_training_quantization_experimental
 

--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -43,7 +43,7 @@ from model_compression_toolkit.core.pytorch.kpi_data_facade import pytorch_kpi_d
 
 from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.keras.load_model import keras_load_quantized_model
 
-
+from model_compression_toolkit import qat
 from model_compression_toolkit import exporter
 
 from model_compression_toolkit import gptq

--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
 import importlib
 
 # Supported frameworks in MCT:
@@ -128,9 +129,3 @@ INPUT_BASE_NAME = 'base_input'
 # Jacobian-weights constants
 MIN_JACOBIANS_ITER = 10
 JACOBIANS_COMP_TOLERANCE = 1e-3
-
-# Quantizers constants (for GPTQ, QAT, etc.)
-FQ_MIN = "min"
-FQ_MAX = "max"
-THRESHOLD_TENSOR = "ptq_threshold_tensor"
-WEIGHTS_QUANTIZATION_PARAMS = 'weights_quantization_params'

--- a/model_compression_toolkit/core/common/constants.py
+++ b/model_compression_toolkit/core/common/constants.py
@@ -128,3 +128,9 @@ INPUT_BASE_NAME = 'base_input'
 # Jacobian-weights constants
 MIN_JACOBIANS_ITER = 10
 JACOBIANS_COMP_TOLERANCE = 1e-3
+
+# Quantizers constants (for GPTQ, QAT, etc.)
+FQ_MIN = "min"
+FQ_MAX = "max"
+THRESHOLD_TENSOR = "ptq_threshold_tensor"
+WEIGHTS_QUANTIZATION_PARAMS = 'weights_quantization_params'

--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -288,13 +288,6 @@ class FrameworkImplementation(ABC):
                              f'framework\'s get_substitutions_after_second_moment_correction '
                              f'method.')  # pragma: no cover
 
-    @abstractmethod
-    def get_gptq_trainer_obj(self):
-        """
-        Returns: GPTQTrainer object
-        """
-        raise NotImplemented(f'{self.__class__.__name__} have to implement the '
-                             f'framework\'s get_gptq_trainer method.')  # pragma: no cover
 
     @abstractmethod
     def get_sensitivity_evaluator(self,

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import List, Any, Tuple, Callable, Type, Dict
+from typing import List, Any, Tuple, Callable, Dict
 
 import numpy as np
 import tensorflow as tf
@@ -52,8 +52,6 @@ from model_compression_toolkit.core.common.model_builder_mode import ModelBuilde
 from model_compression_toolkit.core.common.node_prior_info import NodePriorInfo
 from model_compression_toolkit.core.common.user_info import UserInformation
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
-from model_compression_toolkit.gptq.common.gptq_training import GPTQTrainer
-from model_compression_toolkit.gptq.keras.gptq_training import KerasGPTQTrainer
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.activation_decomposition import \
     ActivationDecomposition
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.softmax_shift import \
@@ -347,12 +345,6 @@ class KerasImplementation(FrameworkImplementation):
         if quant_config.weights_second_moment_correction:
             substitutions_list.append(keras_batchnorm_refusing())
         return substitutions_list
-
-    def get_gptq_trainer_obj(self) -> Type[GPTQTrainer]:
-        """
-        Returns:  Keras object of GPTQTrainer
-        """
-        return KerasGPTQTrainer
 
     def get_sensitivity_evaluator(self,
                                   graph: Graph,

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -76,8 +76,6 @@ from model_compression_toolkit.core.pytorch.reader.reader import model_reader
 from model_compression_toolkit.core.pytorch.statistics_correction.apply_second_moment_correction import \
     pytorch_apply_second_moment_correction
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
-from model_compression_toolkit.gptq.common.gptq_training import GPTQTrainer
-from model_compression_toolkit.gptq.pytorch.gptq_training import PytorchGPTQTrainer
 
 
 class PytorchImplementation(FrameworkImplementation):
@@ -324,12 +322,6 @@ class PytorchImplementation(FrameworkImplementation):
         if quant_config.weights_second_moment_correction:
             substitutions_list.append(pytorch_batchnorm_refusing())
         return substitutions_list
-
-    def get_gptq_trainer_obj(self) -> Type[GPTQTrainer]:
-        """
-        Returns: GPTQTrainer object
-        """
-        return PytorchGPTQTrainer
 
     def get_sensitivity_evaluator(self,
                                   graph: Graph,

--- a/model_compression_toolkit/gptq/common/gptq_framework_implementation.py
+++ b/model_compression_toolkit/gptq/common/gptq_framework_implementation.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from abc import abstractmethod
+
+from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
+
+
+class GPTQFrameworkImplemantation(FrameworkImplementation):
+    """
+    Class to implement framework related methods that are used in GPTQ
+    """
+
+    @abstractmethod
+    def get_gptq_trainer_obj(self):
+        """
+        Returns: GPTQTrainer object
+        """
+        raise NotImplemented(f'{self.__class__.__name__} have to implement the '
+                             f'framework\'s get_gptq_trainer method.')  # pragma: no cover

--- a/model_compression_toolkit/gptq/keras/gptq_keras_implementation.py
+++ b/model_compression_toolkit/gptq/keras/gptq_keras_implementation.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,17 @@
 # limitations under the License.
 # ==============================================================================
 
-FQ_MIN = "min"
-FQ_MAX = "max"
-THRESHOLD_TENSOR = "ptq_threshold_tensor"
-WEIGHTS_QUANTIZATION_PARAMS = 'weights_quantization_params'
+from typing import Type
+
+from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
+from model_compression_toolkit.gptq.common.gptq_framework_implementation import GPTQFrameworkImplemantation
+from model_compression_toolkit.gptq.keras.gptq_training import KerasGPTQTrainer
+
+
+class GPTQKerasImplemantation(GPTQFrameworkImplemantation, KerasImplementation):
+
+    def get_gptq_trainer_obj(self) -> Type[KerasGPTQTrainer]:
+        """
+        Returns:  Keras object of GPTQTrainer
+        """
+        return KerasGPTQTrainer

--- a/model_compression_toolkit/gptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/gptq/keras/quantization_facade.py
@@ -41,7 +41,7 @@ GPTQ_MOMENTUM = 0.9
 if common.constants.FOUND_TF:
     import tensorflow as tf
     from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
-    from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
+    from model_compression_toolkit.gptq.keras.gptq_keras_implementation import GPTQKerasImplemantation
     from model_compression_toolkit.core.keras.keras_model_validation import KerasModelValidation
     from tensorflow.keras.models import Model
     from model_compression_toolkit.gptq.keras.gptq_loss import GPTQMultipleTensorsLoss
@@ -195,7 +195,7 @@ if common.constants.FOUND_TF:
                                "If you encounter an issue please file a bug.")
         tb_w = _init_tensorboard_writer(fw_info)
 
-        fw_impl = KerasImplementation()
+        fw_impl = GPTQKerasImplemantation()
 
         tg, bit_widths_config = core_runner(in_model=in_model,
                                             representative_data_gen=representative_data_gen,

--- a/model_compression_toolkit/gptq/keras/quantizer/soft_rounding/uniform_soft_quantizer.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/soft_rounding/uniform_soft_quantizer.py
@@ -18,12 +18,13 @@ import numpy as np
 
 from model_compression_toolkit.gptq import RoundingType
 from model_compression_toolkit import quantizers_infrastructure as qi
+from model_compression_toolkit.quantizers_infrastructure.constants import FQ_MIN, FQ_MAX
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.gptq.common.gptq_constants import \
     SOFT_ROUNDING_GAMMA, SOFT_ROUNDING_ZETA, AUXVAR
 from model_compression_toolkit.gptq.keras.quantizer import quant_utils as qutils
 from typing import Dict, Any
-from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX, FQ_MAX, FQ_MIN
+from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX
 from model_compression_toolkit.gptq.keras.quantizer.base_keras_gptq_quantizer import BaseKerasGPTQTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure import TrainableQuantizerWeightsConfig
 from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.base_inferable_quantizer import mark_quantizer

--- a/model_compression_toolkit/gptq/keras/quantizer/soft_rounding/uniform_soft_quantizer.py
+++ b/model_compression_toolkit/gptq/keras/quantizer/soft_rounding/uniform_soft_quantizer.py
@@ -23,8 +23,7 @@ from model_compression_toolkit.gptq.common.gptq_constants import \
     SOFT_ROUNDING_GAMMA, SOFT_ROUNDING_ZETA, AUXVAR
 from model_compression_toolkit.gptq.keras.quantizer import quant_utils as qutils
 from typing import Dict, Any
-from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX
-from model_compression_toolkit.qat.common.constants import FQ_MIN, FQ_MAX
+from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX, FQ_MAX, FQ_MIN
 from model_compression_toolkit.gptq.keras.quantizer.base_keras_gptq_quantizer import BaseKerasGPTQTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure import TrainableQuantizerWeightsConfig
 from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.base_inferable_quantizer import mark_quantizer

--- a/model_compression_toolkit/gptq/pytorch/gptq_pytorch_implementation.py
+++ b/model_compression_toolkit/gptq/pytorch/gptq_pytorch_implementation.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Type
+
+from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
+from model_compression_toolkit.gptq.common.gptq_framework_implementation import GPTQFrameworkImplemantation
+from model_compression_toolkit.gptq.pytorch.gptq_training import PytorchGPTQTrainer
+
+
+class GPTQPytorchImplemantation(GPTQFrameworkImplemantation, PytorchImplementation):
+
+    def get_gptq_trainer_obj(self) -> Type[PytorchGPTQTrainer]:
+        """
+        Returns:  Pytorch object of GPTQTrainer
+        """
+        return PytorchGPTQTrainer

--- a/model_compression_toolkit/gptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/gptq/pytorch/quantization_facade.py
@@ -36,7 +36,7 @@ LR_QUANTIZATION_PARAM_DEFAULT = 1e-4
 
 if FOUND_TORCH:
     from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
-    from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
+    from model_compression_toolkit.gptq.pytorch.gptq_pytorch_implementation import GPTQPytorchImplemantation
     from model_compression_toolkit.core.pytorch.constants import DEFAULT_TP_MODEL
     from model_compression_toolkit.gptq.pytorch.gptq_loss import multiple_tensors_mse_loss
     from model_compression_toolkit.exporter.model_wrapper.pytorch.builder.fully_quantized_model_builder import get_exportable_pytorch_model
@@ -161,7 +161,7 @@ if FOUND_TORCH:
 
         tb_w = _init_tensorboard_writer(DEFAULT_PYTORCH_INFO)
 
-        fw_impl = PytorchImplementation()
+        fw_impl = GPTQPytorchImplemantation()
 
         # ---------------------- #
         # Core Runner

--- a/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/uniform_soft_quantizer.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/uniform_soft_quantizer.py
@@ -31,8 +31,7 @@ from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructur
     mark_quantizer
 from model_compression_toolkit.quantizers_infrastructure.trainable_infrastructure.common.base_trainable_quantizer import \
     VariableGroup
-from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN
-from model_compression_toolkit.qat.common.constants import FQ_MIN, FQ_MAX
+from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN, FQ_MIN, FQ_MAX
 
 
 def soft_rounding_unifrom_quantizer(input_tensor: torch.Tensor,

--- a/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/uniform_soft_quantizer.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/uniform_soft_quantizer.py
@@ -18,6 +18,7 @@ from typing import Dict
 import numpy as np
 
 from model_compression_toolkit import quantizers_infrastructure as qi
+from model_compression_toolkit.quantizers_infrastructure.constants import FQ_MIN, FQ_MAX
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.gptq.common.gptq_config import RoundingType
 from model_compression_toolkit.gptq.pytorch.quantizer.base_pytorch_gptq_quantizer import \
@@ -31,7 +32,7 @@ from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructur
     mark_quantizer
 from model_compression_toolkit.quantizers_infrastructure.trainable_infrastructure.common.base_trainable_quantizer import \
     VariableGroup
-from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN, FQ_MIN, FQ_MAX
+from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN
 
 
 def soft_rounding_unifrom_quantizer(input_tensor: torch.Tensor,

--- a/model_compression_toolkit/qat/__init__.py
+++ b/model_compression_toolkit/qat/__init__.py
@@ -12,3 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.qat.common.qat_config import QATConfig, TrainingMethod
+
+from model_compression_toolkit.qat.keras.quantization_facade import keras_quantization_aware_training_init, keras_quantization_aware_training_finalize
+from model_compression_toolkit.qat.pytorch.quantization_facade import pytorch_quantization_aware_training_init, pytorch_quantization_aware_training_finalize

--- a/model_compression_toolkit/qat/common/__init__.py
+++ b/model_compression_toolkit/qat/common/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 # ==============================================================================
 
-from model_compression_toolkit.qat.common.constants import THRESHOLD_TENSOR, WEIGHTS_QUANTIZATION_PARAMS
+from model_compression_toolkit.core.common.constants import THRESHOLD_TENSOR, WEIGHTS_QUANTIZATION_PARAMS

--- a/model_compression_toolkit/qat/keras/quantizer/ste_rounding/symmetric_ste.py
+++ b/model_compression_toolkit/qat/keras/quantizer/ste_rounding/symmetric_ste.py
@@ -18,7 +18,9 @@ from typing import Union
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework.tensor_shape import TensorShape
-from model_compression_toolkit.core.common.constants import SIGNED, FQ_MIN, FQ_MAX
+from model_compression_toolkit.core.common.constants import SIGNED
+from model_compression_toolkit.quantizers_infrastructure.constants import FQ_MIN, FQ_MAX
+
 from model_compression_toolkit.qat import TrainingMethod
 
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod

--- a/model_compression_toolkit/qat/keras/quantizer/ste_rounding/symmetric_ste.py
+++ b/model_compression_toolkit/qat/keras/quantizer/ste_rounding/symmetric_ste.py
@@ -18,12 +18,13 @@ from typing import Union
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework.tensor_shape import TensorShape
-from model_compression_toolkit.core.common.constants import SIGNED
+from model_compression_toolkit.core.common.constants import SIGNED, FQ_MIN, FQ_MAX
+from model_compression_toolkit.qat import TrainingMethod
 
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.qat.common import THRESHOLD_TENSOR
-from model_compression_toolkit.qat.common.constants import FQ_MIN, FQ_MAX
-from model_compression_toolkit import quantizers_infrastructure as qi, TrainingMethod
+from model_compression_toolkit import quantizers_infrastructure as qi
+
 from model_compression_toolkit.core.common import constants as C
 from model_compression_toolkit.qat.keras.quantizer.base_keras_qat_quantizer import BaseKerasQATTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure import TrainableQuantizerWeightsConfig, \

--- a/model_compression_toolkit/qat/keras/quantizer/ste_rounding/uniform_ste.py
+++ b/model_compression_toolkit/qat/keras/quantizer/ste_rounding/uniform_ste.py
@@ -15,7 +15,8 @@
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework.tensor_shape import TensorShape
-from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX, FQ_MIN, FQ_MAX
+from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX
+from model_compression_toolkit.quantizers_infrastructure.constants import FQ_MIN, FQ_MAX
 from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 

--- a/model_compression_toolkit/qat/keras/quantizer/ste_rounding/uniform_ste.py
+++ b/model_compression_toolkit/qat/keras/quantizer/ste_rounding/uniform_ste.py
@@ -15,12 +15,14 @@
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework.tensor_shape import TensorShape
-from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX
+from model_compression_toolkit.core.common.constants import RANGE_MIN, RANGE_MAX, FQ_MIN, FQ_MAX
+from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
-from model_compression_toolkit.qat.common.constants import FQ_MIN, FQ_MAX
+
 from model_compression_toolkit.qat.keras.quantizer.quant_utils import adjust_range_to_include_zero
 from model_compression_toolkit.core.common.quantization.quantizers.quantizers_helpers import fix_range_to_include_zero
-from model_compression_toolkit import quantizers_infrastructure as qi, TrainingMethod
+from model_compression_toolkit import quantizers_infrastructure as qi
+
 from model_compression_toolkit.core.common import constants as C
 from model_compression_toolkit.qat.keras.quantizer.base_keras_qat_quantizer import BaseKerasQATTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure import TrainableQuantizerWeightsConfig, \

--- a/model_compression_toolkit/qat/pytorch/quantizer/ste_rounding/symmetric_ste.py
+++ b/model_compression_toolkit/qat/pytorch/quantizer/ste_rounding/symmetric_ste.py
@@ -18,9 +18,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.qat.common import THRESHOLD_TENSOR
-from model_compression_toolkit import quantizers_infrastructure as qi, TrainingMethod
+from model_compression_toolkit import quantizers_infrastructure as qi
 from model_compression_toolkit.qat.pytorch.quantizer.base_pytorch_qat_quantizer import BasePytorchQATTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.base_inferable_quantizer import mark_quantizer
 from model_compression_toolkit.core.common import constants as C

--- a/model_compression_toolkit/qat/pytorch/quantizer/ste_rounding/uniform_ste.py
+++ b/model_compression_toolkit/qat/pytorch/quantizer/ste_rounding/uniform_ste.py
@@ -17,7 +17,9 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN, FQ_MIN, FQ_MAX
+from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN
+from model_compression_toolkit.quantizers_infrastructure.constants import FQ_MIN, FQ_MAX
+
 from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.core.common import constants as C

--- a/model_compression_toolkit/qat/pytorch/quantizer/ste_rounding/uniform_ste.py
+++ b/model_compression_toolkit/qat/pytorch/quantizer/ste_rounding/uniform_ste.py
@@ -17,11 +17,12 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN
+from model_compression_toolkit.core.common.constants import RANGE_MAX, RANGE_MIN, FQ_MIN, FQ_MAX
+from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
-from model_compression_toolkit.qat.common.constants import FQ_MIN, FQ_MAX
 from model_compression_toolkit.core.common import constants as C
-from model_compression_toolkit import quantizers_infrastructure as qi, TrainingMethod
+from model_compression_toolkit import quantizers_infrastructure as qi
+
 from model_compression_toolkit.qat.pytorch.quantizer.base_pytorch_qat_quantizer import BasePytorchQATTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.base_inferable_quantizer import mark_quantizer
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor

--- a/model_compression_toolkit/quantizers_infrastructure/constants.py
+++ b/model_compression_toolkit/quantizers_infrastructure/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,4 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.quantizers_infrastructure.constants import THRESHOLD_TENSOR, WEIGHTS_QUANTIZATION_PARAMS
+
+# Quantizers constants (for GPTQ, QAT, etc.)
+FQ_MIN = "min"
+FQ_MAX = "max"
+THRESHOLD_TENSOR = "ptq_threshold_tensor"
+WEIGHTS_QUANTIZATION_PARAMS = 'weights_quantization_params'

--- a/model_compression_toolkit/quantizers_infrastructure/trainable_infrastructure/common/get_quantizers.py
+++ b/model_compression_toolkit/quantizers_infrastructure/trainable_infrastructure/common/get_quantizers.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Union
+from typing import Union, Any
 
-from model_compression_toolkit.gptq import RoundingType
-from model_compression_toolkit import TrainingMethod
+# from model_compression_toolkit.gptq import RoundingType
+# from model_compression_toolkit.qat.common.qat_config import TrainingMethod
 from model_compression_toolkit.core.common import Logger
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.quantizers_infrastructure import QuantizationTarget
@@ -26,7 +26,7 @@ from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructur
 
 
 def get_trainable_quantizer_class(quant_target: QuantizationTarget,
-                                  quantizer_type: Union[TrainingMethod, RoundingType],
+                                  quantizer_type: Union[Any, Any], # TODO: Fix type hints
                                   quant_method: QuantizationMethod,
                                   quantizer_base_class: type) -> type:
     """

--- a/model_compression_toolkit/quantizers_infrastructure/trainable_infrastructure/common/get_quantizers.py
+++ b/model_compression_toolkit/quantizers_infrastructure/trainable_infrastructure/common/get_quantizers.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 from typing import Union, Any
 
-# from model_compression_toolkit.gptq import RoundingType
-# from model_compression_toolkit.qat.common.qat_config import TrainingMethod
 from model_compression_toolkit.core.common import Logger
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.quantizers_infrastructure import QuantizationTarget
@@ -26,7 +24,7 @@ from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructur
 
 
 def get_trainable_quantizer_class(quant_target: QuantizationTarget,
-                                  quantizer_type: Union[Any, Any], # TODO: Fix type hints
+                                  quantizer_type: Union[Any, Any],
                                   quant_method: QuantizationMethod,
                                   quantizer_base_class: type) -> type:
     """

--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
@@ -56,7 +56,7 @@ class QuantizationAwareTrainingTest(BaseKerasFeatureNetworkTest):
 
     def run_test(self, **kwargs):
         model_float = self.create_networks()
-        ptq_model, quantization_info, custom_objects = mct.keras_quantization_aware_training_init(model_float,
+        ptq_model, quantization_info, custom_objects = mct.qat.keras_quantization_aware_training_init(model_float,
                                                                                                   self.representative_data_gen,
                                                                                                   fw_info=self.get_fw_info(),
                                                                                                   target_platform_capabilities=self.get_tpc())
@@ -68,7 +68,7 @@ class QuantizationAwareTrainingTest(BaseKerasFeatureNetworkTest):
             os.remove('qat2model.h5')
 
         if self.finalize:
-            ptq_model = mct.keras_quantization_aware_training_finalize(ptq_model)
+            ptq_model = mct.qat.keras_quantization_aware_training_finalize(ptq_model)
 
         self.compare(ptq_model,
                      model_float,
@@ -153,7 +153,7 @@ class QATWrappersTest(BaseKerasFeatureNetworkTest):
 
     def run_test(self, **kwargs):
         model_float = self.create_networks()
-        ptq_model, quantization_info, custom_objects = mct.keras_quantization_aware_training_init(model_float,
+        ptq_model, quantization_info, custom_objects = mct.qat.keras_quantization_aware_training_init(model_float,
                                                                                                   self.representative_data_gen,
                                                                                                   fw_info=self.get_fw_info(),
                                                                                                   target_platform_capabilities=self.get_tpc())
@@ -180,7 +180,7 @@ class QATWrappersTest(BaseKerasFeatureNetworkTest):
 
         if self.finalize:
             # QAT finalize model
-            qat_finalize_model = mct.keras_quantization_aware_training_finalize(qat_model)
+            qat_finalize_model = mct.qat.keras_quantization_aware_training_finalize(qat_model)
             self.compare(qat_finalize_model,
                          finalize=True,
                          input_x=self.representative_data_gen(),
@@ -207,7 +207,7 @@ class QATWrappersTest(BaseKerasFeatureNetworkTest):
                             self.unit_test.assertTrue(isinstance(layer.activation_quantizers[0], q[0]))
                         else:
                             self.unit_test.assertTrue(isinstance(quantizer, BaseKerasTrainableQuantizer))
-                            q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.TrainingMethod.STE
+                            q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.qat.TrainingMethod.STE
                                  and _q.quantization_target == QuantizationTarget.Activation
                                  and self.activation_quantization_method in _q.quantization_method]
                             self.unit_test.assertTrue(len(q) == 1)
@@ -225,7 +225,7 @@ class QATWrappersTest(BaseKerasFeatureNetworkTest):
                             self.unit_test.assertTrue(isinstance(layer.weights_quantizers[KERNEL], q[0]))
                         else:
                             self.unit_test.assertTrue(isinstance(quantizer, BaseKerasTrainableQuantizer))
-                            q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.TrainingMethod.STE
+                            q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.qat.TrainingMethod.STE
                                  and _q.quantization_target == QuantizationTarget.Weights
                                  and self.weights_quantization_method in _q.quantization_method]
                             self.unit_test.assertTrue(len(q) == 1)
@@ -242,7 +242,7 @@ class QATWrappersMixedPrecisionCfgTest(MixedPrecisionActivationBaseTest):
     def run_test(self, **kwargs):
         model_float = self.create_networks()
         config = mct.CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2())
-        qat_ready_model, quantization_info, custom_objects = mct.keras_quantization_aware_training_init(
+        qat_ready_model, quantization_info, custom_objects = mct.qat.keras_quantization_aware_training_init(
             model_float,
             self.representative_data_gen_experimental,
             mct.KPI(weights_memory=self.kpi_weights, activation_memory=self.kpi_activation),

--- a/tests/pytorch_tests/model_tests/feature_models/qat_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/qat_test.py
@@ -96,7 +96,7 @@ class QuantizationAwareTrainingTest(BasePytorchFeatureNetworkTest):
                                                                                            target_platform_capabilities=_tpc,
                                                                                            new_experimental_exporter=True)
 
-        qat_ready_model, quantization_info = mct.pytorch_quantization_aware_training_init(model_float,
+        qat_ready_model, quantization_info = mct.qat.pytorch_quantization_aware_training_init(model_float,
                                                                                           self.representative_data_gen_experimental,
                                                                                           target_platform_capabilities=_tpc)
 
@@ -104,7 +104,7 @@ class QuantizationAwareTrainingTest(BasePytorchFeatureNetworkTest):
             pass # TODO: need to save and load pytorch model
 
         if self.finalize:
-            qat_finalized_model = mct.pytorch_quantization_aware_training_finalize(qat_ready_model)
+            qat_finalized_model = mct.qat.pytorch_quantization_aware_training_finalize(qat_ready_model)
         else:
             qat_finalized_model = None
 
@@ -120,13 +120,13 @@ class QuantizationAwareTrainingTest(BasePytorchFeatureNetworkTest):
         for _, layer in qat_ready_model.named_children():
             self.unit_test.assertTrue(isinstance(layer, qi.PytorchQuantizationWrapper))
             if isinstance(layer.layer, nn.SiLU):
-                q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.TrainingMethod.STE
+                q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.qat.TrainingMethod.STE
                      and _q.quantization_target == QuantizationTarget.Activation
                      and self.activation_quantization_method in _q.quantization_method]
                 self.unit_test.assertTrue(len(q) == 1)
                 self.unit_test.assertTrue(isinstance(layer.activation_quantizers[0], q[0]))
             if isinstance(layer.layer, nn.Conv2d):
-                q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.TrainingMethod.STE
+                q = [_q for _q in all_trainable_quantizers if _q.quantizer_type == mct.qat.TrainingMethod.STE
                      and _q.quantization_target == QuantizationTarget.Weights
                      and self.weights_quantization_method in _q.quantization_method]
                 self.unit_test.assertTrue(len(q) == 1)
@@ -178,7 +178,7 @@ class QuantizationAwareTrainingMixedPrecisionCfgTest(QuantizationAwareTrainingTe
         model_float = self.create_networks()
         config = mct.CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2())
         kpi = mct.KPI() # inf memory
-        qat_ready_model, quantization_info = mct.pytorch_quantization_aware_training_init(model_float,
+        qat_ready_model, quantization_info = mct.qat.pytorch_quantization_aware_training_init(model_float,
                                                                                           self.representative_data_gen_experimental,
                                                                                           kpi,
                                                                                           core_config=config,
@@ -222,7 +222,7 @@ class QuantizationAwareTrainingMixedPrecisionKpiCfgTest(QuantizationAwareTrainin
         model_float = self.create_networks()
         config = mct.CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2())
         kpi = mct.KPI(weights_memory=50, activation_memory=40)
-        qat_ready_model, quantization_info = mct.pytorch_quantization_aware_training_init(model_float,
+        qat_ready_model, quantization_info = mct.qat.pytorch_quantization_aware_training_init(model_float,
                                                                                           self.representative_data_gen_experimental,
                                                                                           kpi,
                                                                                           core_config=config,

--- a/tests/quantizers_infrastructure_tests/trainable_infrastructure_tests/keras/test_keras_trainable_infra_runner.py
+++ b/tests/quantizers_infrastructure_tests/trainable_infrastructure_tests/keras/test_keras_trainable_infra_runner.py
@@ -15,7 +15,7 @@
 import unittest
 import tensorflow as tf
 
-from model_compression_toolkit import TrainingMethod
+from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.qat.keras.quantizer.ste_rounding.symmetric_ste import STEWeightQATQuantizer, \
     STEActivationQATQuantizer

--- a/tests/quantizers_infrastructure_tests/trainable_infrastructure_tests/pytorch/test_pytorch_trainable_infra_runner.py
+++ b/tests/quantizers_infrastructure_tests/trainable_infrastructure_tests/pytorch/test_pytorch_trainable_infra_runner.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from model_compression_toolkit import TrainingMethod
+from model_compression_toolkit.qat import TrainingMethod
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.qat.pytorch.quantizer.ste_rounding.symmetric_ste import STEWeightQATQuantizer, \
     STEActivationQATQuantizer


### PR DESCRIPTION
This commit includes imports reordering which includes:
1. Moving QAT related API from main mct to mct.qat
2. Moving constants that are used by gptq and qat to the core constants (instead of being in qat constants).
3. Moving get_gptq_trainer_obj from FrameworkImplementation to a new class called GPTQFrameworkImplementation.
4. Adding 2 new classes (per-framewrok) that inherits GPTQFrameworkImplementation.