### PR TITLE
Align LUT parameters names with MCTQ

### DIFF
--- a/model_compression_toolkit/constants.py
+++ b/model_compression_toolkit/constants.py
@@ -27,13 +27,13 @@ WEIGHTS_SIGNED = True
 # Minimal threshold to use for quantization ranges:
 MIN_THRESHOLD = (2 ** -16)
 EPS = 1e-8
-MULTIPLIER_N_BITS = 8
+LUT_VALUES_BITWIDTH = 8
 
 # Quantization attributes:
 OUTPUT_SCALE = 'output_scale'
 THRESHOLD = 'threshold'
 SIGNED = 'is_signed'
-CLUSTER_CENTERS = 'cluster_centers'
+LUT_VALUES = 'lut_values'
 SCALE_PER_CHANNEL = 'scale_per_channel'
 RANGE_MIN = 'range_min'
 RANGE_MAX = 'range_max'

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/kmeans_params.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/kmeans_params.py
@@ -17,7 +17,7 @@ import numpy as np
 from sklearn.cluster import KMeans
 
 import model_compression_toolkit.core.common.quantization.quantization_config as qc
-from model_compression_toolkit.constants import CLUSTER_CENTERS, SCALE_PER_CHANNEL, MIN_THRESHOLD, EPS
+from model_compression_toolkit.constants import LUT_VALUES, SCALE_PER_CHANNEL, MIN_THRESHOLD, EPS
 
 
 def kmeans_tensor(tensor_data: np.ndarray,
@@ -59,6 +59,6 @@ def kmeans_tensor(tensor_data: np.ndarray,
     tensor_for_kmeans = (tensor_data / (scales_per_channel + EPS))
     kmeans.fit(tensor_for_kmeans.reshape(-1, 1))
 
-    return {CLUSTER_CENTERS: kmeans.cluster_centers_,
+    return {LUT_VALUES: kmeans.cluster_centers_,
             SCALE_PER_CHANNEL: scales_per_channel,
             }

--- a/model_compression_toolkit/core/common/quantization/quantizers/kmeans_quantizer.py
+++ b/model_compression_toolkit/core/common/quantization/quantizers/kmeans_quantizer.py
@@ -16,7 +16,7 @@
 from sklearn.cluster import KMeans
 import numpy as np
 
-from model_compression_toolkit.constants import CLUSTER_CENTERS, MIN_THRESHOLD, SCALE_PER_CHANNEL
+from model_compression_toolkit.constants import LUT_VALUES, MIN_THRESHOLD, SCALE_PER_CHANNEL
 from model_compression_toolkit.core.common.quantization.quantizers.quantizers_helpers import kmeans_assign_clusters
 
 
@@ -42,12 +42,12 @@ def kmeans_quantizer(tensor_data: np.ndarray,
         Quantized data.
     """
     eps = 1e-8
-    cluster_centers = quantization_params[CLUSTER_CENTERS]
+    lut_values = quantization_params[LUT_VALUES]
     scales_per_channel = quantization_params[SCALE_PER_CHANNEL]
     tensor = (tensor_data / (scales_per_channel + eps))
     shape_before_kmeans = tensor.shape
-    cluster_assignments = kmeans_assign_clusters(cluster_centers, tensor.reshape(-1, 1))
-    quant_tensor = cluster_centers[cluster_assignments].reshape(shape_before_kmeans)
+    cluster_assignments = kmeans_assign_clusters(lut_values, tensor.reshape(-1, 1))
+    quant_tensor = lut_values[cluster_assignments].reshape(shape_before_kmeans)
     if per_channel:
         quant_tensor = (quant_tensor * scales_per_channel)
     return quant_tensor

--- a/model_compression_toolkit/core/common/quantization/quantizers/lut_kmeans_quantizer.py
+++ b/model_compression_toolkit/core/common/quantization/quantizers/lut_kmeans_quantizer.py
@@ -15,8 +15,8 @@
 
 import numpy as np
 
-from model_compression_toolkit.constants import CLUSTER_CENTERS, SCALE_PER_CHANNEL, \
-    MULTIPLIER_N_BITS
+from model_compression_toolkit.constants import LUT_VALUES, SCALE_PER_CHANNEL, \
+    LUT_VALUES_BITWIDTH
 from model_compression_toolkit.core.common.quantization.quantizers.quantizers_helpers import kmeans_assign_clusters, \
     get_quantized_tensor, int_quantization_with_threshold
 
@@ -30,8 +30,8 @@ def lut_kmeans_quantizer(tensor_data: np.ndarray,
     """
     Quantize a tensor with given cluster centers and thresholds-per-channel vector.
     1. We divide tensor_data with the scale vector per channel.
-    2. We scale the result to the range [-2^(MULTIPLIER_N_BITS-1), 2^(MULTIPLIER_N_BITS-1)-1].
-    3. We assign cluster centers to every value, multiply by thresholds_per_channel and divide by 2^(MULTIPLIER_N_BITS-1).
+    2. We scale the result to the range [-2^(LUT_VALUES_BITWIDTH-1), 2^(LUT_VALUES_BITWIDTH-1)-1].
+    3. We assign cluster centers to every value, multiply by thresholds_per_channel and divide by 2^(LUT_VALUES_BITWIDTH-1).
     The result is the quantized tensor.
 
 
@@ -46,12 +46,12 @@ def lut_kmeans_quantizer(tensor_data: np.ndarray,
     Returns:
         Quantized data.
     """
-    cluster_centers = quantization_params[CLUSTER_CENTERS]
+    lut_values = quantization_params[LUT_VALUES]
     thresholds_per_channel = quantization_params[SCALE_PER_CHANNEL]
-    tensor = int_quantization_with_threshold(tensor_data, thresholds_per_channel, MULTIPLIER_N_BITS)
+    tensor = int_quantization_with_threshold(tensor_data, thresholds_per_channel, LUT_VALUES_BITWIDTH)
     shape_before_kmeans = tensor.shape
-    cluster_assignments = kmeans_assign_clusters(cluster_centers, tensor.reshape(-1, 1))
-    quant_tensor = get_quantized_tensor(cluster_centers[cluster_assignments].reshape(shape_before_kmeans),
+    cluster_assignments = kmeans_assign_clusters(lut_values, tensor.reshape(-1, 1))
+    quant_tensor = get_quantized_tensor(lut_values[cluster_assignments].reshape(shape_before_kmeans),
                                         thresholds_per_channel,
-                                        MULTIPLIER_N_BITS)
+                                        LUT_VALUES_BITWIDTH)
     return quant_tensor

--- a/model_compression_toolkit/core/common/quantization/quantizers/quantizers_helpers.py
+++ b/model_compression_toolkit/core/common/quantization/quantizers/quantizers_helpers.py
@@ -151,12 +151,12 @@ def uniform_quantize_tensor(tensor_data: np.ndarray,
     return q
 
 
-def kmeans_assign_clusters(cluster_centers: np.ndarray,
+def kmeans_assign_clusters(lut_values: np.ndarray,
                            query: np.ndarray) -> np.ndarray:
     """
     Assign each data value in query with its closest cluster center point.
     Args:
-        cluster_centers: the cluster centers to assign the query values.
+        lut_values: the cluster centers to assign the query values.
         query: values for which to assign cluster centers.
 
     Returns: A tensor of indexes to the cluster centers that where assigned to each value in
@@ -164,9 +164,9 @@ def kmeans_assign_clusters(cluster_centers: np.ndarray,
 
     """
     d0 = query.shape[0]
-    d1 = cluster_centers.shape[0]
+    d1 = lut_values.shape[0]
     query_ = query.repeat(d1).reshape(d0, d1)
-    cluster_centers_ = cluster_centers.repeat(d0).reshape(d1, d0).transpose(1, 0)
+    cluster_centers_ = lut_values.repeat(d0).reshape(d1, d0).transpose(1, 0)
     return np.argmin(np.abs(query_ - cluster_centers_), axis=1)
 
 

--- a/model_compression_toolkit/exporter/model_wrapper/keras/builder/node_to_quantizer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/keras/builder/node_to_quantizer.py
@@ -15,7 +15,7 @@
 from typing import Dict, Any
 
 from model_compression_toolkit.core.common import BaseNode
-from model_compression_toolkit.constants import THRESHOLD, RANGE_MIN, RANGE_MAX, SIGNED, CLUSTER_CENTERS, SCALE_PER_CHANNEL
+from model_compression_toolkit.constants import THRESHOLD, RANGE_MIN, RANGE_MAX, SIGNED, LUT_VALUES, SCALE_PER_CHANNEL
 from model_compression_toolkit.core.common.quantization.node_quantization_config import BaseNodeQuantizationConfig, \
     NodeWeightsQuantizationConfig, NodeActivationQuantizationConfig
 
@@ -66,7 +66,7 @@ def get_inferable_quantizer_kwargs(node_qc: BaseNodeQuantizationConfig,
         elif quantization_method in [QuantizationMethod.LUT_SYM_QUANTIZER, QuantizationMethod.LUT_POT_QUANTIZER]:
             return {qi_keras_consts.NUM_BITS: node_qc.weights_n_bits,
                     qi_keras_consts.PER_CHANNEL: node_qc.weights_per_channel_threshold,
-                    qi_keras_consts.CLUSTER_CENTERS: list(node_qc.weights_quantization_params[CLUSTER_CENTERS].flatten()),
+                    qi_keras_consts.LUT_VALUES: list(node_qc.weights_quantization_params[LUT_VALUES].flatten()),
                     qi_keras_consts.THRESHOLD: list(node_qc.weights_quantization_params[SCALE_PER_CHANNEL].flatten()),
                     qi_keras_consts.CHANNEL_AXIS: node_qc.weights_channels_axis,
                     # TODO: how to pass multiplier nbits and eps for a specific node?
@@ -98,7 +98,7 @@ def get_inferable_quantizer_kwargs(node_qc: BaseNodeQuantizationConfig,
         elif quantization_method in [QuantizationMethod.LUT_POT_QUANTIZER]:
             return {qi_keras_consts.NUM_BITS: node_qc.activation_n_bits,
                     qi_keras_consts.SIGNED: node_qc.activation_quantization_params[SIGNED],
-                    qi_keras_consts.CLUSTER_CENTERS: node_qc.activation_quantization_params[CLUSTER_CENTERS],
+                    qi_keras_consts.LUT_VALUES: node_qc.activation_quantization_params[LUT_VALUES],
                     qi_keras_consts.THRESHOLD: [node_qc.activation_quantization_params[THRESHOLD]]
                     # TODO: how to pass multiplier nbits and eps for a specific node?
                     }

--- a/model_compression_toolkit/exporter/model_wrapper/pytorch/builder/node_to_quantizer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/pytorch/builder/node_to_quantizer.py
@@ -17,7 +17,7 @@ from typing import Dict, Any
 
 from model_compression_toolkit.core.common import BaseNode
 from model_compression_toolkit.constants import THRESHOLD, SIGNED, RANGE_MIN, RANGE_MAX, \
-    SCALE_PER_CHANNEL, CLUSTER_CENTERS
+    SCALE_PER_CHANNEL, LUT_VALUES
 from model_compression_toolkit.core.common.quantization.node_quantization_config import BaseNodeQuantizationConfig, \
     NodeWeightsQuantizationConfig, NodeActivationQuantizationConfig
 from model_compression_toolkit.logger import Logger
@@ -64,11 +64,11 @@ def get_weights_inferable_quantizer_kwargs(node_qc: NodeWeightsQuantizationConfi
 
     elif quantization_method in [QuantizationMethod.LUT_POT_QUANTIZER, QuantizationMethod.LUT_SYM_QUANTIZER]:
         return {qi_inferable_quantizers_constants.NUM_BITS: node_qc.weights_n_bits,
-                qi_inferable_quantizers_constants.CLUSTER_CENTERS: node_qc.weights_quantization_params[CLUSTER_CENTERS].flatten(),
+                qi_inferable_quantizers_constants.LUT_VALUES: node_qc.weights_quantization_params[LUT_VALUES].flatten(),
                 qi_inferable_quantizers_constants.THRESHOLD: node_qc.weights_quantization_params[SCALE_PER_CHANNEL].flatten(),
                 qi_inferable_quantizers_constants.PER_CHANNEL: node_qc.weights_per_channel_threshold,
                 qi_inferable_quantizers_constants.CHANNEL_AXIS: node_qc.weights_channels_axis}
-                # TODO: Add MULTIPLIER_N_BITS & EPS to node quantization config
+                # TODO: Add LUT_VALUES_BITWIDTH & EPS to node quantization config
 
     else:
         Logger.critical(f'Not supported quantization method for weights inferable quantizers.')  # pragma: no cover
@@ -106,12 +106,12 @@ def get_activation_inferable_quantizer_kwargs(node_qc: NodeActivationQuantizatio
 
     elif quantization_method in [QuantizationMethod.LUT_POT_QUANTIZER]:
         return {qi_inferable_quantizers_constants.NUM_BITS: node_qc.activation_n_bits,
-                qi_inferable_quantizers_constants.CLUSTER_CENTERS: np.asarray(
-                    [node_qc.activation_quantization_params[CLUSTER_CENTERS]]),
+                qi_inferable_quantizers_constants.LUT_VALUES: np.asarray(
+                    [node_qc.activation_quantization_params[LUT_VALUES]]),
                 qi_inferable_quantizers_constants.THRESHOLD: np.asarray(
                     [node_qc.activation_quantization_params[THRESHOLD]]),
                 qi_inferable_quantizers_constants.SIGNED: node_qc.activation_quantization_params.get(SIGNED)}
-        # TODO: Add MULTIPLIER_N_BITS & EPS to node quantization config
+        # TODO: Add LUT_VALUES_BITWIDTH & EPS to node quantization config
     else:
         Logger.critical(f'Not supported quantization method for inferable quantizers.')  # pragma: no cover
 

--- a/model_compression_toolkit/target_platform_capabilities/target_platform/op_quantization_config.py
+++ b/model_compression_toolkit/target_platform_capabilities/target_platform/op_quantization_config.py
@@ -63,7 +63,7 @@ class OpQuantizationConfig:
         self.quantization_preserving = quantization_preserving
         self.fixed_scale = fixed_scale
         self.fixed_zero_point = fixed_zero_point
-        self.weights_multiplier_nbits = weights_multiplier_nbits
+        self.eights_lut_values_bitwidth = weights_multiplier_nbits
 
     def get_info(self):
         """

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -25,7 +25,7 @@ from model_compression_toolkit.core.common.network_editors.actions import EditRu
 from model_compression_toolkit.core.common.network_editors.node_filters import NodeNameFilter
 from model_compression_toolkit.core.keras.constants import KERNEL
 from mct_quantizers.keras.quantizers import ActivationLutPOTInferableQuantizer
-from mct_quantizers.common.constants import THRESHOLD, CLUSTER_CENTERS
+from mct_quantizers.common.constants import THRESHOLD, LUT_VALUES
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from tests.keras_tests.utils import get_layers_from_model_by_type
 
@@ -147,9 +147,9 @@ class LUTActivationQuantizerTest(BaseKerasFeatureNetworkTest):
             self.unit_test.assertTrue(isinstance(ll.activation_holder_quantizer, ActivationLutPOTInferableQuantizer))
             # Check layer's thresholds are power of two
             self.unit_test.assertTrue(math.log2(ll.activation_holder_quantizer.get_config()[THRESHOLD][0]).is_integer())
-            # Check layers number of clusters and clusters values
-            self.unit_test.assertTrue(len(ll.activation_holder_quantizer.get_config()[CLUSTER_CENTERS]) <= 2 ** self.activation_n_bits)
-            self.unit_test.assertTrue(np.all(np.mod(ll.activation_holder_quantizer.get_config()[CLUSTER_CENTERS], 1) == 0))
+            # Check layers number of lut values
+            self.unit_test.assertTrue(len(ll.activation_holder_quantizer.get_config()[LUT_VALUES]) <= 2 ** self.activation_n_bits)
+            self.unit_test.assertTrue(np.all(np.mod(ll.activation_holder_quantizer.get_config()[LUT_VALUES], 1) == 0))
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/function_tests/test_lut_activation_quanitzer_fake_quant.py
+++ b/tests/keras_tests/function_tests/test_lut_activation_quanitzer_fake_quant.py
@@ -17,8 +17,8 @@ import unittest
 
 import numpy as np
 
-from model_compression_toolkit.constants import CLUSTER_CENTERS, THRESHOLD, SIGNED, \
-    MULTIPLIER_N_BITS
+from model_compression_toolkit.constants import LUT_VALUES, THRESHOLD, SIGNED, \
+    LUT_VALUES_BITWIDTH
 from model_compression_toolkit.core.keras.quantizer.lut_fake_quant import LUTFakeQuant
 
 
@@ -26,20 +26,20 @@ class TestLUTQuantizerFakeQuant(unittest.TestCase):
 
     def test_signed_lut_activation_fake_quant(self):
         threshold = 16
-        cluster_centers = np.array([-8.0, 0.0, 4.0])
+        lut_values = np.array([-8.0, 0.0, 4.0])
         tensor = np.linspace(-1*threshold, threshold, num=2*threshold+1)
         quantization_params = {SIGNED: True,
-                               CLUSTER_CENTERS: cluster_centers,
+                               LUT_VALUES: lut_values,
                                THRESHOLD: threshold}
 
         # We divide the centers in 2^(8-1) (the minus 1 because of the signed quantization)
-        div_val_output = (2 ** (MULTIPLIER_N_BITS - 1))
+        div_val_output = (2 ** (LUT_VALUES_BITWIDTH - 1))
 
         # Construct the FakeQuant
         model = LUTFakeQuant(quantization_params)
         output = model(tensor)
 
-        expected_unique_values = (cluster_centers / div_val_output) * threshold
+        expected_unique_values = (lut_values / div_val_output) * threshold
 
         # Check expected unique values of the output
         self.assertTrue((np.unique(output) == expected_unique_values).all())
@@ -53,20 +53,20 @@ class TestLUTQuantizerFakeQuant(unittest.TestCase):
 
     def test_unsigned_lut_activation_fake_quant(self):
         threshold = 8
-        cluster_centers = np.array([0.0, 256.0])
+        lut_values = np.array([0.0, 256.0])
         tensor = np.linspace(0, threshold, num=threshold+1)
         quantization_params = {SIGNED: False,
-                               CLUSTER_CENTERS: cluster_centers,
+                               LUT_VALUES: lut_values,
                                THRESHOLD: threshold}
 
         # We divide the centers in 2^8
-        div_val_output = (2 ** MULTIPLIER_N_BITS)
+        div_val_output = (2 ** LUT_VALUES_BITWIDTH)
 
         # Construct the FakeQuant
         model = LUTFakeQuant(quantization_params)
         output = model(tensor)
 
-        expected_unique_values = (cluster_centers / div_val_output) * threshold
+        expected_unique_values = (lut_values / div_val_output) * threshold
 
         # Check expected unique values of the output
         self.assertTrue((np.unique(output) == expected_unique_values).all())

--- a/tests/keras_tests/function_tests/test_lut_activation_quanitzer_params.py
+++ b/tests/keras_tests/function_tests/test_lut_activation_quanitzer_params.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 from model_compression_toolkit.core import QuantizationErrorMethod
-from model_compression_toolkit.constants import CLUSTER_CENTERS, MIN_THRESHOLD, THRESHOLD
+from model_compression_toolkit.constants import LUT_VALUES, MIN_THRESHOLD, THRESHOLD
 from model_compression_toolkit.core.common.quantization.quantization_params_generation.lut_kmeans_params import \
     lut_kmeans_histogram
 
@@ -42,16 +42,16 @@ class TestLUTActivationsQuantizerParams(unittest.TestCase):
                                                    quant_error_method=QuantizationErrorMethod.MSE  # dummy
                                                    )
 
-        cluster_centers = quantization_params[CLUSTER_CENTERS]
+        lut_values = quantization_params[LUT_VALUES]
         threshold = quantization_params[THRESHOLD]
         # check threshold is power-of-two
         self.assertTrue(math.log2(threshold).is_integer(), "LUT quantization threshold must be a power of two")
 
-        # check number of clusters
-        self.assertTrue(cluster_centers.shape[0] <= 2 ** n_bits,
-                        f"Number of clusters is {cluster_centers.shape[0]} but should not exceed {2 ** n_bits}"),
-        # check clusters are rounded
-        self.assertTrue(np.all(np.mod(cluster_centers, 1) == 0), "Cluster points are supposed to be rounded")
+        # check number of lut values
+        self.assertTrue(lut_values.shape[0] <= 2 ** n_bits,
+                        f"Number of lut values is {lut_values.shape[0]} but should not exceed {2 ** n_bits}"),
+        # check lut values are rounded
+        self.assertTrue(np.all(np.mod(lut_values, 1) == 0), "lut values are supposed to be rounded")
 
     def test_unsigned_lut_activation_quantization_params(self):
         data = np.random.randn(3, 4, 5, 6)
@@ -71,16 +71,16 @@ class TestLUTActivationsQuantizerParams(unittest.TestCase):
                                                    quant_error_method=QuantizationErrorMethod.MSE  # dummy
                                                    )
 
-        cluster_centers = quantization_params[CLUSTER_CENTERS]
+        lut_values = quantization_params[LUT_VALUES]
         threshold = quantization_params[THRESHOLD]
         # check threshold is power-of-two
         self.assertTrue(math.log2(threshold).is_integer(), "LUT quantization threshold must be a power of two")
 
-        # check number of clusters
-        self.assertTrue(cluster_centers.shape[0] <= 2 ** n_bits,
-                        f"Number of clusters is {cluster_centers.shape[0]} but should not exceed {2 ** n_bits}"),
-        # check clusters are rounded
-        self.assertTrue(np.all(np.mod(cluster_centers, 1) == 0), "Cluster points are supposed to be rounded")
+        # check number of lut values
+        self.assertTrue(lut_values.shape[0] <= 2 ** n_bits,
+                        f"Number of lut values is {lut_values.shape[0]} but should not exceed {2 ** n_bits}"),
+        # check lut values are rounded
+        self.assertTrue(np.all(np.mod(lut_values, 1) == 0), "lut values are supposed to be rounded")
 
     def test_lut_activation_quantization_params_with_fewer_data(self):
         # check when the number of values of the data is lower than 2**n_bits
@@ -100,16 +100,16 @@ class TestLUTActivationsQuantizerParams(unittest.TestCase):
                                                    quant_error_method=QuantizationErrorMethod.MSE  # dummy
                                                    )
 
-        cluster_centers = quantization_params[CLUSTER_CENTERS]
+        lut_values = quantization_params[LUT_VALUES]
         threshold = quantization_params[THRESHOLD]
         # check threshold is power-of-two
         self.assertTrue(math.log2(threshold).is_integer(), "LUT quantization threshold must be a power of two")
 
-        # check number of clusters
-        self.assertTrue(cluster_centers.shape[0] <= bins.shape[0],
-                        f"Number of clusters is {cluster_centers.shape[0]} but should not exceed {bins.shape[0]}"),
-        # check clusters are rounded
-        self.assertTrue(np.all(np.mod(cluster_centers, 1) == 0), "Cluster points are supposed to be rounded")
+        # check number of lut values
+        self.assertTrue(lut_values.shape[0] <= bins.shape[0],
+                        f"Number of lut values is {lut_values.shape[0]} but should not exceed {bins.shape[0]}"),
+        # check lut values are rounded
+        self.assertTrue(np.all(np.mod(lut_values, 1) == 0), "lut values are supposed to be rounded")
 
 
 if __name__ == '__main__':

--- a/tests/keras_tests/function_tests/test_lut_quanitzer_params.py
+++ b/tests/keras_tests/function_tests/test_lut_quanitzer_params.py
@@ -18,7 +18,7 @@ import random
 import unittest
 import numpy as np
 
-from model_compression_toolkit.constants import CLUSTER_CENTERS, SCALE_PER_CHANNEL
+from model_compression_toolkit.constants import LUT_VALUES, SCALE_PER_CHANNEL
 from model_compression_toolkit.core.common.quantization.quantization_params_generation.lut_kmeans_params import \
     lut_kmeans_tensor
 
@@ -33,14 +33,14 @@ class TestLUTQuantizerParams(unittest.TestCase):
                                                 n_bits=4,
                                                 per_channel=True,
                                                 channel_axis=channel_axis)
-        cluster_centers = quantization_params[CLUSTER_CENTERS]
+        lut_values = quantization_params[LUT_VALUES]
         scales_per_channel = quantization_params[SCALE_PER_CHANNEL]
         # check size of scales
         self.assertTrue(scales_per_channel.shape[channel_axis] == tensor_data.shape[channel_axis])
         self.assertTrue(len(scales_per_channel.shape) == len(tensor_data.shape))
         # check that all scales are power of 2
         self.assertTrue(np.all([math.log2(n).is_integer() for n in list(scales_per_channel.flatten())]))
-        self.assertTrue(len(np.unique(cluster_centers.flatten())) <= len(np.unique(tensor_data.flatten())))
+        self.assertTrue(len(np.unique(lut_values.flatten())) <= len(np.unique(tensor_data.flatten())))
 
     def test_properties_with_fewer_data(self):
         # check when the number of values of the tensor_data is lower than 2**n_bits
@@ -51,15 +51,15 @@ class TestLUTQuantizerParams(unittest.TestCase):
                                                 n_bits=4,
                                                 per_channel=True,
                                                 channel_axis=channel_axis)
-        cluster_centers = quantization_params[CLUSTER_CENTERS]
+        lut_values = quantization_params[LUT_VALUES]
         scales_per_channel = quantization_params[SCALE_PER_CHANNEL]
         # check size of scales
         self.assertTrue(scales_per_channel.shape[channel_axis] == tensor_data.shape[channel_axis])
         self.assertTrue(len(scales_per_channel.shape) == len(tensor_data.shape))
         # check that all scales are power of 2
         self.assertTrue(np.all([math.log2(n).is_integer() for n in list(scales_per_channel.flatten())]))
-        # len(unique(tensor_data)) < 2 ** n_bits then cluster_centers = len(unique(tensor_data))
-        self.assertTrue(len(cluster_centers.flatten()) <= len(np.unique(tensor_data.flatten())))
+        # len(unique(tensor_data)) < 2 ** n_bits then lut_values = len(unique(tensor_data))
+        self.assertTrue(len(lut_values.flatten()) <= len(np.unique(tensor_data.flatten())))
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/lut_quantizer_test.py
@@ -148,7 +148,7 @@ class LUTActivationQuantizerTest(BasePytorchTest):
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
         quantized_model = quantized_models.get('lut_quantizer_test')
 
-        # Check that quantization occurred and the number of quantization clusters
+        # Check that quantization occurred and the number of quantization lut values
         set_model(float_model)
         self.unit_test.assertFalse(np.all(torch_tensor_to_numpy(float_model(input_x[0]) == quantized_model(input_x[0]))))
         self.unit_test.assertTrue(len(np.unique(torch_tensor_to_numpy(quantized_model(input_x[0])).flatten())) <=


### PR DESCRIPTION
replace "multiplier_n_bits" to "lut_values_bitwidth" and "cluster_centers" to "lut_values" in lut related code to be compatible with MCTQ