### PR TITLE
Remove activation quantizers from KerasQuantizeWrapper

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/int8_tflite_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/int8_tflite_exporter.py
@@ -133,8 +133,7 @@ class INT8TFLiteExporter(FakelyQuantKerasExporter):
 
         # Wrap pw with the new quantizers (the activation is not affected thus we take the Dense quantizers)
         wrapped_pw = KerasQuantizationWrapper(pw_layer,
-                                              pw_weights_quantizers,
-                                              wrapped_layer.activation_quantizers)
+                                              pw_weights_quantizers)
 
         # Compute the shape that the input to the new layer should be reshaped into
         # Example: Dense kernel with the following shape (3, 20) expects to have input with the

--- a/tests/keras_tests/feature_networks_tests/feature_networks/experimental_exporter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/experimental_exporter_test.py
@@ -45,10 +45,8 @@ class ExportableModelTest(BaseKerasFeatureNetworkTest):
         for holder in holders_layer:
             self.unit_test.assertTrue(isinstance(holder.activation_holder_quantizer, BaseInferableQuantizer))
 
-        self.unit_test.assertTrue(len(conv_layers[0].activation_quantizers) == 0)
         self.unit_test.assertTrue(len(conv_layers[0].weights_quantizers) == 1)
         self.unit_test.assertTrue(isinstance(conv_layers[0].weights_quantizers[KERNEL], BaseInferableQuantizer))
 
-        self.unit_test.assertTrue(len(conv_layers[1].activation_quantizers) == 0)
         self.unit_test.assertTrue(len(conv_layers[1].weights_quantizers) == 1)
         self.unit_test.assertTrue(isinstance(conv_layers[1].weights_quantizers[KERNEL], BaseInferableQuantizer))

--- a/tests/keras_tests/function_tests/test_activation_quantization_holder_gptq.py
+++ b/tests/keras_tests/function_tests/test_activation_quantization_holder_gptq.py
@@ -50,18 +50,12 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         input_shape = (8, 8, 3)
         gptq_model = self._get_gptq_model(input_shape, basic_model)
         self.assertTrue(isinstance(gptq_model.layers[3], KerasActivationQuantizationHolder))
-        for l in gptq_model.layers:
-            if isinstance(l, KerasQuantizationWrapper):
-                self.assertTrue(len(l.activation_quantizers)==0)
 
     def test_adding_holders_after_reuse(self):
         input_shape = (8, 8, 3)
         gptq_model = self._get_gptq_model(input_shape, reuse_model)
         self.assertTrue(isinstance(gptq_model.layers[3], KerasActivationQuantizationHolder))
         self.assertTrue(isinstance(gptq_model.layers[4], KerasActivationQuantizationHolder))
-        for l in gptq_model.layers:
-            if isinstance(l, KerasQuantizationWrapper):
-                self.assertTrue(len(l.activation_quantizers)==0)
 
         # Test that two holders are getting inputs from reused conv2d (the layer that is wrapped)
         self.assertTrue(gptq_model.layers[2].get_output_at(0).ref() == gptq_model.layers[3].input.ref())


### PR DESCRIPTION
Remove the activation quantizers attribute from the Keras wrapper (since it was moved to KerasActivationQuantizationHolder previously).