### PR TITLE
Add old APIs

### DIFF
--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -25,7 +25,6 @@ from model_compression_toolkit import ptq
 from model_compression_toolkit import qat
 from model_compression_toolkit import exporter
 from model_compression_toolkit import gptq
-from model_compression_toolkit.gptq import GradientPTQConfig
 
 
 # Old API (will not be accessible in future releases)

--- a/model_compression_toolkit/__init__.py
+++ b/model_compression_toolkit/__init__.py
@@ -28,4 +28,26 @@ from model_compression_toolkit import gptq
 from model_compression_toolkit.gptq import GradientPTQConfig
 
 
+# Old API (will not be accessible in future releases)
+from model_compression_toolkit.core.common import network_editors as network_editor
+from model_compression_toolkit.core.common.quantization import quantization_config
+from model_compression_toolkit.core.common.mixed_precision import mixed_precision_quantization_config
+from model_compression_toolkit.core.common.quantization.debug_config import DebugConfig
+from model_compression_toolkit.core.common.quantization.quantization_config import QuantizationConfig, QuantizationErrorMethod, DEFAULTCONFIG
+from model_compression_toolkit.core.common.mixed_precision.kpi_tools.kpi import KPI
+from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig
+from model_compression_toolkit.logger import set_log_folder
+from model_compression_toolkit.core.common.data_loader import FolderImageLoader
+from model_compression_toolkit.core.common.framework_info import FrameworkInfo, ChannelAxis
+from model_compression_toolkit.core.common.defaultdict import DefaultDict
+from model_compression_toolkit.legacy.keras_quantization_facade import keras_post_training_quantization, keras_post_training_quantization_mixed_precision
+from model_compression_toolkit.legacy.pytorch_quantization_facade import pytorch_post_training_quantization, pytorch_post_training_quantization_mixed_precision
+from model_compression_toolkit.core.keras.kpi_data_facade import keras_kpi_data
+from model_compression_toolkit.core.pytorch.kpi_data_facade import pytorch_kpi_data
+from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig
+from model_compression_toolkit.gptq.common.gptq_config import RoundingType
+from model_compression_toolkit.gptq.keras.quantization_facade import get_keras_gptq_config
+from model_compression_toolkit.gptq.pytorch.quantization_facade import get_pytorch_gptq_config
+from model_compression_toolkit.quantizers_infrastructure.inferable_infrastructure.keras.load_model import keras_load_quantized_model
+
 __version__ = "1.8.0"

--- a/tests/keras_tests/feature_networks_tests/feature_networks/old_api_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/old_api_test.py
@@ -41,7 +41,7 @@ class OldApiTest(BaseKerasFeatureNetworkTest):
                                              name="old_api_test")
 
     def get_kpi(self):
-        return mct.core.KPI()
+        return mct.KPI()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
@@ -55,7 +55,7 @@ class OldApiTest(BaseKerasFeatureNetworkTest):
         quant_config = core_config.quantization_config
         gptq_config = mct.GradientPTQConfig(1, keras.optimizers.Adam(learning_rate=1e-12)) if self.gptq_enable else None
         if self.mp_enable:
-            quant_config = mct.core.MixedPrecisionQuantizationConfig(quant_config, num_of_images=1)
+            quant_config = mct.MixedPrecisionQuantizationConfig(quant_config, num_of_images=1)
             facade_fn = mct.keras_post_training_quantization_mixed_precision
             ptq_model, quantization_info = facade_fn(model_float,
                                                      self.representative_data_gen,


### PR DESCRIPTION
As part of the rearrangement of the API, some non experimental APIs were removed. This commit revert this.