### PR TITLE
Fix inferable quantizers serialization and inference issues

### DIFF
--- a/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -71,8 +71,10 @@ if FOUND_TF:
                                              adj_min=_min_range,
                                              adj_max=_max_range)
 
-            self.max_range = _max_range[0]
-            self.min_range = _min_range[0]
+            # Save ranges as lists since during deserialization
+            # init expects list as returned values from get_config
+            self.max_range = _max_range.tolist()
+            self.min_range = _min_range.tolist()
 
 
         def __call__(self, inputs:tf.Tensor) -> tf.Tensor:
@@ -88,8 +90,8 @@ if FOUND_TF:
             assert inputs.dtype==tf.float32, f'Input tensor was expected to be a float tensor but is of type {inputs.dtype}'
 
             return tf.quantization.fake_quant_with_min_max_vars(inputs,
-                                                                min=self.min_range,
-                                                                max=self.max_range,
+                                                                min=self.min_range[0],
+                                                                max=self.max_range[0],
                                                                 num_bits=self.num_bits)
 
         def get_config(self):

--- a/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/model_compression_toolkit/quantizers_infrastructure/inferable_infrastructure/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -37,7 +37,7 @@ if FOUND_TF:
 
         def __init__(self,
                      num_bits: int,
-                     cluster_centers: np.ndarray,
+                     cluster_centers: List[float],
                      threshold: List[float],
                      per_channel: bool,
                      channel_axis: int = None,
@@ -67,8 +67,8 @@ if FOUND_TF:
                                                                   multiplier_n_bits=multiplier_n_bits,
                                                                   eps=eps)
 
-            is_threshold_pot = np.all([int(np.log2(x)) == np.log2(x) for x in self.threshold.flatten()])
-            assert is_threshold_pot, f'Expected threshold to be power of 2 but is {self.threshold}'
+            is_threshold_pot = np.all([int(np.log2(x)) == np.log2(x) for x in self._np_threshold.flatten()])
+            assert is_threshold_pot, f'Expected threshold to be power of 2 but is {self._np_threshold}'
 
 
 else:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -148,9 +148,9 @@ class LUTActivationQuantizerTest(BaseKerasFeatureNetworkTest):
             # Check that lut quantizer layer is added where expected (after each layer, for quantizing activation)
             self.unit_test.assertTrue(isinstance(ll.activation_quantizers[0], ActivationLutPOTInferableQuantizer))
             # Check layer's thresholds are power of two
-            self.unit_test.assertTrue(math.log2(ll.activation_quantizers[0].get_config()[THRESHOLD]).is_integer())
+            self.unit_test.assertTrue(math.log2(ll.activation_quantizers[0].get_config()[THRESHOLD][0]).is_integer())
             # Check layers number of clusters and clusters values
-            self.unit_test.assertTrue(ll.activation_quantizers[0].get_config()[CLUSTER_CENTERS].shape[0] <= 2 ** self.activation_n_bits)
+            self.unit_test.assertTrue(len(ll.activation_quantizers[0].get_config()[CLUSTER_CENTERS]) <= 2 ** self.activation_n_bits)
             self.unit_test.assertTrue(np.all(np.mod(ll.activation_quantizers[0].get_config()[CLUSTER_CENTERS], 1) == 0))
 
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -83,11 +83,20 @@ class UniformRangeSelectionBoundedActivationTest(UniformRangeSelectionActivation
         input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
         softmax_layer_min, softmax_layer_max = fake_layer_softmax_args['min_range'], fake_layer_softmax_args['max_range']
 
+        self.unit_test.assertTrue(len(input_layer_min) == 1,
+                                  f'Activation quantizer must have a single min value but found {len(input_layer_min)}')
+        self.unit_test.assertTrue(len(input_layer_max) == 1,
+                                  f'Activation quantizer must have a single max value but found {len(input_layer_max)}')
+        self.unit_test.assertTrue(len(softmax_layer_min) == 1,
+                                  f'Activation quantizer must have a single min value but found {len(softmax_layer_min)}')
+        self.unit_test.assertTrue(len(softmax_layer_max) == 1,
+                                  f'Activation quantizer must have a single max value but found {len(softmax_layer_max)}')
+
         # Verify quantization range contains zero
-        self.unit_test.assertTrue(input_layer_min <= 0.0 <= input_layer_max,
-                                  msg=f"0.0 is not within the quantization range ({input_layer_min}, {input_layer_max})"
+        self.unit_test.assertTrue(input_layer_min[0] <= 0.0 <= input_layer_max[0],
+                                  msg=f"0.0 is not within the quantization range ({input_layer_min[0]}, {input_layer_max[0]})"
                                       f"for Input layer.")
 
         # Check range_min, range_max == softmax_layer's bound
-        self.unit_test.assertTrue(softmax_layer_min == 0.0)
-        self.unit_test.assertTrue(softmax_layer_max == 1.0)
+        self.unit_test.assertTrue(softmax_layer_min[0] == 0.0)
+        self.unit_test.assertTrue(softmax_layer_max[0] == 1.0)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -58,10 +58,20 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
         input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
         add_layer_min, add_layer_max = fake_layer_add_args['min_range'], fake_layer_add_args['max_range']
 
-        self.unit_test.assertTrue(input_layer_min <= 0.0 <= input_layer_max,
+
+        self.unit_test.assertTrue(len(input_layer_min) == 1,
+                                  f'Activation quantizer must have a single min value but found {len(input_layer_min)}')
+        self.unit_test.assertTrue(len(input_layer_max) == 1,
+                                  f'Activation quantizer must have a single max value but found {len(input_layer_max)}')
+        self.unit_test.assertTrue(len(add_layer_min) == 1,
+                                  f'Activation quantizer must have a single min value but found {len(add_layer_min)}')
+        self.unit_test.assertTrue(len(add_layer_max) == 1,
+                                  f'Activation quantizer must have a single max value but found {len(add_layer_max)}')
+
+        self.unit_test.assertTrue(input_layer_min[0] <= 0.0 <= input_layer_max[0],
                                   msg=f"0.0 is not within the quantization range ({input_layer_min}, {input_layer_max}) "
                                       f"for Input layer.")
-        self.unit_test.assertTrue(add_layer_min <= 0.0 <= add_layer_max,
+        self.unit_test.assertTrue(add_layer_min[0] <= 0.0 <= add_layer_max[0],
                                   msg=f"0.0 is not within the quantization range ({add_layer_min}, {add_layer_max}) "
                                       f"for Relu layer.")
 

--- a/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_activation_inferable_quantizers.py
+++ b/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_activation_inferable_quantizers.py
@@ -198,7 +198,7 @@ class TestKerasActivationsUnsignedPOTInferableQuantizer(BaseInferableQuantizerTe
             np.log2(delta) == np.log2(delta).astype(int))
         self.unit_test.assertTrue(is_pot_delta, f'Expected delta to be POT but: {delta}')
 
-        self.unit_test.assertTrue(np.all(quantizer.min_range == 0))
+        self.unit_test.assertTrue(np.all(quantizer.min_range == [0]))
 
         # Initialize a random input to quantize between -50 to 50.
         input_tensor = tf.constant(np.random.rand(1, 50, 50, 3) * 100 - 50, tf.float32)

--- a/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_load_model.py
+++ b/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_load_model.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from keras import Input
 from keras.layers import Conv2D
 from tensorflow import keras
 
@@ -32,7 +33,11 @@ from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructur
 class TestKerasLoadModel(unittest.TestCase):
 
     def _one_layer_model_save_and_load(self, layer_with_quantizer):
-        model = keras.Sequential([layer_with_quantizer])
+        # Create one layer model (layer is reused twice)
+        model_input = Input((5,5,3))
+        x = layer_with_quantizer(model_input)
+        model_output = layer_with_quantizer(x)
+        model = keras.models.Model(model_input, model_output)
 
         x = np.random.randn(1,5,5,3)
         pred = model(x)

--- a/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_load_model.py
+++ b/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_load_model.py
@@ -1,0 +1,176 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+from keras.layers import Conv2D
+from tensorflow import keras
+
+from model_compression_toolkit.quantizers_infrastructure import keras_load_quantized_model, \
+    ActivationQuantizationHolder, KerasQuantizationWrapper
+from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.keras.quantizers import \
+    ActivationPOTInferableQuantizer, WeightsUniformInferableQuantizer, WeightsLUTSymmetricInferableQuantizer, \
+    ActivationSymmetricInferableQuantizer, ActivationUniformInferableQuantizer, WeightsPOTInferableQuantizer, \
+    ActivationLutPOTInferableQuantizer, WeightsSymmetricInferableQuantizer, WeightsLUTPOTInferableQuantizer
+
+
+class TestKerasLoadModel(unittest.TestCase):
+
+    def _one_layer_model_save_and_load(self, layer_with_quantizer):
+        model = keras.Sequential([layer_with_quantizer])
+
+        x = np.random.randn(1,5,5,3)
+        pred = model(x)
+
+        _, tmp_h5_file = tempfile.mkstemp('.h5')
+        keras.models.save_model(model, tmp_h5_file)
+        loaded_model = keras_load_quantized_model(tmp_h5_file)
+        os.remove(tmp_h5_file)
+
+        loaded_pred = loaded_model(x)
+        self.assertTrue(np.all(loaded_pred == pred))
+
+    def test_save_and_load_activation_pot(self):
+        num_bits = 3
+        thresholds = [4.]
+        signed = True
+        quantizer = ActivationPOTInferableQuantizer(num_bits=num_bits,
+                                                    threshold=thresholds,
+                                                    signed=signed)
+        layer_with_quantizer = ActivationQuantizationHolder(quantizer)
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_activation_symmetric(self):
+        num_bits = 3
+        thresholds = [4.]
+        signed = True
+        quantizer = ActivationSymmetricInferableQuantizer(num_bits=num_bits,
+                                                          threshold=thresholds,
+                                                          signed=signed)
+        layer_with_quantizer = ActivationQuantizationHolder(quantizer)
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_activation_uniform(self):
+        num_bits = 3
+        min_range = [1.]
+        max_range = [4.]
+        quantizer = ActivationUniformInferableQuantizer(num_bits=num_bits,
+                                                        min_range=min_range,
+                                                        max_range=max_range)
+        layer_with_quantizer = ActivationQuantizationHolder(quantizer)
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_activation_lut_pot(self):
+        cluster_centers = [-25, 25]
+        thresholds = [4.]
+        num_bits = 3
+        signed = True
+        multiplier_n_bits = 8
+        eps = 1e-8
+
+        quantizer = ActivationLutPOTInferableQuantizer(num_bits=num_bits,
+                                                       cluster_centers=cluster_centers,
+                                                       signed=signed,
+                                                       threshold=thresholds,
+                                                       multiplier_n_bits=
+                                                       multiplier_n_bits,
+                                                       eps=eps)
+
+        layer_with_quantizer = ActivationQuantizationHolder(quantizer)
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_weights_pot(self):
+        thresholds = [4., 0.5, 2.]
+        num_bits = 2
+        quantizer = WeightsPOTInferableQuantizer(num_bits=num_bits,
+                                                 per_channel=True,
+                                                 threshold=thresholds,
+                                                 channel_axis=3,
+                                                 input_rank=4)
+        layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3, 3),
+                                                        {'kernel': quantizer})
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_weights_symmetric(self):
+        thresholds = [3., 6., 2.]
+        num_bits = 2
+        quantizer = WeightsSymmetricInferableQuantizer(num_bits=num_bits,
+                                                       per_channel=True,
+                                                       threshold=thresholds,
+                                                       channel_axis=3,
+                                                       input_rank=4)
+        layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3, 3),
+                                                        {'kernel': quantizer})
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_weights_uniform(self):
+        min_range = [3., 6., 2.]
+        max_range = [13., 16., 12.]
+        num_bits = 2
+        quantizer = WeightsUniformInferableQuantizer(num_bits=num_bits,
+                                                     per_channel=True,
+                                                     min_range=min_range,
+                                                     max_range=max_range,
+                                                     channel_axis=3,
+                                                     input_rank=4)
+        layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3, 3),
+                                                        {'kernel': quantizer})
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+    def test_save_and_load_weights_lut_symmetric(self):
+        cluster_centers = [-25, 25]
+        per_channel = True
+        input_rank = 4
+        num_bits = 8
+        threshold = [3., 8., 7.]
+        channel_axis = 3
+        multiplier_n_bits = 8
+        eps = 1e-8
+        quantizer = WeightsLUTSymmetricInferableQuantizer(num_bits=num_bits,
+                                                          cluster_centers=cluster_centers,
+                                                          threshold=threshold,
+                                                          per_channel=per_channel,
+                                                          channel_axis=channel_axis,
+                                                          input_rank=input_rank,
+                                                          multiplier_n_bits=multiplier_n_bits,
+                                                          eps=eps)
+        layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3,3),
+                                                        {'kernel': quantizer})
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+
+    def test_save_and_load_weights_lut_pot(self):
+        cluster_centers = [-25, 25]
+        per_channel = True
+        input_rank = 4
+        num_bits = 8
+        threshold = [1., 8., 4.]
+        channel_axis = 3
+        multiplier_n_bits = 8
+        eps = 1e-8
+        quantizer = WeightsLUTPOTInferableQuantizer(num_bits=num_bits,
+                                                    cluster_centers=cluster_centers,
+                                                    threshold=threshold,
+                                                    per_channel=per_channel,
+                                                    channel_axis=channel_axis,
+                                                    input_rank=input_rank,
+                                                    multiplier_n_bits=multiplier_n_bits,
+                                                    eps=eps)
+        layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3, 3),
+                                                        {'kernel': quantizer})
+        self._one_layer_model_save_and_load(layer_with_quantizer)

--- a/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_weights_lut_inferable_quantizer.py
+++ b/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/inferable_keras/test_weights_lut_inferable_quantizer.py
@@ -203,6 +203,8 @@ class BaseKerasWeightsLUTQuantizerTest(BaseInferableQuantizerTest):
         clip_max = 2 ** (multiplier_n_bits - 1) - 1
         clip_min = -2 ** (multiplier_n_bits - 1)
 
+        cluster_centers = np.asarray(cluster_centers, np.float32)
+
         if per_channel:
             for i in range(len(threshold)):
                 channel_slice_i = quantized_tensor[:, :, :, i]
@@ -325,7 +327,7 @@ class TestKerasWeightsSymmetricLUTQuantizer(BaseKerasWeightsLUTQuantizerTest):
 
     def run_test(self):
         inferable_quantizer = WeightsLUTSymmetricInferableQuantizer
-        cluster_centers = np.asarray([-25, 25])
+        cluster_centers = [-25, 25]
         per_channel = True
         input_rank = 4
         num_bits = 8
@@ -373,7 +375,7 @@ class TestKerasWeightsLUTPOTQuantizerAssertions(BaseKerasWeightsLUTQuantizerTest
                                 threshold=[3.],
                                 channel_axis=None,
                                 input_rank=4)
-        self.unit_test.assertEqual('Expected threshold to be power of 2 but is 3.0', str(e.exception))
+        self.unit_test.assertEqual('Expected threshold to be power of 2 but is [3.]', str(e.exception))
 
         cluster_centers = np.asarray([-25.6, 25])
         per_channel = False

--- a/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/test_keras_inferable_infra_runner.py
+++ b/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/test_keras_inferable_infra_runner.py
@@ -53,6 +53,14 @@ class KerasInferableInfrastructureTestRunner(unittest.TestCase):
 
     def test_save_and_load_quantizers(self):
         TestKerasLoadModel().test_save_and_load_weights_uniform()
+        TestKerasLoadModel().test_save_and_load_weights_symmetric()
+        TestKerasLoadModel().test_save_and_load_weights_pot()
+        TestKerasLoadModel().test_save_and_load_weights_lut_symmetric()
+        TestKerasLoadModel().test_save_and_load_weights_lut_pot()
+        TestKerasLoadModel().test_save_and_load_activation_lut_pot()
+        TestKerasLoadModel().test_save_and_load_activation_pot()
+        TestKerasLoadModel().test_save_and_load_activation_uniform()
+        TestKerasLoadModel().test_save_and_load_activation_symmetric()
 
     def test_weights_inferable_quantizers(self):
         TestKerasWeightsPOTInferableQuantizerRaise(self).run_test()

--- a/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/test_keras_inferable_infra_runner.py
+++ b/tests/quantizers_infrastructure_tests/inferable_infrastructure_tests/keras/test_keras_inferable_infra_runner.py
@@ -31,6 +31,8 @@ from tests.quantizers_infrastructure_tests.inferable_infrastructure_tests.keras.
 from tests.quantizers_infrastructure_tests.inferable_infrastructure_tests.keras.inferable_keras.test_activation_quantizer_holder import TestActivationQuantizationHolderInference, TestActivationQuantizationHolderSaveAndLoad
 from tests.quantizers_infrastructure_tests.inferable_infrastructure_tests.keras.inferable_keras.test_get_quantizers import \
     TestGetInferableQuantizer
+from tests.quantizers_infrastructure_tests.inferable_infrastructure_tests.keras.inferable_keras.test_load_model import \
+    TestKerasLoadModel
 from tests.quantizers_infrastructure_tests.inferable_infrastructure_tests.keras.inferable_keras.test_weights_inferable_quantizer import \
     TestKerasWeightsPOTInferableQuantizerRaise, \
     TestKerasWeightsPOTInferableSignedPerTensorQuantizer, TestKerasWeightsPOTInferableSignedPerChannelQuantizer, \
@@ -48,6 +50,9 @@ layers = tf.keras.layers
 
 
 class KerasInferableInfrastructureTestRunner(unittest.TestCase):
+
+    def test_save_and_load_quantizers(self):
+        TestKerasLoadModel().test_save_and_load_weights_uniform()
 
     def test_weights_inferable_quantizers(self):
         TestKerasWeightsPOTInferableQuantizerRaise(self).run_test()


### PR DESCRIPTION
Fix issues with inferable quantizers:
1. Keras quantizers should receive list in their init instead of np arrays. The reason for that is that during deserialization keras build the quantizers with lists (even if they were saved as np arrays).
2. In LUT weight quantizers the kernel had dtype of float64 which failed inference. The reason for this is that by default numpy arrays are float64. This commit fixes this by explicity stating the dtype to be float32.