### PR TITLE
Add final filtering phase to node candidates filtering

### DIFF
--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/lut_kmeans_params.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/lut_kmeans_params.py
@@ -67,7 +67,7 @@ def lut_kmeans_tensor(tensor_data: np.ndarray,
         n_clusters = len(np.unique(tensor_data.flatten()))
     else:
         n_clusters = 2 ** n_bits
-    kmeans = KMeans(n_clusters=n_clusters)
+    kmeans = KMeans(n_clusters=n_clusters, n_init=10)
 
     threshold_selection_tensor = symmetric_selection_tensor if is_symmetric else power_of_two_selection_tensor
     thresholds_per_channel = threshold_selection_tensor(tensor_data, p, n_bits, per_channel,
@@ -125,7 +125,7 @@ def lut_kmeans_histogram(bins: np.ndarray,
     else:
         n_clusters = 2 ** n_bits
 
-    kmeans = KMeans(n_clusters=n_clusters)
+    kmeans = KMeans(n_clusters=n_clusters, n_init=10)
     tensor_max = np.max(bins_with_values)
     threshold = max_power_of_two(tensor_max, min_threshold)
 


### PR DESCRIPTION
Adding an additional filtering step to node candidates filtering, since after first filter we might get duplications in the remaining candidates (in specific mixed precision scenario that include LUT quantization option).

In addition, a small fix to LUT kmeans call is done to eliminate some sklearn's warning