### PR TITLE
Add arguments for Keras tutorials

### DIFF
--- a/model_compression_toolkit/gptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/gptq/keras/quantization_facade.py
@@ -62,7 +62,8 @@ if common.constants.FOUND_TF:
                               optimizer: OptimizerV2 = tf.keras.optimizers.Adam(learning_rate=LR_DEFAULT),
                               optimizer_rest: OptimizerV2 = tf.keras.optimizers.Adam(learning_rate=LR_REST_DEFAULT),
                               loss: Callable = GPTQMultipleTensorsLoss(),
-                              log_function: Callable = None) -> GradientPTQConfigV2:
+                              log_function: Callable = None,
+                              use_hessian_based_weights: bool = True) -> GradientPTQConfigV2:
         """
         Create a GradientPTQConfigV2 instance for Keras models.
 
@@ -72,6 +73,7 @@ if common.constants.FOUND_TF:
             optimizer_rest (OptimizerV2): Keras optimizer to use for fine-tuning of the bias variable.
             loss (Callable): loss to use during fine-tuning. should accept 4 lists of tensors. 1st list of quantized tensors, the 2nd list is the float tensors, the 3rd is a list of quantized weights and the 4th is a list of float weights.
             log_function (Callable): Function to log information about the gptq process.
+            use_hessian_based_weights (bool): Whether to use Hessian-based weights for weighted average loss.
 
         returns:
             a GradientPTQConfigV2 object to use when fine-tuning the quantized model using gptq.
@@ -94,9 +96,16 @@ if common.constants.FOUND_TF:
             The configuration can be passed to :func:`~model_compression_toolkit.keras_post_training_quantization` in order to quantize a keras model using gptq.
 
         """
-        bias_optimizer = tf.keras.optimizers.SGD(learning_rate=LR_BIAS_DEFAULT, momentum=GPTQ_MOMENTUM)
-        return GradientPTQConfigV2(n_epochs, optimizer, optimizer_rest=optimizer_rest, loss=loss,
-                                   log_function=log_function, train_bias=True, optimizer_bias=bias_optimizer)
+        bias_optimizer = tf.keras.optimizers.SGD(learning_rate=LR_BIAS_DEFAULT,
+                                                 momentum=GPTQ_MOMENTUM)
+        return GradientPTQConfigV2(n_epochs,
+                                   optimizer,
+                                   optimizer_rest=optimizer_rest,
+                                   loss=loss,
+                                   log_function=log_function,
+                                   train_bias=True,
+                                   optimizer_bias=bias_optimizer,
+                                   use_hessian_based_weights=use_hessian_based_weights)
 
 
     def keras_gradient_post_training_quantization_experimental(in_model: Model,

--- a/tutorials/example_keras_mobilenet_mixed_precision.py
+++ b/tutorials/example_keras_mobilenet_mixed_precision.py
@@ -60,6 +60,10 @@ def argument_handler():
                         help='batch size for the representative data.')
     parser.add_argument('--num_calibration_iterations', type=int, default=10,
                         help='number of iterations for calibration.')
+    parser.add_argument('--mixed_precision_num_of_images', type=int, default=32,
+                        help='number of images to use for mixed-precision configuration search.')
+    parser.add_argument('--enable_mixed_precision_gradients_weighting', action='store_true', default=False,
+                        help='Whether to use gradients during mixed-precision configuration search or not.')
     parser.add_argument('--weights_compression_ratio', type=float, default=0.75,
                         help='weights compression ratio.')
     return parser.parse_args()
@@ -103,7 +107,8 @@ if __name__ == '__main__':
     # MCT will search a mixed-precision configuration (namely, bit-width for each layer)
     # and quantize the model according to this configuration.
     # The candidates bit-width for quantization should be defined in the target platform model:
-    configuration = CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2())
+    configuration = CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
+                                                                                         use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
 
     # Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.
     # Here, for example, we use the default platform that is attached to a Tensorflow layers representation.

--- a/tutorials/example_keras_mobilenet_mixed_precision_lut.py
+++ b/tutorials/example_keras_mobilenet_mixed_precision_lut.py
@@ -14,8 +14,10 @@
 # ==============================================================================
 
 import argparse
-import model_compression_toolkit as mct
+
 from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
+
+import model_compression_toolkit as mct
 
 """
 Mixed precision is a method for quantizing a model using different bit widths
@@ -64,6 +66,11 @@ def argument_handler():
                         help='number of iterations for calibration.')
     parser.add_argument('--weights_compression_ratio', type=float, default=0.4,
                         help='weights compression ratio.')
+    parser.add_argument('--mixed_precision_num_of_images', type=int, default=32,
+                        help='number of images to use for mixed-precision configuration search.')
+    parser.add_argument('--enable_mixed_precision_gradients_weighting', action='store_true', default=False,
+                        help='Whether to use gradients during mixed-precision configuration search or not.')
+
     return parser.parse_args()
 
 
@@ -105,7 +112,8 @@ if __name__ == '__main__':
     # MCT will search a mixed-precision configuration (namely, bit-width for each layer)
     # and quantize the model according to this configuration.
     # The candidates bit-width for quantization should be defined in the target platform model:
-    configuration = CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2())
+    configuration = CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
+                                                                                         use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
 
     # Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.
     # In this example, we use a pre-defined platform that allows us to set a non-uniform (LUT) quantizer


### PR DESCRIPTION
Add arguments to Keras tutorials.
Add use_hessian_based_weights to get_keras_gptq_config API (True by default).