### PR TITLE
Support export of QAT finalized models

### DIFF
--- a/model_compression_toolkit/qat/keras/quantization_facade.py
+++ b/model_compression_toolkit/qat/keras/quantization_facade.py
@@ -260,10 +260,11 @@ if FOUND_TF:
                 layer.convert_to_inferable_quantizers()
             # In the KerasActivationQuantizationHolder case - converting the quantizers only
             # is not enough. We need to create a new layer with inferable quantizers. The reason for that
-            # is that if we only convert the quantizers, the layer will have some weights that do not
-            # match the configuration, thus loading such a model will fail. To overcome this, the
-            # convert_to_inferable_quantizers of KerasActivationQuantizationHolder creates a new layer
-            # from its new configuration after converting the trainable quantizer to an inferable quantizer.
+            # is that if we only convert the quantizers, the layer will have some weights (such as min, max,
+            # threshold) that do not match the configuration, thus loading such a model will fail.
+            # To overcome this, the convert_to_inferable_quantizers of KerasActivationQuantizationHolder
+            # creates a new layer from its new configuration after converting the trainable quantizer
+            # to an inferable quantizer.
             elif isinstance(layer, KerasActivationQuantizationHolder):
                 layer = layer.convert_to_inferable_quantizers()
             return layer

--- a/model_compression_toolkit/qat/keras/quantization_facade.py
+++ b/model_compression_toolkit/qat/keras/quantization_facade.py
@@ -256,8 +256,16 @@ if FOUND_TF:
 
          """
         def _export(layer):
-            if isinstance(layer, (KerasQuantizationWrapper, KerasActivationQuantizationHolder)):
+            if isinstance(layer, KerasQuantizationWrapper):
                 layer.convert_to_inferable_quantizers()
+            # In the KerasActivationQuantizationHolder case - converting the quantizers only
+            # is not enough. We need to create a new layer with inferable quantizers. The reason for that
+            # is that if we only convert the quantizers, the layer will have some weights that do not
+            # match the configuration, thus loading such a model will fail. To overcome this, the
+            # convert_to_inferable_quantizers of KerasActivationQuantizationHolder creates a new layer
+            # from its new configuration after converting the trainable quantizer to an inferable quantizer.
+            elif isinstance(layer, KerasActivationQuantizationHolder):
+                layer = layer.convert_to_inferable_quantizers()
             return layer
 
         # clone each layer in the model and apply _export to layers with TrainableQuantizeWrappers

--- a/tests/keras_tests/exporter_tests/test_runner.py
+++ b/tests/keras_tests/exporter_tests/test_runner.py
@@ -23,6 +23,7 @@ from tests.keras_tests.exporter_tests.tflite_int8.networks.dense_test import Tes
 from tests.keras_tests.exporter_tests.tflite_int8.networks.depthwiseconv2d_test import TestDepthwiseConv2DTFLiteINT8Exporter
 from tests.keras_tests.exporter_tests.tflite_int8.networks.mobilenetv2_test import TestMBV2TFLiteINT8Exporter, \
     TestMBV2UniformActivationTFLiteINT8Exporter
+from tests.keras_tests.function_tests.test_exporting_qat_models import TestExportingQATModelTFLite, TestExportingQATModelBase
 
 
 class ExporterTestsRunner(unittest.TestCase):
@@ -57,5 +58,11 @@ class ExporterTestsRunner(unittest.TestCase):
     def test_tflite_fq_dense_reused(self):
         TestDenseReusedTFLiteFQExporter().run_test()
 
+    #########################
+    # Exporting QAT models
+    #########################
 
+    def test_export_qat(self):
+        TestExportingQATModelBase().test_exported_qat_model()
+        TestExportingQATModelTFLite().test_exported_qat_model()
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
@@ -62,7 +62,7 @@ class EditActivationErrorMethod(BaseKerasFeatureNetworkTest):
         holder_layer = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)[0]
         input_q_params = holder_layer.activation_holder_quantizer.get_config()
         threshold = input_q_params['threshold']
-        self.unit_test.assertTrue(len(threshold) == 1, f'In per-tensor quantization, expected to fins a single threshold but founod {len(threshold)}')
+        self.unit_test.assertTrue(len(threshold) == 1, f'In per-tensor quantization, expected to find a single threshold but found {len(threshold)} thresholds')
         self.unit_test.assertTrue(threshold[0] == 2,
                                   f'After editing input layer to no clipping error method,'
                                   f'threshold should be 2, but is {threshold}')

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
@@ -62,6 +62,7 @@ class EditActivationErrorMethod(BaseKerasFeatureNetworkTest):
         holder_layer = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)[0]
         input_q_params = holder_layer.activation_holder_quantizer.get_config()
         threshold = input_q_params['threshold']
-        self.unit_test.assertTrue(threshold == 2,
+        self.unit_test.assertTrue(len(threshold) == 1, f'In per-tensor quantization, expected to fins a single threshold but founod {len(threshold)}')
+        self.unit_test.assertTrue(threshold[0] == 2,
                                   f'After editing input layer to no clipping error method,'
                                   f'threshold should be 2, but is {threshold}')

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -113,5 +113,5 @@ class SymmetricThresholdSelectionBoundedActivationTest(SymmetricThresholdSelecti
         # Verify min/max is bounded by 0 and 1
         self.unit_test.assertTrue(fake_layer_softmax_args['signed'] == False,
                                   msg=f"Softmax layer symmetric range is signed. Expected to be unsigned")
-        self.unit_test.assertTrue(fake_layer_softmax_args['threshold'] == 1.0,
+        self.unit_test.assertTrue(fake_layer_softmax_args['threshold'] == [1.0],
                                   msg=f"Softmax layer threshold is {fake_layer_softmax_args['threshold']}. Expected to be 1")

--- a/tests/keras_tests/function_tests/text_exporting_qat_models.py
+++ b/tests/keras_tests/function_tests/text_exporting_qat_models.py
@@ -1,0 +1,158 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import tempfile
+import unittest
+
+import keras
+import numpy as np
+import tensorflow as tf
+
+import model_compression_toolkit as mct
+from mct_quantizers import KerasActivationQuantizationHolder
+from tests.keras_tests.utils import get_layers_from_model_by_type
+
+layers = keras.layers
+
+class TestExportingQATModelBase(unittest.TestCase):
+
+    def get_model(self):
+        i = keras.Input(shape=(224,224,3))
+        x = layers.Conv2D(3,3)(i)
+        model = keras.models.Model(i,x)
+        return model
+
+    def get_dataset(self):
+        yield [np.random.rand(1, 224, 224, 3)]
+
+    def get_tpc(self):
+        return mct.get_target_platform_capabilities('tensorflow','default')
+
+    def get_serialization_format(self):
+        return mct.exporter.KerasExportSerializationFormat.KERAS_H5
+
+    def get_filepath(self):
+        return tempfile.mkstemp('.h5')[1]
+
+    def load_model(self, filepath):
+        return mct.keras_load_quantized_model(filepath)
+
+    def infer(self, model, images):
+        return model(images)
+
+    def setUp(self) -> None:
+        model = self.get_model()
+        self.qat_ready, _, _ = mct.qat.keras_quantization_aware_training_init(model,
+                                                                         self.get_dataset)
+        images = next(self.get_dataset())
+        qat_ready_pred = self.qat_ready(images)
+        self.final_model = mct.qat.keras_quantization_aware_training_finalize(self.qat_ready)
+        qat_final_pred = self.final_model(images)
+        diff = np.sum(np.abs(qat_ready_pred - qat_final_pred))
+        assert diff == 0, f'QAT Model before and after finalizing should predict identical predictions but diff is ' \
+                          f'{diff}'
+
+        self.filepath = self.get_filepath()
+        mct.exporter.keras_export_model(self.final_model,
+                                        self.filepath,
+                                        self.get_tpc(),
+                                        serialization_format=self.get_serialization_format())
+
+        self.loaded_model = self.load_model(self.filepath)
+        self.infer(self.loaded_model, images)
+
+    def test_export_qat_model(self):
+        images = next(self.get_dataset())
+        a = self.infer(self.final_model, images)
+        b = self.infer(self.loaded_model, images)
+        diff = np.max(np.abs(a-b))
+        assert diff == 0, f'QAT Model before and after export to h5 should ' \
+                          f'predict identical predictions but diff is ' \
+                          f'{diff}'
+        holder_layers_finalized_model = get_layers_from_model_by_type(self.final_model,
+                                                                      KerasActivationQuantizationHolder)
+        holder_layers_loaded_model = get_layers_from_model_by_type(self.loaded_model,
+                                                                   KerasActivationQuantizationHolder)
+        self.assertTrue(holder_layers_loaded_model[0].get_config()==holder_layers_finalized_model[0].get_config())
+        self.assertTrue(holder_layers_loaded_model[1].get_config() == holder_layers_finalized_model[1].get_config())
+
+        conv_finalized_model = get_layers_from_model_by_type(self.final_model, layers.Conv2D)[0]
+        conv_loaded_model = get_layers_from_model_by_type(self.loaded_model, layers.Conv2D)[0]
+        self.assertTrue(np.all(conv_finalized_model.get_quantized_weights()['kernel']==conv_loaded_model.kernel))
+
+
+class TestExportingQATModelTFLite(TestExportingQATModelBase):
+
+    def get_serialization_format(self):
+        return mct.exporter.KerasExportSerializationFormat.TFLITE
+
+    def get_filepath(self):
+        return tempfile.mkstemp('.tflite')[1]
+
+    def load_model(self, filepath):
+        # Load model
+        interpreter = tf.lite.Interpreter(model_path=filepath)
+        interpreter.allocate_tensors()
+        return interpreter
+
+    def infer(self, model, images):
+        input_index = model.get_input_details()[0]['index']
+        model.set_tensor(input_index, images[0].astype("float32"))
+        model.invoke()
+        output_details = model.get_output_details()
+        output_data = model.get_tensor(output_details[0]['index'])
+        return output_data
+
+    def test_export_qat_model(self):
+        # Compare scales from tflite model to the fully-quantized model
+        exported_model_scales=[]
+        for op in self.loaded_model._get_ops_details():
+            if op['op_name'] == 'QUANTIZE':
+                # Take scale from quant params of the output tensor of QUANTIZE op
+                exported_model_scales.append(self.loaded_model._get_tensor_details(op['outputs'][0])['quantization_parameters']['scales'][0])
+
+        # Get Kernel values
+        tflite_kernel=None
+        for t in self.loaded_model.get_tensor_details():
+            if np.all(t['shape'] == np.asarray([3, 3, 3, 3])) and len(t['shape']) == 4:
+                tflite_kernel = self.loaded_model.tensor(t['index'])()
+        assert tflite_kernel is not None, f' Could not find conv kernel in tflite model'
+
+        def _get_activation_scale(fq_args):
+            if fq_args['signed']:
+                return fq_args['threshold'][0] / (2 ** (fq_args['num_bits'] - 1))
+            return fq_args['threshold'][0] / (2 ** fq_args['num_bits'])
+
+        holder_layers = get_layers_from_model_by_type(self.final_model, KerasActivationQuantizationHolder)
+        first_fq_args = holder_layers[0].activation_holder_quantizer.get_config()
+        first_scale = _get_activation_scale(first_fq_args)
+        second_fq_args = holder_layers[1].activation_holder_quantizer.get_config()
+        second_scale = _get_activation_scale(second_fq_args)
+        self.assertTrue(first_scale == exported_model_scales[0],
+                        f'Expect same scales from exported tflite model and QAT finalized model but found '
+                        f'{first_scale} and {exported_model_scales[0]}')
+        self.assertTrue(second_scale == exported_model_scales[1],
+                        f'Expect same scales from exported tflite model and QAT finalized model but found '
+                        f'{second_scale} and {exported_model_scales[1]}')
+
+        conv_layer = get_layers_from_model_by_type(self.final_model, layers.Conv2D)[0]
+        finalized_kernel = conv_layer.get_quantized_weights()['kernel']
+        kernels_diff=np.max(np.abs(finalized_kernel-tflite_kernel.transpose((1,2,3,0))))
+        self.assertTrue(kernels_diff==0, f'Kernels should be identical but diff of {kernels_diff} was found')
+
+
+
+
+


### PR DESCRIPTION
Two changes to support exporting QAT finalized models:
1. Creating new KerasActivationQuantizationHolder layers after converting the trainable quantizer to inferable. This is done to remove the training-related weights.
2. When creating an unwrap layer (during export), we create the weights based on the wrapped layer instead of going over the weights of the wrapped layer (which caused issues when the model was in eager mode).