### PR TITLE
Fix issues with softmax layer in mixed precision distance metric computation

### DIFF
--- a/model_compression_toolkit/constants.py
+++ b/model_compression_toolkit/constants.py
@@ -42,6 +42,7 @@ RANGE_MAX = 'range_max'
 REUSE = 'reuse'
 REUSE_GROUP = 'reuse_group'
 LAST_AXIS = -1
+AXIS = 'axis'
 
 # Data types:
 DATA_TYPE = 'dtype'

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -17,6 +17,7 @@ import copy
 import numpy as np
 from typing import Callable, Any, List
 
+from model_compression_toolkit.constants import AXIS
 from model_compression_toolkit.core import FrameworkInfo, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.core.common import Graph, BaseNode
 from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
@@ -283,7 +284,8 @@ class SensitivityEvaluation:
                                                   framework_attrs=self.interest_points[i].framework_attr,
                                                   compute_distance_fn=self.quant_config.compute_distance_fn)
 
-            distance_matrix[i] = point_distance_fn(baseline_tensors[i], mp_tensors[i], batch=True)
+            axis = self.interest_points[i].framework_attr.get(AXIS, None)
+            distance_matrix[i] = point_distance_fn(baseline_tensors[i], mp_tensors[i], batch=True, axis=axis)
 
         return distance_matrix
 

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -284,7 +284,7 @@ class SensitivityEvaluation:
                                                   framework_attrs=self.interest_points[i].framework_attr,
                                                   compute_distance_fn=self.quant_config.compute_distance_fn)
 
-            axis = self.interest_points[i].framework_attr.get(AXIS, None)
+            axis = self.interest_points[i].framework_attr.get(AXIS)
             distance_matrix[i] = point_distance_fn(baseline_tensors[i], mp_tensors[i], batch=True, axis=axis)
 
         return distance_matrix

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -20,6 +20,7 @@ from typing import Callable, Any, List
 from model_compression_toolkit.constants import AXIS
 from model_compression_toolkit.core import FrameworkInfo, MixedPrecisionQuantizationConfigV2
 from model_compression_toolkit.core.common import Graph, BaseNode
+from model_compression_toolkit.core.common.graph.functional_node import FunctionalNode
 from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
 from model_compression_toolkit.logger import Logger
 
@@ -279,12 +280,15 @@ class SensitivityEvaluation:
         distance_matrix = np.ndarray((num_interest_points, num_samples))
 
         for i in range(num_interest_points):
+            point_node = self.interest_points[i]
             point_distance_fn = \
-                self.fw_impl.get_node_distance_fn(layer_class=self.interest_points[i].layer_class,
-                                                  framework_attrs=self.interest_points[i].framework_attr,
+                self.fw_impl.get_node_distance_fn(layer_class=point_node.layer_class,
+                                                  framework_attrs=point_node.framework_attr,
                                                   compute_distance_fn=self.quant_config.compute_distance_fn)
 
-            axis = self.interest_points[i].framework_attr.get(AXIS)
+            axis = point_node.framework_attr.get(AXIS) if not isinstance(point_node, FunctionalNode) \
+                else point_node.op_call_kwargs.get(AXIS)
+
             distance_matrix[i] = point_distance_fn(baseline_tensors[i], mp_tensors[i], batch=True, axis=axis)
 
         return distance_matrix

--- a/model_compression_toolkit/core/common/similarity_analyzer.py
+++ b/model_compression_toolkit/core/common/similarity_analyzer.py
@@ -65,9 +65,11 @@ def flatten_tensor(t: np.ndarray, batch: bool, axis: int = None) -> np.ndarray:
     """
 
     if axis is not None and batch:
-        f_t = t.reshape([t.shape[0], -1, t.shape[axis]])
+        t = np.moveaxis(t, axis, -1)
+        f_t = t.reshape([t.shape[0], -1, t.shape[-1]])
     elif axis is not None:
-        f_t = t.reshape([-1, t.shape[axis]])
+        t = np.moveaxis(t, axis, -1)
+        f_t = t.reshape([-1, t.shape[-1]])
     elif batch:
         f_t = t.reshape([t.shape[0], -1])
     else:

--- a/model_compression_toolkit/core/common/similarity_analyzer.py
+++ b/model_compression_toolkit/core/common/similarity_analyzer.py
@@ -51,19 +51,24 @@ def _similarity_tensor_norm(x: np.ndarray, p: float = 2.0) -> np.ndarray:
     return (np.abs(x) ** p).sum(axis=-1) ** (1.0/p)
 
 
-def flatten_tensor(t: np.ndarray, batch: bool) -> np.ndarray:
+def flatten_tensor(t: np.ndarray, batch: bool, axis: int = None) -> np.ndarray:
     """
     Flattening the samples batch to allow similarity analysis computation per sample.
 
     Args:
         t: A tensor to be flattened.
         batch: Whether the similarity computation is per image or per tensor.
+        axis: Axis along which the operator has been computed.
 
     Returns: A flattened tensor which has the number of samples as is first dimension.
 
     """
 
-    if batch:
+    if axis is not None and batch:
+        f_t = t.reshape([t.shape[0], -1, t.shape[axis]])
+    elif axis is not None:
+        f_t = t.reshape([-1, t.shape[axis]])
+    elif batch:
         f_t = t.reshape([t.shape[0], -1])
     else:
         f_t = t.flatten()
@@ -79,7 +84,8 @@ def compute_mse(float_tensor: np.ndarray,
                 fxp_tensor: np.ndarray,
                 norm: bool = False,
                 norm_eps: float = 1e-8,
-                batch: bool = False) -> float:
+                batch: bool = False,
+                axis: int = None) -> float:
     """
     Compute the mean square error between two numpy arrays.
 
@@ -89,6 +95,7 @@ def compute_mse(float_tensor: np.ndarray,
         norm: whether to normalize the error function result.
         norm_eps: epsilon value for error normalization stability.
         batch: Whether to run batch similarity analysis or not.
+        axis: Axis along which the operator has been computed.
 
     Returns:
         The MSE distance between the two tensors.
@@ -109,7 +116,8 @@ def compute_mae(float_tensor: np.ndarray,
                 fxp_tensor: np.ndarray,
                 norm: bool = False,
                 norm_eps: float = 1e-8,
-                batch: bool = False) -> float:
+                batch: bool = False,
+                axis: int = None) -> float:
     """
     Compute the mean average error function between two numpy arrays.
 
@@ -119,6 +127,7 @@ def compute_mae(float_tensor: np.ndarray,
         norm: whether to normalize the error function result.
         norm_eps: epsilon value for error normalization stability.
         batch: Whether to run batch similarity analysis or not.
+        axis: Axis along which the operator has been computed.
 
     Returns:
         The mean average distance between the two tensors.
@@ -135,7 +144,8 @@ def compute_mae(float_tensor: np.ndarray,
     return error
 
 
-def compute_cs(float_tensor: np.ndarray, fxp_tensor: np.ndarray, eps: float = 1e-8, batch: bool = False) -> float:
+def compute_cs(float_tensor: np.ndarray, fxp_tensor: np.ndarray, eps: float = 1e-8, batch: bool = False,
+               axis: int = None) -> float:
     """
     Compute the similarity between two tensor using cosine similarity.
     The returned values is between 0 to 1: the smaller returned value,
@@ -146,6 +156,7 @@ def compute_cs(float_tensor: np.ndarray, fxp_tensor: np.ndarray, eps: float = 1e
         fxp_tensor: Second tensor to compare.
         eps: Small value to avoid zero division.
         batch: Whether to run batch similarity analysis or not.
+        axis: Axis along which the operator has been computed.
 
     Returns:
         The cosine similarity between two tensors.
@@ -174,7 +185,8 @@ def compute_lp_norm(float_tensor: np.ndarray,
                     p: int,
                     norm: bool = False,
                     norm_eps: float = 1e-8,
-                    batch: bool = False) -> float:
+                    batch: bool = False,
+                    axis: int = None) -> float:
     """
     Compute the error function between two numpy arrays.
     The error is computed based on Lp-norm distance of the tensors.
@@ -186,6 +198,7 @@ def compute_lp_norm(float_tensor: np.ndarray,
         norm: whether to normalize the error function result.
         norm_eps: epsilon value for error normalization stability.
         batch: Whether to run batch similarity analysis or not.
+        axis: Axis along which the operator has been computed.
 
     Returns:
         The Lp-norm distance between the two tensors.
@@ -201,7 +214,8 @@ def compute_lp_norm(float_tensor: np.ndarray,
     return error
 
 
-def compute_kl_divergence(float_tensor: np.ndarray, fxp_tensor: np.ndarray, batch: bool = False) -> float:
+def compute_kl_divergence(float_tensor: np.ndarray, fxp_tensor: np.ndarray, batch: bool = False,
+                          axis: int = None) -> float:
     """
     Compute the similarity between two tensor using KL-divergence.
     The returned values is between 0 to 1: the smaller returned value,
@@ -211,6 +225,7 @@ def compute_kl_divergence(float_tensor: np.ndarray, fxp_tensor: np.ndarray, batc
         float_tensor: First tensor to compare.
         fxp_tensor: Second tensor to compare.
         batch: Whether to run batch similarity analysis or not.
+        axis: Axis along which the operator has been computed.
 
     Returns:
         The KL-divergence between two tensors.
@@ -218,10 +233,10 @@ def compute_kl_divergence(float_tensor: np.ndarray, fxp_tensor: np.ndarray, batc
 
     validate_before_compute_similarity(float_tensor, fxp_tensor)
 
-    float_flat = flatten_tensor(float_tensor, batch)
-    fxp_flat = flatten_tensor(fxp_tensor, batch)
+    float_flat = flatten_tensor(float_tensor, batch, axis)
+    fxp_flat = flatten_tensor(fxp_tensor, batch, axis)
 
     non_zero_fxp_tensor = fxp_flat.copy()
     non_zero_fxp_tensor[non_zero_fxp_tensor == 0] = EPS
 
-    return np.sum(np.where(float_flat != 0, float_flat * np.log(float_flat / non_zero_fxp_tensor), 0), axis=-1)
+    return np.mean(np.sum(np.where(float_flat != 0, float_flat * np.log(float_flat / non_zero_fxp_tensor), 0), axis=-1))

--- a/model_compression_toolkit/core/common/similarity_analyzer.py
+++ b/model_compression_toolkit/core/common/similarity_analyzer.py
@@ -95,7 +95,7 @@ def compute_mse(float_tensor: np.ndarray,
         norm: whether to normalize the error function result.
         norm_eps: epsilon value for error normalization stability.
         batch: Whether to run batch similarity analysis or not.
-        axis: Axis along which the operator has been computed.
+        axis: Axis along which the operator has been computed (not used in this function).
 
     Returns:
         The MSE distance between the two tensors.
@@ -127,7 +127,7 @@ def compute_mae(float_tensor: np.ndarray,
         norm: whether to normalize the error function result.
         norm_eps: epsilon value for error normalization stability.
         batch: Whether to run batch similarity analysis or not.
-        axis: Axis along which the operator has been computed.
+        axis: Axis along which the operator has been computed (not used in this function).
 
     Returns:
         The mean average distance between the two tensors.
@@ -156,7 +156,7 @@ def compute_cs(float_tensor: np.ndarray, fxp_tensor: np.ndarray, eps: float = 1e
         fxp_tensor: Second tensor to compare.
         eps: Small value to avoid zero division.
         batch: Whether to run batch similarity analysis or not.
-        axis: Axis along which the operator has been computed.
+        axis: Axis along which the operator has been computed (not used in this function).
 
     Returns:
         The cosine similarity between two tensors.
@@ -198,7 +198,7 @@ def compute_lp_norm(float_tensor: np.ndarray,
         norm: whether to normalize the error function result.
         norm_eps: epsilon value for error normalization stability.
         batch: Whether to run batch similarity analysis or not.
-        axis: Axis along which the operator has been computed.
+        axis: Axis along which the operator has been computed (not used in this function).
 
     Returns:
         The Lp-norm distance between the two tensors.

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import keras.layers
 from functools import partial
 from typing import List, Any, Tuple, Callable, Dict
 
@@ -418,7 +417,7 @@ class KerasImplementation(FrameworkImplementation):
             node_type_name = node.framework_attr[keras_constants.ACTIVATION]
             if node_type_name in [keras_constants.SOFTMAX, keras_constants.SIGMOID]:
                 return True
-        elif node.type in [tf.nn.softmax, keras.layers.Softmax, tf.nn.sigmoid, Conv2D, DepthwiseConv2D, Conv2DTranspose, Dense, Concatenate,
+        elif node.type in [tf.nn.softmax, tf.keras.layers.Softmax, tf.nn.sigmoid, Conv2D, DepthwiseConv2D, Conv2DTranspose, Dense, Concatenate,
                            tf.concat, Add, tf.add]:
             return True
 
@@ -449,10 +448,10 @@ class KerasImplementation(FrameworkImplementation):
                 return compute_kl_divergence
             elif node_type_name == SIGMOID:
                 return compute_cs
-        elif layer_class == tf.nn.softmax or layer_class == keras.layers.Softmax \
+        elif layer_class == tf.nn.softmax or layer_class == tf.keras.layers.Softmax \
                 or (layer_class == TFOpLambda and SOFTMAX in framework_attrs[keras_constants.FUNCTION]):
             return compute_kl_divergence
-        elif layer_class == tf.nn.sigmoid or layer_class:
+        elif layer_class == tf.nn.sigmoid:
             return compute_cs
         elif layer_class == Dense:
             return compute_cs
@@ -509,7 +508,7 @@ class KerasImplementation(FrameworkImplementation):
             node_attr = getattr(node, 'framework_attr', None)
             if node_attr is not None and (ARGMAX in node_attr[LAYER_NAME] or SOFTMAX in node_attr[LAYER_NAME]):
                 return False
-        elif node.layer_class in [tf.nn.softmax, keras.layers.Softmax, tf.math.argmax]:
+        elif node.layer_class in [tf.nn.softmax, tf.keras.layers.Softmax, tf.math.argmax]:
             return False
 
         return True

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -389,7 +389,8 @@ class PytorchImplementation(FrameworkImplementation):
         Returns: True if the node should be considered an interest point, False otherwise.
         """
 
-        if node.type in [Conv2d, Linear, ConvTranspose2d, Sigmoid, sigmoid, Softmax, softmax, operator.add, add, cat]:
+        if node.type in [Conv2d, Linear, ConvTranspose2d, Sigmoid, sigmoid, Softmax, softmax, operator.add, add, cat,
+                         operator.concat]:
             return True
         return False
 
@@ -466,7 +467,7 @@ class PytorchImplementation(FrameworkImplementation):
 
         """
 
-        return node.layer_class not in [argmax, softmax]
+        return node.layer_class not in [argmax, softmax, Softmax]
 
     def get_node_mac_operations(self,
                                 node: BaseNode,

--- a/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
+++ b/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
@@ -19,6 +19,7 @@ from keras.applications.densenet import DenseNet121
 from keras.applications.mobilenet_v2 import MobileNetV2
 from keras.layers import TFOpLambda
 
+from model_compression_toolkit.constants import AXIS
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import get_average_weights
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
     MixedPrecisionQuantizationConfig
@@ -132,8 +133,12 @@ class TestSensitivityMetricInterestPoints(unittest.TestCase):
             self.assertEqual(distance_fn, compute_kl_divergence,
                              f"Softmax node should use KL Divergence for distance computation.")
 
-            distance_per_softmax_axis = distance_fn(t1, t2, axis=-1)
-            distance_global = distance_fn(t1, t2, axis=None)
+            axis = sn.framework_attr.get(AXIS)
+            if axis is None:
+                axis = sn.op_call_kwargs.get(AXIS)
+
+            distance_per_softmax_axis = distance_fn(t1, t2, batch=True, axis=axis)
+            distance_global = distance_fn(t1, t2, batch=True, axis=None)
 
             self.assertFalse(np.isclose(distance_per_softmax_axis, distance_global),
                              f"Computing distance for softmax node on softmax activation axis should be different than "

--- a/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
+++ b/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
@@ -71,7 +71,7 @@ def softmax_model(input_shape):
     inputs = tf.keras.layers.Input(shape=input_shape)
     x = tf.keras.layers.Conv2D(32, 4)(inputs)
     x = tf.keras.layers.BatchNormalization()(x)
-    x = tf.keras.layers.Softmax(axis=-1)(x)
+    x = tf.keras.layers.Softmax(axis=2)(x)
     x = tf.keras.layers.Dense(32)(x)
     outputs = tf.nn.softmax(x, axis=-1)
     model = tf.keras.Model(inputs=inputs, outputs=outputs)


### PR DESCRIPTION
* Fixed softmax node type in MP-related nodes mapping functions.
*  Fix KL divergence computation per softmax activation axis.
* Fix other missing types in node mapping by type functions for mixed precision.

See:
https://app.clickup.com/t/860r59zcb
https://app.clickup.com/t/32wz4zf