### PR TITLE
Qi refactor qat

### DIFF
--- a/model_compression_toolkit/qat/keras/quantization_facade.py
+++ b/model_compression_toolkit/qat/keras/quantization_facade.py
@@ -22,6 +22,7 @@ from model_compression_toolkit.constants import FOUND_TF
 from model_compression_toolkit.core.common.mixed_precision.kpi_tools.kpi import KPI
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
     MixedPrecisionQuantizationConfigV2
+from model_compression_toolkit.quantizers_infrastructure import ActivationQuantizationHolder
 from model_compression_toolkit.target_platform_capabilities.target_platform.targetplatform2framework import TargetPlatformCapabilities
 from model_compression_toolkit.core.runner import core_runner, _init_tensorboard_writer
 from model_compression_toolkit.ptq.runner import ptq_runner
@@ -261,7 +262,7 @@ if FOUND_TF:
 
          """
         def _export(layer):
-            if isinstance(layer, qi.KerasQuantizationWrapper):
+            if isinstance(layer, (qi.KerasQuantizationWrapper, ActivationQuantizationHolder)):
                 layer.convert_to_inferable_quantizers()
             return layer
 

--- a/model_compression_toolkit/qat/keras/quantization_facade.py
+++ b/model_compression_toolkit/qat/keras/quantization_facade.py
@@ -49,7 +49,8 @@ if FOUND_TF:
     from model_compression_toolkit.qat.common.qat_config import _is_qat_applicable
     from model_compression_toolkit.target_platform_capabilities.constants import DEFAULT_TP_MODEL
     from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
-    from model_compression_toolkit.qat.keras.quantizer.quantization_builder import quantization_builder
+    from model_compression_toolkit.qat.keras.quantizer.quantization_builder import quantization_builder, \
+    get_activation_quantizer_holder
     from model_compression_toolkit.qat.common.qat_config import QATConfig
     from model_compression_toolkit import quantizers_infrastructure as qi
 
@@ -59,7 +60,7 @@ if FOUND_TF:
     def qat_wrapper(n: common.BaseNode,
                     layer: Layer,
                     qat_config: QATConfig,
-                    include_activation_quantizers: bool=True):
+                    include_activation_quantizers: bool=False):
         """
         A function which takes a computational graph node and a keras layer and perform the quantization wrapping
         Args:
@@ -197,7 +198,9 @@ if FOUND_TF:
         _qat_wrapper = partial(qat_wrapper, qat_config=qat_config)
         qat_model, user_info = KerasModelBuilder(graph=tg,
                                                  fw_info=fw_info,
-                                                 wrapper=_qat_wrapper).build_model()
+                                                 wrapper=_qat_wrapper,
+                                                 get_activation_quantizer_holder_fn=partial(get_activation_quantizer_holder,
+                                                                                            qat_config=qat_config)).build_model()
 
         user_info.mixed_precision_cfg = bit_widths_config
         #TODO: remove the last output after updating documentation.

--- a/model_compression_toolkit/qat/keras/quantizer/quantization_builder.py
+++ b/model_compression_toolkit/qat/keras/quantizer/quantization_builder.py
@@ -12,18 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Tuple, Dict, List
+from typing import Tuple, Dict, List, Union, Callable
 
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo
+from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
+from model_compression_toolkit.qat.common.qat_config import QATConfig, _is_qat_applicable
+from model_compression_toolkit.qat.keras.quantizer.base_keras_qat_quantizer import BaseKerasQATTrainableQuantizer
+from model_compression_toolkit.quantizers_infrastructure import QuantizationTarget, ActivationQuantizationHolder
 from model_compression_toolkit.quantizers_infrastructure.trainable_infrastructure.common.get_quantizer_config import \
     get_trainable_quantizer_weights_config, get_trainable_quantizer_activation_config, \
     get_trainable_quantizer_quantization_candidates
-from model_compression_toolkit.qat.keras.quantizer.base_keras_qat_quantizer import BaseKerasQATTrainableQuantizer
-from model_compression_toolkit.qat.common.qat_config import QATConfig
-from model_compression_toolkit.quantizers_infrastructure import QuantizationTarget
 from model_compression_toolkit.quantizers_infrastructure.trainable_infrastructure.common.get_quantizers import \
     get_trainable_quantizer_class
+
+
+def get_activation_quantizer_holder(n: common.BaseNode,
+                                    qat_config: QATConfig) -> Union[None, Callable]:
+    """
+    Retrieve a ActivationQuantizationHolder layer to use for activation quantization for a node.
+    If the layer is not supposed to be wrapped with activation quantizers - return None.
+
+    Args:
+        n: Node to get ActivationQuantizationHolder to attach in its output.
+        qat_config: Configuration of QAT (such as training methods for example).
+
+    Returns:
+        A ActivationQuantizationHolder layer for the node activation quantization.
+    """
+    if _is_qat_applicable(n, DEFAULT_KERAS_INFO):
+        _, activation_quantizers = quantization_builder(n,
+                                                        qat_config,
+                                                        DEFAULT_KERAS_INFO)
+
+        # Holder by definition uses a single quantizer for the activation quantization
+        # thus we make sure this is the only possible case (unless it's a node we no activation
+        # quantization, which in this case has an empty list).
+        if len(activation_quantizers) > 0:
+            assert len(activation_quantizers) == 1, f'ActivationQuantizationHolder supports a ' \
+                                                    f'single quantizer but {len(activation_quantizers)} quantizers ' \
+                                                    f'were found for node {n}'
+            return ActivationQuantizationHolder(activation_quantizers[0])
+    return None
 
 
 def quantization_builder(n: common.BaseNode,

--- a/model_compression_toolkit/qat/keras/quantizer/quantization_builder.py
+++ b/model_compression_toolkit/qat/keras/quantizer/quantization_builder.py
@@ -46,7 +46,7 @@ def get_activation_quantizer_holder(n: common.BaseNode,
                                                         DEFAULT_KERAS_INFO)
 
         # Holder by definition uses a single quantizer for the activation quantization
-        # thus we make sure this is the only possible case (unless it's a node we no activation
+        # thus we make sure this is the only possible case (unless it's a node with no activation
         # quantization, which in this case has an empty list).
         if len(activation_quantizers) > 0:
             assert len(activation_quantizers) == 1, f'ActivationQuantizationHolder supports a ' \

--- a/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/activation_quantization_holder.py
+++ b/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/activation_quantization_holder.py
@@ -16,10 +16,22 @@
 from model_compression_toolkit.constants import FOUND_TF
 from model_compression_toolkit.logger import Logger
 from model_compression_toolkit.quantizers_infrastructure import BaseInferableQuantizer
-from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.constants import ACTIVATION_HOLDER_QUANTIZER
+from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.constants import \
+    ACTIVATION_HOLDER_QUANTIZER, TRAINING, STEPS
 
 if FOUND_TF:
     import tensorflow as tf
+    from keras.utils import tf_inspect
+    from tensorflow_model_optimization.python.core.keras import utils
+
+    def _make_quantizer_fn(quantizer, x, training):
+        """Use currying to return True/False specialized fns to the cond."""
+
+        def quantizer_fn():
+            return quantizer(x, training)
+
+        return quantizer_fn
+
     keras = tf.keras
 
     class ActivationQuantizationHolder(keras.layers.Layer):
@@ -55,7 +67,7 @@ if FOUND_TF:
             """
 
             Args:
-                config(dict): dictionary  of  ActivationQuantizationHolder Configuration
+                config(dict): dictionary  of ActivationQuantizationHolder Configuration
 
             Returns: A ActivationQuantizationHolder object
 
@@ -68,17 +80,52 @@ if FOUND_TF:
             return cls(activation_holder_quantizer=activation_holder_quantizer,
                        **config)
 
-        def call(self, inputs):
+        def build(self, input_shape):
+            """
+            ActivationQuantizationHolder build function.
+            Args:
+                input_shape: the layer input shape
+
+            Returns: None
+
+            """
+            super(ActivationQuantizationHolder, self).build(input_shape)
+
+            self.optimizer_step = self.add_weight(
+                STEPS,
+                initializer=tf.keras.initializers.Constant(-1),
+                dtype=tf.dtypes.int32,
+                trainable=False)
+
+            self.activation_holder_quantizer.initialize_quantization(None,
+                                                                     self.name + '/out_',
+                                                                     self)
+
+        def call(self,
+                 inputs: tf.Tensor,
+                 training=None) -> tf.Tensor:
             """
             Quantizes the input tensor using the activation quantizer the ActivationQuantizationHolder holds.
 
             Args:
                 inputs: Input tensors to quantize use the activation quantizer the object holds
+                training: a boolean stating if layer is in training mode.
 
             Returns: Output of the activation quantizer (quantized input tensor).
 
             """
+            if training is None:
+                training = tf.keras.backend.learning_phase()
+
+            activation_quantizer_args_spec = tf_inspect.getfullargspec(self.activation_holder_quantizer.__call__).args
+            if TRAINING in activation_quantizer_args_spec:
+                return utils.smart_cond(
+                    training,
+                    _make_quantizer_fn(self.activation_holder_quantizer, inputs, True),
+                    _make_quantizer_fn(self.activation_holder_quantizer, inputs, False))
+
             return self.activation_holder_quantizer(inputs)
+
 
 else:
     class ActivationQuantizationHolder:  # pragma: no cover

--- a/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/activation_quantization_holder.py
+++ b/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/activation_quantization_holder.py
@@ -15,7 +15,7 @@
 
 from model_compression_toolkit.constants import FOUND_TF
 from model_compression_toolkit.logger import Logger
-from model_compression_toolkit.quantizers_infrastructure import BaseInferableQuantizer
+from model_compression_toolkit.quantizers_infrastructure import BaseInferableQuantizer, BaseKerasTrainableQuantizer
 from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.common.constants import \
     ACTIVATION_HOLDER_QUANTIZER, TRAINING, STEPS
 
@@ -125,6 +125,18 @@ if FOUND_TF:
                     _make_quantizer_fn(self.activation_holder_quantizer, inputs, False))
 
             return self.activation_holder_quantizer(inputs)
+
+        def convert_to_inferable_quantizers(self):
+            """
+            Convert layer's quantizer to inferable quantizer.
+
+            Returns:
+                None
+            """
+            if isinstance(self.activation_holder_quantizer, BaseKerasTrainableQuantizer):
+                self.activation_holder_quantizer = self.activation_holder_quantizer.convert2inferable()
+
+
 
 
 else:

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -91,7 +91,8 @@ from tests.keras_tests.feature_networks_tests.feature_networks.output_in_middle_
 from tests.keras_tests.feature_networks_tests.feature_networks.per_tensor_weight_quantization_test import \
     PerTensorWeightQuantizationTest
 from tests.keras_tests.feature_networks_tests.feature_networks.qat.qat_test import QATWrappersTest, \
-    QuantizationAwareTrainingQuantizersTest, QATWrappersMixedPrecisionCfgTest
+    QuantizationAwareTrainingQuantizersTest, QATWrappersMixedPrecisionCfgTest, \
+    QuantizationAwareTrainingQuantizerHolderTest
 from tests.keras_tests.feature_networks_tests.feature_networks.relu_replacement_test import ReluReplacementTest, \
     SingleReluReplacementTest, ReluReplacementWithAddBiasTest
 from tests.keras_tests.feature_networks_tests.feature_networks.residual_collapsing_test import ResidualCollapsingTest1, \
@@ -671,6 +672,7 @@ class FeatureNetworkTest(unittest.TestCase):
         # DW-Conv2D are tested under the tests below because an extra check is needed to verify the
         # quantization per channel of its kernel TODO: should be part of the quantizers tests
         QuantizationAwareTrainingQuantizersTest(self).run_test()
+        QuantizationAwareTrainingQuantizerHolderTest(self).run_test()
         QATWrappersMixedPrecisionCfgTest(self).run_test()
         QATWrappersMixedPrecisionCfgTest(self,kpi_weights=17920 * 4 / 8, kpi_activation=5408 * 4 / 8, expected_mp_cfg=[0, 4, 1, 1]).run_test()
 


### PR DESCRIPTION
Use ActivationQuantizationHolder for QAT ready models. The wrappers that were used for QAT are no longer hold the activation quantizers.