### PR TITLE
Refactor keras tests

### DIFF
--- a/tests/keras_tests/exporter_tests/tflite_int8/networks/dense_test.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/networks/dense_test.py
@@ -17,6 +17,7 @@ from tests.keras_tests.exporter_tests.tflite_int8.tflite_int8_exporter_base_test
 import keras
 import numpy as np
 import tests.keras_tests.exporter_tests.constants as constants
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 layers = keras.layers
 
@@ -48,7 +49,8 @@ class TestDenseTFLiteINT8Exporter(TFLiteINT8ExporterBaseTest):
         assert len(kernel_quantization_parameters[constants.ZERO_POINTS]) == 20
         assert np.all(kernel_quantization_parameters[constants.ZERO_POINTS]==np.zeros(20))
 
-        fake_quantized_kernel_from_exportable_model = self.exportable_model.layers[2].weights_quantizers[KERNEL](self.exportable_model.layers[2].layer.kernel)
+        dense_layer = get_layers_from_model_by_type(self.exportable_model, layers.Dense)[0]
+        fake_quantized_kernel_from_exportable_model = dense_layer.weights_quantizers[KERNEL](dense_layer.layer.kernel)
         # First reshape Conv kernel to be at the same dimensions as in TF.
         # Then reshape it to the original Dense kernel shape.
         # Then use scales to compute the fake quant kernel and compare it to the Dense fake quantized kernel

--- a/tests/keras_tests/exporter_tests/tflite_int8/networks/depthwiseconv2d_test.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/networks/depthwiseconv2d_test.py
@@ -17,6 +17,7 @@ from tests.keras_tests.exporter_tests.tflite_int8.tflite_int8_exporter_base_test
 import keras
 import numpy as np
 import tests.keras_tests.exporter_tests.constants as constants
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 layers = keras.layers
 
@@ -43,7 +44,8 @@ class TestDepthwiseConv2DTFLiteINT8Exporter(TFLiteINT8ExporterBaseTest):
 
         # Reshape DW kernel to be at the same dimensions as in TF.
         kernel = self.interpreter.tensor(kernel_tensor_index)().transpose(0, 1, 3, 2)
-        fake_quantized_kernel_from_exportable_model = self.exportable_model.layers[2].weights_quantizers[DEPTHWISE_KERNEL](self.exportable_model.layers[2].layer.depthwise_kernel)
+        dw_layer = get_layers_from_model_by_type(self.exportable_model, layers.DepthwiseConv2D)[0]
+        fake_quantized_kernel_from_exportable_model = dw_layer.weights_quantizers[DEPTHWISE_KERNEL](dw_layer.layer.depthwise_kernel)
         fake_quantized_kernel_from_int8_model = kernel * kernel_quantization_parameters[constants.SCALES].reshape(1, 1, 3, 1)
         assert np.all(
             fake_quantized_kernel_from_exportable_model == fake_quantized_kernel_from_int8_model), f'Expected quantized kernel to be the same in exportable model and in int8 model'

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -20,6 +20,7 @@ from model_compression_toolkit.core.keras.constants import ACTIVATION, LINEAR
 from mct_quantizers import KerasQuantizationWrapper
 from tests.keras_tests.tpc_keras import get_quantization_disabled_keras_tpc
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -39,12 +40,8 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2], KerasQuantizationWrapper))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[3], KerasQuantizationWrapper))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.Activation))
-        self.unit_test.assertTrue(
-            quantized_model.layers[2].layer.get_config().get(ACTIVATION) == LINEAR)
-        self.unit_test.assertTrue(
-            quantized_model.layers[3].layer.get_config().get(ACTIVATION) == self.activation_function)
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        activation_layer = get_layers_from_model_by_type(quantized_model, layers.Activation)[0]
+        self.unit_test.assertTrue(conv_layer.get_config().get(ACTIVATION) == LINEAR)
+        self.unit_test.assertTrue(activation_layer.get_config().get(ACTIVATION) == self.activation_function)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -40,8 +40,8 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
-        activation_layer = get_layers_from_model_by_type(quantized_model, layers.Activation)[0]
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0].layer
+        activation_layer = get_layers_from_model_by_type(quantized_model, layers.Activation)[0].layer
         self.unit_test.assertTrue(conv_layer.get_config().get(ACTIVATION) == LINEAR)
         self.unit_test.assertTrue(activation_layer.get_config().get(ACTIVATION) == self.activation_function)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/add_same_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/add_same_test.py
@@ -21,6 +21,7 @@ from tests.keras_tests.feature_networks_tests.base_keras_feature_test import Bas
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from model_compression_toolkit.core.common.quantization.quantization_config import DEFAULTCONFIG
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -38,5 +39,6 @@ class AddSameTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(len(quantized_model.layers[3].input) == 2)
-        self.unit_test.assertTrue(quantized_model.layers[3].input[0].ref()==quantized_model.layers[3].input[1].ref())
+        add_layer = get_layers_from_model_by_type(quantized_model, layers.Add)[0]
+        self.unit_test.assertTrue(len(add_layer.input) == 2)
+        self.unit_test.assertTrue(add_layer.input[0].ref()==add_layer.input[1].ref())

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bias_correction_dw_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bias_correction_dw_test.py
@@ -25,6 +25,8 @@ from tests.keras_tests.feature_networks_tests.base_keras_feature_test import Bas
 import model_compression_toolkit as mct
 from tests.keras_tests.feature_networks_tests.feature_networks.network_editor.node_filter_test import get_uniform_weights
 
+from tests.keras_tests.utils import get_layers_from_model_by_type
+
 keras = tf.keras
 layers = keras.layers
 
@@ -49,9 +51,10 @@ class BiasCorrectionDepthwiseTest(BaseKerasFeatureNetworkTest):
         return np.ones(*self.get_input_shapes())
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        error = float_model.layers[1].depthwise_kernel - quantized_model.layers[2].get_quantized_weights()['depthwise_kernel']
+        dw_layer = get_layers_from_model_by_type(quantized_model, DepthwiseConv2D)[0]
+        error = float_model.layers[1].depthwise_kernel - dw_layer.get_quantized_weights()['depthwise_kernel']
         error = np.sum(error, axis=(0,1)).flatten()
-        bias = quantized_model.layers[2].weights[2]
+        bias = dw_layer.weights[2]
         # Input mean is 1 so correction_term = quant_error * 1
         self.unit_test.assertTrue(np.isclose(error, bias).all())
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/decompose_separable_conv_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/decompose_separable_conv_test.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -39,10 +40,9 @@ class DecomposeSeparableConvTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(len(quantized_model.layers) == 4)
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.Conv2D))
-        self.unit_test.assertTrue(quantized_model.layers[2].weights[0].shape == (2, 2, 3, 1 * self.depth_multiplier))
-        self.unit_test.assertTrue(quantized_model.layers[3].weights[0].shape == (1, 1, 3 * self.depth_multiplier, 1))
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        dw_layer = get_layers_from_model_by_type(quantized_model, layers.DepthwiseConv2D)[0]
+        self.unit_test.assertTrue(dw_layer.weights[0].shape == (2, 2, 3, 1 * self.depth_multiplier))
+        self.unit_test.assertTrue(conv_layer.weights[0].shape == (1, 1, 3 * self.depth_multiplier, 1))
         self.unit_test.assertTrue(quantized_model.output_shape == float_model.output_shape)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -26,6 +26,7 @@ from model_compression_toolkit.core.keras.constants import KERNEL
 from mct_quantizers.keras.quantizers import ActivationLutPOTInferableQuantizer
 from mct_quantizers.common.constants import THRESHOLD, CLUSTER_CENTERS
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -89,10 +90,11 @@ class LUTWeightsQuantizerTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
         # check that the two conv's weights have different values since they where quantized
         # using different methods (but started as the same value)
         self.unit_test.assertTrue(np.sum(
-            np.abs(quantized_model.layers[2].get_quantized_weights()[KERNEL]) - quantized_model.layers[3].get_quantized_weights()[KERNEL]) > 0)
+            np.abs(conv_layers[0].get_quantized_weights()[KERNEL]) - conv_layers[1].get_quantized_weights()[KERNEL]) > 0)
 
 
 class LUTActivationQuantizerTest(BaseKerasFeatureNetworkTest):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
@@ -25,6 +25,7 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.common.mixed_precision.kpi_tools.kpi import KPI
 from model_compression_toolkit.core.common.user_info import UserInformation
 from tests.keras_tests.tpc_keras import get_tpc_with_activation_mp_keras
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -101,10 +102,11 @@ class MixedPrecisionActivationBaseTest(BaseKerasFeatureNetworkTest):
     def verify_quantization(self, quantized_model, input_x, weights_layers_idx, weights_layers_channels_size,
                             activation_layers_idx, unique_tensor_values):
         # verify weights quantization
-        for i in range(len(weights_layers_idx)):
-            for j in range(weights_layers_channels_size[i]):  # quantized per channel
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
+        for conv_layer, num_channels in zip(conv_layers,weights_layers_channels_size):
+            for j in range(num_channels):  # quantized per channel
                 self.unit_test.assertTrue(
-                    np.unique(quantized_model.layers[weights_layers_idx[i]].get_quantized_weights()['kernel'][:, :, :, j]).flatten().shape[
+                    np.unique(conv_layer.get_quantized_weights()['kernel'][:, :, :, j]).flatten().shape[
                         0] <= unique_tensor_values)
 
         # verify activation quantization

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
@@ -22,6 +22,7 @@ from model_compression_toolkit.core.common.network_editors.actions import EditRu
     ChangeFinalActivationQuantConfigAttr, ChangeCandidatesActivationQuantConfigAttr
 from model_compression_toolkit.core.common.network_editors.node_filters import NodeTypeFilter
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -44,9 +45,8 @@ class ChangeFinalWeightQCAttrTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
-        self.unit_test.assertTrue(quantized_model.layers[
-                                      2].layer.bias is None)  # If bias correction is enabled, a bias should be added -
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        self.unit_test.assertTrue(conv_layer.layer.bias is None)  # If bias correction is enabled, a bias should be added -
         # This asserts the editing occured
 
 
@@ -66,5 +66,5 @@ class ChangeFinalActivationQCAttrTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
-        self.unit_test.assertTrue(quantized_model.layers[2].activation_quantizers[0].get_config()['num_bits'] == 7)
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        self.unit_test.assertTrue(conv_layer.activation_quantizers[0].get_config()['num_bits'] == 7)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 import tensorflow as tf
+from keras.engine.base_layer import Layer
 from keras.engine.input_layer import InputLayer
 
 from model_compression_toolkit.core import QuantizationErrorMethod, DebugConfig
@@ -22,6 +23,7 @@ from model_compression_toolkit.core.common.network_editors.actions import EditRu
     ChangeCandidatesActivationQuantConfigAttr
 from model_compression_toolkit.core.common.network_editors.node_filters import NodeTypeFilter
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -56,7 +58,8 @@ class EditActivationErrorMethod(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        input_q_params = quantized_model.layers[1].activation_quantizers[0].get_config()
+        identity_layer = get_layers_from_model_by_type(quantized_model, Layer)[0]
+        input_q_params = identity_layer.activation_quantizers[0].get_config()
         threshold = input_q_params['threshold']
         self.unit_test.assertTrue(threshold == 2,
                                   f'After editing input layer to no clipping error method,'

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/node_filter_test.py
@@ -104,7 +104,7 @@ class ScopeFilterTest(BaseKerasFeatureNetworkTest):
         conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
         # check that this conv's weights had changed due to change in number of bits
         self.unit_test.assertTrue(
-            len(np.unique(conv_layers[2].get_quantized_weights()['kernel'].numpy())) in [2 ** (self.weights_n_bits) - 1,
+            len(np.unique(conv_layers[1].get_quantized_weights()['kernel'].numpy())) in [2 ** (self.weights_n_bits) - 1,
                                                                              2 ** (self.weights_n_bits)])
         # check that this conv's weights did not change
         self.unit_test.assertTrue(np.all(conv_layers[0].get_quantized_weights()['kernel'].numpy() == self.conv_w))

--- a/tests/keras_tests/feature_networks_tests/feature_networks/output_in_middle_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/output_in_middle_test.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -39,5 +40,5 @@ class OutputInMiddleTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         self.unit_test.assertTrue(len(quantized_model.outputs) == 2)
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
-        self.unit_test.assertTrue(quantized_model.layers[2].output.ref() in [t.ref() for t in quantized_model.outputs])
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        self.unit_test.assertTrue(conv_layer.output.ref() in [t.ref() for t in quantized_model.outputs])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/per_tensor_weight_quantization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/per_tensor_weight_quantization_test.py
@@ -21,6 +21,7 @@ from model_compression_toolkit.core.keras.constants import KERNEL
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -40,7 +41,8 @@ class PerTensorWeightQuantizationTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=x)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
         self.unit_test.assertTrue(
-            len(quantized_model.layers[2].weights_quantizers[KERNEL].get_config()[THRESHOLD]) == 1,
+            len(conv_layer.weights_quantizers[KERNEL].get_config()[THRESHOLD]) == 1,
             f'Expected in per-tensor quantization to have a single threshold but found '
-            f'{len(quantized_model.layers[2].weights_quantizers[KERNEL].get_config()[THRESHOLD])}')
+            f'{len(conv_layer.weights_quantizers[KERNEL].get_config()[THRESHOLD])}')

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
@@ -23,6 +23,7 @@ from tests.keras_tests.feature_networks_tests.base_keras_feature_test import Bas
 import numpy as np
 
 from tests.keras_tests.tpc_keras import get_weights_only_mp_tpc_keras
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -66,13 +67,13 @@ class ReusedLayerMixedPrecisionTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         if isinstance(float_model.layers[1], layers.Conv2D):
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
-            self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
+            conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+            self.unit_test.assertFalse(hasattr(conv_layer, 'input_shape'))  # assert it's reused
         if isinstance(float_model.layers[1], layers.SeparableConv2D):
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
-            self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.Conv2D))
-            self.unit_test.assertFalse(hasattr(quantized_model.layers[3].layer, 'input_shape'))  # assert it's reused
+            dw_layer = get_layers_from_model_by_type(quantized_model, layers.DepthwiseConv2D)[0]
+            self.unit_test.assertFalse(hasattr(dw_layer, 'input_shape'))  # assert it's reused
+            conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+            self.unit_test.assertFalse(hasattr(conv_layer, 'input_shape'))  # assert it's reused
 
 
 class ReusedSeparableMixedPrecisionTest(ReusedLayerMixedPrecisionTest):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_test.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -38,6 +39,6 @@ class ReusedLayerTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.Conv2D))
-        self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
-        self.unit_test.assertFalse(hasattr(quantized_model.layers[2].layer, 'input_shape'))  # assert it's reused
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        self.unit_test.assertFalse(hasattr(conv_layer, 'input_shape'))  # assert it's reused
+        self.unit_test.assertFalse(hasattr(conv_layer.layer, 'input_shape'))  # assert it's reused

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_separable_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_separable_test.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -38,8 +39,7 @@ class ReusedSeparableTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        assert len(quantized_model.layers) == 4  # input, fq_input, dw, pw
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
-        self.unit_test.assertFalse(hasattr(quantized_model.layers[2], 'input_shape'))  # assert it's reused
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[3].layer, layers.Conv2D))
-        self.unit_test.assertFalse(hasattr(quantized_model.layers[3], 'input_shape'))  # assert it's reused
+        dwconv_layer = get_layers_from_model_by_type(quantized_model, layers.DepthwiseConv2D)[0]
+        self.unit_test.assertFalse(hasattr(dwconv_layer, 'input_shape'))  # assert it's reused
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        self.unit_test.assertFalse(hasattr(conv_layer, 'input_shape'))  # assert it's reused

--- a/tests/keras_tests/feature_networks_tests/feature_networks/softmax_shift_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/softmax_shift_test.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from model_compression_toolkit.core import QuantizationConfig
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -48,14 +49,15 @@ class SoftmaxShiftTest(BaseKerasFeatureNetworkTest):
         return QuantizationConfig(softmax_shift=True)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        linear_layer = get_layers_from_model_by_type(quantized_model, type(self.kernel_op_layer))[0]
         if self.kernel_op_layer.__getattribute__('activation') == keras_softmax:
-            quant_bias = quantized_model.layers[2].layer.bias
+            quant_bias = linear_layer.layer.bias
             float_bias = float_model.layers[-1].bias
             diff_bias = float_bias - quant_bias
             mean_diff_bias = np.mean(diff_bias)
             self.unit_test.assertTrue(np.allclose(diff_bias, mean_diff_bias, atol=1e-1))
         else:
-            quant_bias = quantized_model.layers[2].layer.bias
+            quant_bias = linear_layer.layer.bias
             float_bias = float_model.layers[1].bias
             diff_bias = float_bias - quant_bias
             mean_diff_bias = np.mean(diff_bias)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_depthwise_conv2d_replacement.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_depthwise_conv2d_replacement.py
@@ -24,6 +24,7 @@ from tests.keras_tests.tpc_keras import get_quantization_disabled_keras_tpc
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as mct
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -56,8 +57,8 @@ class DwConv2dReplacementTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         self.unit_test.assertTrue(np.isclose(0, np.mean(quantized_model.predict(input_x) - input_x)))
-        self.unit_test.assertTrue(isinstance(quantized_model.layers[2].layer, layers.DepthwiseConv2D))
-        self.unit_test.assertTrue(np.all(quantized_model.layers[2].layer.depthwise_kernel.numpy() == 1))
+        dw_layer = get_layers_from_model_by_type(quantized_model, layers.DepthwiseConv2D)[0]
+        self.unit_test.assertTrue(np.all(dw_layer.layer.depthwise_kernel.numpy() == 1))
 
     def get_debug_config(self):
         return mct.core.DebugConfig(network_editor=[EditRule(filter=NodeTypeFilter(layers.DepthwiseConv2D),

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -26,6 +26,8 @@ from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_m
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 
+from tests.keras_tests.utils import get_layers_from_model_by_type
+
 keras = tf.keras
 layers = keras.layers
 
@@ -94,8 +96,9 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # check that the two conv's weights have different values since they were quantized
         # using different methods (but started as the same value)
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
         self.unit_test.assertTrue(np.sum(
-            np.abs(quantized_model.layers[2].weights[0].numpy() - quantized_model.layers[4].weights[0].numpy())) > 0)
+            np.abs(conv_layers[0].weights[0].numpy() - conv_layers[2].weights[0].numpy())) > 0)
 
 
 class KmeansQuantizerTest(KmeansQuantizerTestBase):
@@ -112,8 +115,9 @@ class KmeansQuantizerTest(KmeansQuantizerTestBase):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # check that the two conv's weights have different values since they where quantized
         # using different methods (but started as the same value)
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
         self.unit_test.assertTrue(np.sum(
-            np.abs(quantized_model.layers[2].weights[0].numpy() - quantized_model.layers[4].weights[0].numpy())) > 0)
+            np.abs(conv_layers[0].weights[0].numpy() - conv_layers[2].weights[0].numpy())) > 0)
 
 
 class KmeansQuantizerNotPerChannelTest(KmeansQuantizerTestBase):
@@ -138,8 +142,9 @@ class KmeansQuantizerNotPerChannelTest(KmeansQuantizerTestBase):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # check that the two conv's weights have different values since they where quantized
         # using different methods (but started as the same value)
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
         self.unit_test.assertTrue(np.sum(
-            np.abs(quantized_model.layers[2].weights[0].numpy() - quantized_model.layers[4].weights[0].numpy())) > 0)
+            np.abs(conv_layers[0].weights[0].numpy() - conv_layers[2].weights[0].numpy())) > 0)
 
 
 class KmeansQuantizerTestManyClasses(KmeansQuantizerTestBase):
@@ -153,8 +158,9 @@ class KmeansQuantizerTestManyClasses(KmeansQuantizerTestBase):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # check that the two conv's weights have different values since they were quantized
         # using different methods (but started as the same value)
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
         self.unit_test.assertTrue(
-            np.all(np.isclose(float_model.layers[1].weights[0].numpy(), quantized_model.layers[4].weights[0].numpy())))
+            np.all(np.isclose(float_model.layers[1].weights[0].numpy(), conv_layers[2].weights[0].numpy())))
 
 
 class KmeansQuantizerTestZeroWeights(KmeansQuantizerTestBase):
@@ -170,9 +176,10 @@ class KmeansQuantizerTestZeroWeights(KmeansQuantizerTestBase):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # check that the two conv's weights have different values since they where quantized
         # using different methods (but started as the same value)
-        self.unit_test.assertTrue(np.sum(np.abs(quantized_model.layers[2].weights[0].numpy())) == 0)
-        self.unit_test.assertTrue(np.sum(np.abs(quantized_model.layers[4].weights[0].numpy())) == 0)
-        self.unit_test.assertTrue(np.sum(np.abs(quantized_model.layers[6].weights[0].numpy())) == 0)
+        conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
+        self.unit_test.assertTrue(np.sum(np.abs(conv_layers[0].weights[0].numpy())) == 0)
+        self.unit_test.assertTrue(np.sum(np.abs(conv_layers[1].weights[0].numpy())) == 0)
+        self.unit_test.assertTrue(np.sum(np.abs(conv_layers[2].weights[0].numpy())) == 0)
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -16,11 +16,14 @@
 
 import tensorflow as tf
 import numpy as np
+from keras.engine.base_layer import Layer
+from keras.layers import TFOpLambda
 
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import model_compression_toolkit as mct
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 keras = tf.keras
 layers = keras.layers
@@ -52,8 +55,10 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify quantization range contains zero
-        fake_layer_input_args = quantized_model.layers[1].activation_quantizers[0].get_config()
-        fake_layer_add_args = quantized_model.layers[3].activation_quantizers[0].get_config()
+        identity_layers = get_layers_from_model_by_type(quantized_model, Layer)[0]
+        fake_layer_input_args = identity_layers.activation_quantizers[0].get_config()
+        add_layer = get_layers_from_model_by_type(quantized_model, TFOpLambda)[0]
+        fake_layer_add_args = add_layer.activation_quantizers[0].get_config()
 
         input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
         add_layer_min, add_layer_max = fake_layer_add_args['min_range'], fake_layer_add_args['max_range']
@@ -87,8 +92,10 @@ class UniformRangeSelectionBoundedActivationTest(UniformRangeSelectionActivation
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        fake_layer_input_args = quantized_model.layers[1].activation_quantizers[0].get_config()
-        fake_layer_softmax_args = quantized_model.layers[2].activation_quantizers[0].get_config()
+        identity_layer = get_layers_from_model_by_type(quantized_model, Layer)[0]
+        fake_layer_input_args = identity_layer.activation_quantizers[0].get_config()
+        softmax_layer = get_layers_from_model_by_type(quantized_model, layers.Softmax)[0]
+        fake_layer_softmax_args = softmax_layer.activation_quantizers[0].get_config()
 
         input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
         softmax_layer_min, softmax_layer_max = fake_layer_softmax_args['min_range'], fake_layer_softmax_args['max_range']

--- a/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
+++ b/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
@@ -30,6 +30,7 @@ from model_compression_toolkit.quantizers_infrastructure.trainable_infrastructur
 from model_compression_toolkit.target_platform_capabilities.constants import DEFAULT_TP_MODEL
 from model_compression_toolkit.constants import TENSORFLOW
 from model_compression_toolkit import get_target_platform_capabilities
+from tests.keras_tests.utils import get_layers_from_model_by_type
 
 DEFAULT_KERAS_TPC = get_target_platform_capabilities(TENSORFLOW, DEFAULT_TP_MODEL)
 
@@ -140,6 +141,6 @@ class TestKerasFakeQuantExporter(unittest.TestCase):
         assert kernel_tensor_index is not None, f'did not find the kernel tensor index'
 
         # Test equal weights of the first conv2d layer between exported TFLite and exported TF
-        diff = np.transpose(interpreter.tensor(kernel_tensor_index)(), (1, 2, 3, 0)) - tf_exported_model.layers[
-            2].kernel
+        conv_layer = get_layers_from_model_by_type(tf_exported_model, Conv2D)[0]
+        diff = np.transpose(interpreter.tensor(kernel_tensor_index)(), (1, 2, 3, 0)) - conv_layer.kernel
         self.assertTrue(np.sum(np.abs(diff)) == 0)

--- a/tests/keras_tests/utils.py
+++ b/tests/keras_tests/utils.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import keras
 
-from model_compression_toolkit.quantizers_infrastructure import KerasQuantizationWrapper
+from mct_quantizers import KerasQuantizationWrapper
 
 
 def get_layers_from_model_by_type(model:keras.Model,

--- a/tests/keras_tests/utils.py
+++ b/tests/keras_tests/utils.py
@@ -20,6 +20,20 @@ from mct_quantizers import KerasQuantizationWrapper
 def get_layers_from_model_by_type(model:keras.Model,
                                   layer_type: type,
                                   include_wrapped_layers: bool = True):
+    """
+    Return a list of layers of some type from a Keras model. The order of the returned list
+    is according the order of the layers in model.layers.
+    If include_wrapped_layers is True, layers from that type that are wrapped using KerasQuantizationWrapper
+    are returned as well.
+
+    Args:
+        model: Keras model to get its layers.
+        layer_type: Type of the layer we want to retrieve from the model.
+        include_wrapped_layers: Whether or not to include layers that are wrapped using KerasQuantizationWrapper.
+
+    Returns:
+        List of layers from type layer_type from the model.
+    """
     if include_wrapped_layers:
         return [layer for layer in model.layers if type(layer)==layer_type or (isinstance(layer, KerasQuantizationWrapper) and type(layer.layer)==layer_type)]
     return [layer for layer in model.layers if type(layer)==layer_type]

--- a/tests/keras_tests/utils.py
+++ b/tests/keras_tests/utils.py
@@ -21,8 +21,8 @@ def get_layers_from_model_by_type(model:keras.Model,
                                   layer_type: type,
                                   include_wrapped_layers: bool = True):
     if include_wrapped_layers:
-        return [layer for layer in model.layers if isinstance(layer, layer_type) or (isinstance(layer, KerasQuantizationWrapper) and isinstance(layer.layer, layer_type))]
-    return [layer for layer in model.layers if isinstance(layer, layer_type)]
+        return [layer for layer in model.layers if type(layer)==layer_type or (isinstance(layer, KerasQuantizationWrapper) and type(layer.layer)==layer_type)]
+    return [layer for layer in model.layers if type(layer)==layer_type]
 
 
 

--- a/tests/keras_tests/utils.py
+++ b/tests/keras_tests/utils.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import keras
+
+from model_compression_toolkit.quantizers_infrastructure import KerasQuantizationWrapper
+
+
+def get_layers_from_model_by_type(model:keras.Model,
+                                  layer_type: type,
+                                  include_wrapped_layers: bool = True):
+    if include_wrapped_layers:
+        return [layer for layer in model.layers if isinstance(layer, layer_type) or (isinstance(layer, KerasQuantizationWrapper) and isinstance(layer.layer, layer_type))]
+    return [layer for layer in model.layers if isinstance(layer, layer_type)]
+
+
+
+
+


### PR DESCRIPTION
Refactor keras tests to search for a layer from a certian type instead of retreiving a layer from the model by index.