### PR TITLE
Fix tf export of reused layers

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -78,7 +78,7 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
                 if layer.is_weights_quantization:
                     new_layer = layer.layer.__class__.from_config(layer.layer.get_config())
                     with tf.name_scope(new_layer.name):
-                        new_layer.build(layer.input_shape)
+                        new_layer.build(layer.get_input_shape_at(0))
 
                     # Build a list of the layer's new weights.
                     weights_list = []

--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -78,6 +78,11 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
                 if layer.is_weights_quantization:
                     new_layer = layer.layer.__class__.from_config(layer.layer.get_config())
                     with tf.name_scope(new_layer.name):
+                        # In order to add the weights of the layer, we need to build it. To build it
+                        # we need to pass its input shape. Not every layer has input_shape since some
+                        # layers may have multiple inputs with different input shapes (reused layers for
+                        # example). For this reason, we take input shape at index 0 so these layers
+                        # can be exported as well.
                         new_layer.build(layer.get_input_shape_at(0))
 
                     # Build a list of the layer's new weights.

--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -81,8 +81,9 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
                         # In order to add the weights of the layer, we need to build it. To build it
                         # we need to pass its input shape. Not every layer has input_shape since some
                         # layers may have multiple inputs with different input shapes (reused layers for
-                        # example). For this reason, we take input shape at index 0 so these layers
-                        # can be exported as well.
+                        # example). For this reason, we take input shape at index 0 (any input shape
+                        # should work since the weights are dependent only at some dimensions which have to
+                        # be the same for all inputs).
                         new_layer.build(layer.get_input_shape_at(0))
 
                     # Build a list of the layer's new weights.

--- a/tests/keras_tests/exporter_tests/test_runner.py
+++ b/tests/keras_tests/exporter_tests/test_runner.py
@@ -17,6 +17,7 @@ import unittest
 
 from tests.keras_tests.exporter_tests.tflite_fake_quant.networks.conv2d_test import TestConv2DTFLiteFQExporter, \
     TestConv2DReusedTFLiteFQExporter
+from tests.keras_tests.exporter_tests.tflite_fake_quant.networks.dense_test import TestDenseReusedTFLiteFQExporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.conv2d_test import TestConv2DPOTTFLiteINT8Exporter, TestConv2DSymmetricTFLiteINT8Exporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.dense_test import TestDenseTFLiteINT8Exporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.depthwiseconv2d_test import TestDepthwiseConv2DTFLiteINT8Exporter
@@ -52,6 +53,9 @@ class ExporterTestsRunner(unittest.TestCase):
 
     def test_tflite_fq_conv2d_reused(self):
         TestConv2DReusedTFLiteFQExporter().run_test()
+
+    def test_tflite_fq_dense_reused(self):
+        TestDenseReusedTFLiteFQExporter().run_test()
 
 
 

--- a/tests/keras_tests/exporter_tests/test_runner.py
+++ b/tests/keras_tests/exporter_tests/test_runner.py
@@ -15,9 +15,9 @@
 
 import unittest
 
-from tests.keras_tests.exporter_tests.tflite_fake_quant.networks.conv2d_test import TestConv2DTFLiteFQExporter
-from tests.keras_tests.exporter_tests.tflite_int8.networks.conv2d_test import TestConv2DPOTTFLiteINT8Exporter, \
-    TestConv2DSymmetricTFLiteINT8Exporter
+from tests.keras_tests.exporter_tests.tflite_fake_quant.networks.conv2d_test import TestConv2DTFLiteFQExporter, \
+    TestConv2DReusedTFLiteFQExporter
+from tests.keras_tests.exporter_tests.tflite_int8.networks.conv2d_test import TestConv2DPOTTFLiteINT8Exporter, TestConv2DSymmetricTFLiteINT8Exporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.dense_test import TestDenseTFLiteINT8Exporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.depthwiseconv2d_test import TestDepthwiseConv2DTFLiteINT8Exporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.mobilenetv2_test import TestMBV2TFLiteINT8Exporter, \
@@ -50,6 +50,8 @@ class ExporterTestsRunner(unittest.TestCase):
     def test_tflite_fq_conv2d(self):
         TestConv2DTFLiteFQExporter().run_test()
 
+    def test_tflite_fq_conv2d_reused(self):
+        TestConv2DReusedTFLiteFQExporter().run_test()
 
 
 

--- a/tests/keras_tests/exporter_tests/tflite_fake_quant/networks/dense_test.py
+++ b/tests/keras_tests/exporter_tests/tflite_fake_quant/networks/dense_test.py
@@ -1,0 +1,56 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import keras
+from keras import Input
+from keras.layers import Conv2D, Dense, Flatten
+import numpy as np
+import tests.keras_tests.exporter_tests.constants as constants
+
+
+from tests.keras_tests.exporter_tests.tflite_fake_quant.tflite_fake_quant_exporter_base_test import \
+    TFLiteFakeQuantExporterBaseTest
+
+from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
+from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
+
+
+class TestDenseReusedTFLiteFQExporter(TFLiteFakeQuantExporterBaseTest):
+
+    def get_input_shape(self):
+        return [(3, 3, 3)]
+
+    def get_tpc(self):
+        tp = generate_test_tp_model({'weights_n_bits': 2})
+        return generate_keras_tpc(name="test_dense_2bit_reused_weight", tp_model=tp)
+
+    def get_model(self):
+        dense = Dense(27)
+        inputs = Input(shape=self.get_input_shape()[0])
+        x = Flatten()(inputs)
+        x = dense(x)
+        x = dense(x)
+        return keras.Model(inputs=inputs, outputs=x)
+
+    def run_checks(self):
+        ops = self.interpreter._get_ops_details()
+        op_inputs = []
+        for op in ops:
+            if op['op_name'] == 'FULLY_CONNECTED':
+                op_inputs.append(op['inputs'])
+        assert len(op_inputs) == 2, f'Expected to find 2 ops of CONV_2D but found {len(op_inputs)}'
+        # Inputs like kernel and bias are expected to be the same since the conv is reused.
+        first_inputs = op_inputs[0][1:] # Ignore first input of activations
+        second_inputs = op_inputs[1][1:] # Ignore first input of activations
+        assert np.all(first_inputs==second_inputs), f'Since conv is reused, the input weight tensors of the op are expected to be identical in both occurrences of the op but indices are {first_inputs} and {second_inputs}'


### PR DESCRIPTION
In TF export, as part of weights building of a layer, the attribute input_shape of the layer was searched. When a layer has multiple inbound layers with different shapes this is impossible. For this reason, we get the first input shape of the layer to support cases where multiple input shapes exist.