### PR TITLE
Remove restriction on numpy version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 networkx!=2.8.1
 tqdm
 Pillow
-numpy!=1.25.0
+numpy
 opencv-python
 scikit-image
 scikit-learn

--- a/tests/keras_tests/exporter_tests/tflite_fake_quant/networks/conv2d_test.py
+++ b/tests/keras_tests/exporter_tests/tflite_fake_quant/networks/conv2d_test.py
@@ -44,7 +44,7 @@ class TestConv2DTFLiteFQExporter(TFLiteFakeQuantExporterBaseTest):
         # Fetch quantized weights from fq model tensors
         kernel_quantization_parameters, kernel_tensor_index, kernel_dtype = None, None, None
         for t in self.interpreter.get_tensor_details():
-            if np.all(t[constants.SHAPE] == np.asarray([6, 20, 20, 3])):
+            if len(t[constants.SHAPE]) == 4 and np.all(t[constants.SHAPE] == np.asarray([6, 20, 20, 3])):
                 kernel_tensor_index = t[constants.INDEX]
                 kernel_quantization_parameters = t[constants.QUANTIZATION_PARAMETERS]
                 kernel_dtype = t[constants.DTYPE]

--- a/tests/keras_tests/exporter_tests/tflite_int8/networks/dense_test.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/networks/dense_test.py
@@ -38,7 +38,7 @@ class TestDenseTFLiteINT8Exporter(TFLiteINT8ExporterBaseTest):
         # Fetch quantized weights from int8 model tensors
         kernel_quantization_parameters, kernel_tensor_index = None, None
         for t in self.interpreter.get_tensor_details():
-            if np.all(t[constants.SHAPE] == np.asarray([20, 1, 1, 8])):
+            if len(t[constants.SHAPE]) == 4 and np.all(t[constants.SHAPE] == np.asarray([20, 1, 1, 8])):
                 kernel_tensor_index = t[constants.INDEX]
                 kernel_quantization_parameters = t[constants.QUANTIZATION_PARAMETERS]
         assert kernel_quantization_parameters is not None

--- a/tests/keras_tests/function_tests/test_exporting_qat_models.py
+++ b/tests/keras_tests/function_tests/test_exporting_qat_models.py
@@ -156,7 +156,7 @@ class TestExportingQATModelTFLite(TestExportingQATModelBase):
         # Get Kernel values
         tflite_kernel=None
         for t in self.loaded_model.get_tensor_details():
-            if np.all(t['shape'] == np.asarray([3, 3, 3, 3])) and len(t['shape']) == 4:
+            if len(t['shape']) == 4 and np.all(t['shape'] == np.asarray([3, 3, 3, 3])):
                 tflite_kernel = self.loaded_model.tensor(t['index'])()
         assert tflite_kernel is not None, f' Could not find conv kernel in tflite model'
 


### PR DESCRIPTION
Removing the restriction of numpy!=1.25.0 from the requirements.
The difference in new numpy versions is that it no longer returns 'False' when comparing np arrays of different shapes, but instead throws an exception.
This only required a small modification in several tests and didn't affect any of the actual code.