### PR TITLE
Add MP pytorch MBV2 cifar100 notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-data/
-tutorials/notebooks/.ipynb_checkpoints/
 .idea/
 scratch_pad.py
 **/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+data/
+tutorials/notebooks/.ipynb_checkpoints/
 .idea/
 scratch_pad.py
 **/__pycache__/

--- a/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.ipynb
+++ b/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.ipynb
@@ -319,7 +319,7 @@
    "source": [
     "class RetrainArguments:\n",
     "    def __init__(self):\n",
-    "        self.retrain_num_epochs = 1 # Number of epochs to retrain the model\n",
+    "        self.retrain_num_epochs = 20 # Number of epochs to retrain the model\n",
     "        self.eval_batch_size = 32 # Batch size of test loader\n",
     "        self.retrain_batch_size = 32 # Batch size of train loader\n",
     "        self.retrain_lr = 0.001 # Learning rate to use during retraining\n",

--- a/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.ipynb
+++ b/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.ipynb
@@ -1,0 +1,663 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7cf96fb4",
+   "metadata": {
+    "id": "7cf96fb4"
+   },
+   "source": [
+    "# Mixed-Precision PTQ - Pytorch MobileNetV2 on CIFAR100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59ed8f02",
+   "metadata": {
+    "id": "59ed8f02"
+   },
+   "source": [
+    "[Run this tutorial in Google Colab](https://colab.research.google.com/github/reuvenperetz/model_optimization/blob/add-cifar100-notebook/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "822944a1",
+   "metadata": {
+    "id": "822944a1"
+   },
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "743dbc3d",
+   "metadata": {
+    "id": "743dbc3d"
+   },
+   "source": [
+    "This tutorial demonstrates the process of retraining and quantizing a MobileNetV2 on CIFAR100 dataset. It starts by fine-tuning a pretrained MobileNetV2 model on the CIFAR100 dataset. After retraining, the model is quantized using MCT. This tutorial specifically uses mixed-precision quantization, which assigns different precision levels to different layers in the model based on their impact on the output. The quantized model is then evaluated and exported to an ONNX file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59e2eeae",
+   "metadata": {
+    "id": "59e2eeae"
+   },
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1daf577a",
+   "metadata": {
+    "id": "1daf577a"
+   },
+   "source": [
+    "In this tutorial we will cover:\n",
+    "1. Retraining Pytorch MobileNetV2 on CIFAR100.\n",
+    "2. Quantizing the model using post-training quantization in mixes-precision for the weights.\n",
+    "3. Evaluating and exporting the model to ONNX."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b3396bf",
+   "metadata": {
+    "id": "8b3396bf"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e7690ef",
+   "metadata": {
+    "id": "5e7690ef"
+   },
+   "source": [
+    "First install the relevant packages and import them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89e0bb04",
+   "metadata": {
+    "id": "89e0bb04"
+   },
+   "outputs": [],
+   "source": [
+    "! pip install -q model-compression-toolkit\n",
+    "! pip install -q mct-quantizers==1.1.0\n",
+    "! pip install -q torch\n",
+    "! pip install -q torchvision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a82928d0",
+   "metadata": {
+    "id": "a82928d0"
+   },
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "import tempfile\n",
+    "\n",
+    "import torch\n",
+    "import torchvision\n",
+    "from torch import nn, optim\n",
+    "from torchvision import transforms\n",
+    "from tqdm import tqdm\n",
+    "import numpy as np\n",
+    "import random\n",
+    "\n",
+    "import model_compression_toolkit as mct"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bafa05a4-b897-4d58-afa9-6416221266b5",
+   "metadata": {},
+   "source": [
+    "In addition, let's set a seed for reproduction results purposes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d9c893c-b3b5-41fc-858b-af886e818f1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def seed_everything(seed_value):\n",
+    "    random.seed(seed_value)\n",
+    "    np.random.seed(seed_value)\n",
+    "    torch.manual_seed(seed_value)\n",
+    "    torch.cuda.manual_seed_all(seed_value)\n",
+    "    torch.backends.cudnn.deterministic = True\n",
+    "    torch.backends.cudnn.benchmark = False\n",
+    "\n",
+    "seed_everything(0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1653425b",
+   "metadata": {
+    "id": "1653425b"
+   },
+   "source": [
+    "## Define functions for creating dataset loaders\n",
+    "\n",
+    "We use two functions to create data loaders for the CIFAR100 dataset:\n",
+    "\n",
+    "get_cifar100_trainloader - This function creates a data loader for the CIFAR100 training dataset, applying the specified transformations and using the provided batch size.\n",
+    "\n",
+    "get_cifar100_testloader - Similarly, this function creates a data loader for the CIFAR100 testing dataset with the given transformations and batch size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac38177b-6ba4-4fc0-b1f5-a72d63631e40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def get_cifar100_trainloader(dataset_folder, transform, train_batch_size):\n",
+    "    \"\"\"\n",
+    "    Get CIFAR100 train loader.\n",
+    "    \"\"\"\n",
+    "    trainset = torchvision.datasets.CIFAR100(root=dataset_folder, train=True, download=True, transform=transform)\n",
+    "    trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, shuffle=True)\n",
+    "    return trainloader\n",
+    "\n",
+    "\n",
+    "def get_cifar100_testloader(dataset_folder, transform, eval_batch_size):\n",
+    "    \"\"\"\n",
+    "    Get CIFAR100 test loader.\n",
+    "    \"\"\"\n",
+    "    testset = torchvision.datasets.CIFAR100(root=dataset_folder, train=False, download=True, transform=transform)\n",
+    "    testloader = torch.utils.data.DataLoader(testset, batch_size=eval_batch_size, shuffle=False)\n",
+    "    return testloader\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02312089",
+   "metadata": {
+    "id": "02312089"
+   },
+   "source": [
+    "## Evaluation helper function\n",
+    "Now, we will create a function for evaluating a model (we will use it later on)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16f9bcc0",
+   "metadata": {
+    "id": "16f9bcc0"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def evaluate(model, testloader, device):\n",
+    "    \"\"\"\n",
+    "    Evaluate a model using a test loader.\n",
+    "    \"\"\"\n",
+    "    model.to(device)\n",
+    "    model.eval()  # Set the model to evaluation mode\n",
+    "    correct = 0\n",
+    "    total = 0\n",
+    "    with torch.no_grad():\n",
+    "        for data in testloader:\n",
+    "            images, labels = data\n",
+    "            images, labels = images.to(device), labels.to(device)\n",
+    "            outputs = model(images)\n",
+    "            _, predicted = torch.max(outputs.data, 1)\n",
+    "            total += labels.size(0)\n",
+    "            correct += (predicted == labels).sum().item()\n",
+    "    val_acc = (100 * correct / total)\n",
+    "    print('Accuracy: %.2f%%' % val_acc)\n",
+    "    return val_acc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c24d3c5a",
+   "metadata": {
+    "id": "c24d3c5a"
+   },
+   "source": [
+    "## Fine-tuning MobileNetV2 to CIFAR100\n",
+    "\n",
+    "We now create a function for the retraining phase of our model. This is a simple training schema for 20 wpochs. The trained model is evaluated after each epoch and the returned model is the model with the best observed accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c615a27e",
+   "metadata": {
+    "id": "c615a27e"
+   },
+   "outputs": [],
+   "source": [
+    "def retrain(model, transform, device, args):\n",
+    "    trainloader = get_cifar100_trainloader(args.representative_dataset_dir,\n",
+    "                                           transform,\n",
+    "                                           args.retrain_batch_size)\n",
+    "\n",
+    "    testloader = get_cifar100_testloader(args.representative_dataset_dir,\n",
+    "                                         transform,\n",
+    "                                         args.eval_batch_size)\n",
+    "\n",
+    "    model.to(device)\n",
+    "\n",
+    "    # Define loss function and optimizer\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "    optimizer = optim.SGD(model.parameters(),\n",
+    "                          lr=args.retrain_lr,\n",
+    "                          momentum=args.retrain_momentum)\n",
+    "\n",
+    "    best_acc = 0.0\n",
+    "    # Training loop\n",
+    "    for epoch in range(args.retrain_num_epochs):\n",
+    "        prog_bar = tqdm(enumerate(trainloader),\n",
+    "                        total=len(trainloader),\n",
+    "                        leave=True)\n",
+    "\n",
+    "        print(f'Retrain epoch: {epoch}')\n",
+    "        for i, data in prog_bar:\n",
+    "            inputs, labels = data\n",
+    "            inputs, labels = inputs.to(device), labels.to(device)\n",
+    "\n",
+    "            # Zero the parameter gradients\n",
+    "            optimizer.zero_grad()\n",
+    "\n",
+    "            # Forward, backward, and update parameters\n",
+    "            outputs = model(inputs)\n",
+    "            loss = criterion(outputs, labels)\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "\n",
+    "        val_acc = evaluate(model, testloader, device)\n",
+    "\n",
+    "        # Check if this model has the best accuracy, and if so, save it\n",
+    "        if val_acc > best_acc:\n",
+    "            print(f'Best accuracy so far {val_acc}')\n",
+    "            best_acc = val_acc\n",
+    "            best_state_dict = copy.deepcopy(model.state_dict())\n",
+    "\n",
+    "    model.load_state_dict(best_state_dict)\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b64a5f1f-9583-4982-ab0b-fb3ecba80ecb",
+   "metadata": {},
+   "source": [
+    "Let's create an object for the retraining parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35cac44f-5813-4559-9753-c88660d2229c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RetrainArguments:\n",
+    "    def __init__(self):\n",
+    "        self.retrain_num_epochs = 1 # Number of epochs to retrain the model\n",
+    "        self.eval_batch_size = 32 # Batch size of test loader\n",
+    "        self.retrain_batch_size = 32 # Batch size of train loader\n",
+    "        self.retrain_lr = 0.001 # Learning rate to use during retraining\n",
+    "        self.retrain_momentum = 0.9 # SGD momentum to use during retraining\n",
+    "        self.representative_dataset_dir = './data' # Path to save the dataset (CIFAR100)\n",
+    "\n",
+    "retrain_args = RetrainArguments()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69366614",
+   "metadata": {
+    "id": "69366614"
+   },
+   "source": [
+    "In order to retrain MobileNetV2 we first load the ImageNet weights and then fine-tune it using the above-mentioned retraining function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9de970bf-f50e-45a8-a59c-57367b2a4559",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load pretrained MobileNetV2 model on ImageNet\n",
+    "model = torchvision.models.mobilenet_v2(pretrained=True)\n",
+    "\n",
+    "# Modify last layer to match CIFAR-100 classes\n",
+    "model.classifier[1] = nn.Linear(model.last_channel, 100)\n",
+    "\n",
+    "# Create preprocessing pipeline for training and evaluation\n",
+    "transform = transforms.Compose([\n",
+    "    transforms.Resize((224, 224)),  # Resize images to fit MobileNetV2 input\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]) # Normalize inputs to range [-1, 1]\n",
+    "\n",
+    "# If GPU available, move the model to GPU\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "# Fine-tune the model to adapt to CIFAR100\n",
+    "model = retrain(model,\n",
+    "                transform,\n",
+    "                device,\n",
+    "                retrain_args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9d099ed-9b44-4e4c-b89d-0a7a2da3eb03",
+   "metadata": {},
+   "source": [
+    "Finally, let's evaluate our new model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5fbd70-8f0f-47c6-ad78-dd3a41d0e7bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate the retrained model\n",
+    "testloader = get_cifar100_testloader(retrain_args.representative_dataset_dir,\n",
+    "                                     transform,\n",
+    "                                     retrain_args.eval_batch_size)\n",
+    "evaluate(model, testloader, device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9cd25a7",
+   "metadata": {
+    "id": "e9cd25a7"
+   },
+   "source": [
+    "## Mixed-Precision Quantization Using MCT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0321aad",
+   "metadata": {
+    "id": "c0321aad"
+   },
+   "source": [
+    "Now we would like to quantize this model using MCT.\n",
+    "To do so, we need to define a representative dataset, which is a generator that returns a list of images for 10 times (in this example):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "618975be",
+   "metadata": {
+    "id": "618975be"
+   },
+   "outputs": [],
+   "source": [
+    "# Create representative_data_gen function from the train dataset\n",
+    "trainloader = get_cifar100_trainloader(retrain_args.representative_dataset_dir,\n",
+    "                                       transform,\n",
+    "                                       retrain_args.retrain_batch_size)\n",
+    "\n",
+    "num_calibration_iterations = 10\n",
+    "def representative_data_gen() -> list:\n",
+    "    for _ in range(num_calibration_iterations):\n",
+    "        yield [next(iter(trainloader))[0]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0a92bee",
+   "metadata": {
+    "id": "d0a92bee"
+   },
+   "source": [
+    "In addition, MCT optimizes the model for dedicated hardware. This is done using TPC (for more details, please visit our [documentation](https://sony.github.io/model_optimization/docs/api/experimental_api_docs/modules/target_platform.html)). Here, we use the default Pytorch TPC:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63f695dd",
+   "metadata": {
+    "id": "63f695dd"
+   },
+   "outputs": [],
+   "source": [
+    "# Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.\n",
+    "# Here, for example, we use the default platform that is attached to a Pytorch layers representation.\n",
+    "target_platform_cap = mct.get_target_platform_capabilities('pytorch', 'default')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3521637",
+   "metadata": {
+    "id": "d3521637"
+   },
+   "source": [
+    "In order to use mixed-precision quantization we need to set some parameters in the CoreConfig that MCT uses:\n",
+    "1. Number of images - MCT uses images from the representative dataset to search for a suitable bit-width configuration. This parameter determine the number of images MCT will use. The more images, the bit-width configuration is expected to be more accurate (however this affects the search time, so there is a trade-off between runtime and expected accuracy).\n",
+    "2. Gradient weighting - A method to improve the bit-width configuration search (in exchange for longer search time). In this example, we will not use it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ce7789b-aa3d-4a44-8dc5-dc052ece9cad",
+   "metadata": {
+    "id": "4f5fa4a2"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a mixed-precision quantization configuration with possible mixed-precision search options.\n",
+    "# MCT will search a mixed-precision configuration (namely, bit-width for each layer)\n",
+    "# and quantize the model according to this configuration.\n",
+    "# The candidates bit-width for quantization should be defined in the target platform model:\n",
+    "configuration = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(\n",
+    "    num_of_images=32,\n",
+    "    use_grad_based_weights=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "534eeb45-dba7-45cc-b8c7-75cc60e6e002",
+   "metadata": {},
+   "source": [
+    "In addition, when using mixed-precision we define the desired compression ratio. Here, we will search for a mixed-precision configuration that will compress the weights to 0.75% of the 8bits model weights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec6f2ea5-9a79-4961-b746-aac45a95aecb",
+   "metadata": {
+    "id": "4f5fa4a2"
+   },
+   "outputs": [],
+   "source": [
+    "# Get KPI information to constraint your model's memory size.\n",
+    "# Retrieve a KPI object with helpful information of each KPI metric,\n",
+    "# to constraint the quantized model to the desired memory size.\n",
+    "kpi_data = mct.core.pytorch_kpi_data_experimental(model,\n",
+    "                                                  representative_data_gen,\n",
+    "                                                  configuration,\n",
+    "                                                  target_platform_capabilities=target_platform_cap)\n",
+    "\n",
+    "# Set a constraint for each of the KPI metrics.\n",
+    "# Create a KPI object to limit our returned model's size. Note that this values affect only layers and attributes\n",
+    "# that should be quantized (for example, the kernel of Conv2D in Pytorch will be affected by this value,\n",
+    "# while the bias will not)\n",
+    "# examples:\n",
+    "# weights_compression_ratio = 0.75 - About 0.75 of the model's weights memory size when quantized with 8 bits.\n",
+    "kpi = mct.core.KPI(kpi_data.weights_memory * 0.75)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd09fa27",
+   "metadata": {
+    "id": "fd09fa27"
+   },
+   "source": [
+    "Now, we are ready to use MCT to quantize the model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13263c5e-aac0-4f54-a0d4-705fd97451a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quantized_model, quantization_info = mct.ptq.pytorch_post_training_quantization_experimental(model,\n",
+    "                                                                                             representative_data_gen,\n",
+    "                                                                                             target_kpi=kpi,\n",
+    "                                                                                             core_config=configuration,\n",
+    "                                                                                             target_platform_capabilities=target_platform_cap)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7697b885-ed23-411c-903f-72542593b6e0",
+   "metadata": {},
+   "source": [
+    "Finally, we evaluate the quantized model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "886f063c-bb61-4e2e-bff1-c0c7333613f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluate(quantized_model,\n",
+    "         testloader,\n",
+    "         device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9nQBVWFhbKXV",
+   "metadata": {
+    "id": "9nQBVWFhbKXV"
+   },
+   "source": [
+    "Now, we can export the quantized model to ONNX. Notice that onnx is not in MCT requierments, so first it should be installed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52313ce3-c735-40aa-8ec7-7d32c7359326",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install -q onnx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "oXMn6bFjbQad",
+   "metadata": {
+    "id": "oXMn6bFjbQad"
+   },
+   "outputs": [],
+   "source": [
+    "# Export quantized model to ONNX\n",
+    "import tempfile\n",
+    "_, onnx_file_path = tempfile.mkstemp('.onnx') # Path of exported model\n",
+    "mct.exporter.pytorch_export_model(model=quantized_model, save_model_path=onnx_file_path,\n",
+    "                                  repr_dataset=representative_data_gen, target_platform_capabilities=target_platform_cap,\n",
+    "                                  serialization_format=mct.exporter.PytorchExportSerializationFormat.ONNX)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14877777",
+   "metadata": {
+    "id": "14877777"
+   },
+   "source": [
+    "## Conclusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb7e1572",
+   "metadata": {
+    "id": "bb7e1572"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.\n",
+    "\n",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "you may not use this file except in compliance with the License.\n",
+    "You may obtain a copy of the License at\n",
+    "\n",
+    "    http://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "Unless required by applicable law or agreed to in writing, software\n",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "See the License for the specific language governing permissions and\n",
+    "limitations under the License.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add notebook to demonstrate quantizing mbv2 on cifar100 using mixed-precision.
Fixes to current example script:
1. Reducing eval batch size to 32
2. Setting seed to reproduce results