### PR TITLE
support tf2.13

### DIFF
--- a/.github/workflows/run_tests_tf213.yml
+++ b/.github/workflows/run_tests_tf213.yml
@@ -1,0 +1,14 @@
+name: Run Tests - Tensorflow 2.13
+on:
+  workflow_dispatch: # Allow manual triggers
+  schedule:
+    - cron: 0 0 * * *
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run-tensorflow-2_13:
+    uses: ./.github/workflows/run_keras_tests.yml
+    with:
+      tf-version: "2.13.*"

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ MCT supports compressing models built with the TensorFlow or PyTorch frameworks,
 
 | TensorFlow Version                                                                                   | PyTorch Version                                                                                          |
 |------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_tf212.yml/badge.svg) | ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_torch1_13.yml/badge.svg) |
-| ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_tf211.yml/badge.svg) | ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_torch1_12.yml/badge.svg) |
-| ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_tf210.yml/badge.svg) | ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_torch1_11.yml/badge.svg) |
+| ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_tf213.yml/badge.svg) | ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_torch1_13.yml/badge.svg) |
+| ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_tf212.yml/badge.svg) | ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_torch1_12.yml/badge.svg) |
+| ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_tf211.yml/badge.svg) | ![tests](https://github.com/sony/model_optimization/actions/workflows/run_tests_torch1_11.yml/badge.svg) |
 
 
 ## Supported Features

--- a/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
@@ -20,12 +20,10 @@ from packaging import version
 from model_compression_toolkit.core.common.back2framework.base_model_builder import BaseModelBuilder
 from model_compression_toolkit.core.common.user_info import UserInformation
 
-# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Input
-    from tensorflow.python.keras.layers.core import TFOpLambda
-    from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
-    from tensorflow.python.keras.layers import Layer
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras import Input
+    from keras.src.layers.core import TFOpLambda
+    from keras.src.engine.base_layer import TensorFlowOpLayer, Layer
 else:
     from keras import Input
     from keras.layers.core import TFOpLambda

--- a/model_compression_toolkit/core/keras/back2framework/mixed_precision_model_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/mixed_precision_model_builder.py
@@ -14,7 +14,13 @@
 # ==============================================================================
 from typing import Tuple, Any, Dict, Union, List
 
-from keras.engine.base_layer import Layer
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.base_layer import Layer
+else:
+    from keras.engine.base_layer import Layer
+
 from keras.models import Model
 from mct_quantizers import KerasQuantizationWrapper, KerasActivationQuantizationHolder, QuantizationTarget
 from mct_quantizers.common.get_quantizers import get_inferable_quantizer_class

--- a/model_compression_toolkit/core/keras/back2framework/model_gradients.py
+++ b/model_compression_toolkit/core/keras/back2framework/model_gradients.py
@@ -19,10 +19,10 @@ from packaging import version
 # As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
 from tqdm import tqdm
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.layers import Layer  # pragma: no cover
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.base_layer import Layer
 else:
-    from keras.engine.base_layer import Layer
+    from tensorflow.python.keras.engine.base_layer import Layer
 
 from typing import Any, Dict, List, Tuple
 from tensorflow.python.util.object_identity import Reference as TFReference

--- a/model_compression_toolkit/core/keras/default_framework_info.py
+++ b/model_compression_toolkit/core/keras/default_framework_info.py
@@ -19,8 +19,8 @@ import tensorflow as tf
 from model_compression_toolkit.core.keras.quantizer.lut_fake_quant import activation_lut_kmean_quantizer
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Softmax, ELU
 

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/multi_head_attention_decomposition.py
@@ -16,9 +16,9 @@ import numpy as np
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.layers.core import TFOpLambda
-    from tensorflow.keras.layers import MultiHeadAttention, Conv2D, Softmax, Concatenate, Reshape, Permute
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import TFOpLambda
+    from keras.src.layers import MultiHeadAttention, Conv2D, Softmax, Concatenate, Reshape, Permute
 else:
     from keras.layers.core import TFOpLambda
     from keras.layers import MultiHeadAttention, Conv2D, Softmax, Concatenate, Reshape, Permute

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/shift_negative_activation.py
@@ -16,11 +16,16 @@
 from typing import Tuple, Any
 
 import numpy as np
-import tensorflow as tf
 
+from packaging import version
+import tensorflow as tf
 from tensorflow.python.keras.layers.core import TFOpLambda
-from tensorflow.keras.layers import Activation, Conv2D, Dense, DepthwiseConv2D, ZeroPadding2D, Reshape, \
-    GlobalAveragePooling2D, Dropout, ReLU, PReLU, ELU
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Activation, Conv2D, Dense, DepthwiseConv2D, ZeroPadding2D, Reshape, \
+        GlobalAveragePooling2D, Dropout, ReLU, PReLU, ELU
+else:
+    from tensorflow.keras.layers import Activation, Conv2D, Dense, DepthwiseConv2D, ZeroPadding2D, Reshape, \
+        GlobalAveragePooling2D, Dropout, ReLU, PReLU, ELU
 
 from model_compression_toolkit.core import CoreConfig, FrameworkInfo
 from model_compression_toolkit.core.common import BaseNode, Graph

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -41,9 +41,10 @@ from model_compression_toolkit.core.keras.statistics_correction.apply_second_mom
     keras_apply_second_moment_correction
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Dense, Activation, Conv2D, DepthwiseConv2D, Conv2DTranspose, Concatenate, Add
-    from tensorflow.python.keras.layers.core import TFOpLambda
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Dense, Activation, Conv2D, DepthwiseConv2D, Conv2DTranspose, \
+        Concatenate, Add
+    from keras.src.layers.core import TFOpLambda
 else:
     from keras.layers import Dense, Activation, Conv2D, DepthwiseConv2D, Conv2DTranspose, \
         Concatenate, Add

--- a/model_compression_toolkit/core/keras/keras_node_prior_info.py
+++ b/model_compression_toolkit/core/keras/keras_node_prior_info.py
@@ -3,8 +3,8 @@ import numpy as np
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Activation, ReLU, BatchNormalization
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Activation, ReLU, BatchNormalization
 else:
     from keras.layers import Activation, ReLU, BatchNormalization
 

--- a/model_compression_toolkit/core/keras/reader/common.py
+++ b/model_compression_toolkit/core/keras/reader/common.py
@@ -17,12 +17,12 @@
 import tensorflow as tf
 from packaging import version
 
-# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.node import Node as KerasNode
-    from tensorflow.keras.layers import InputLayer
-    from tensorflow.python.keras.engine.functional import Functional
-    from tensorflow.python.keras.engine.sequential import Sequential
+
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.input_layer import InputLayer
+    from keras.src.engine.node import Node as KerasNode
+    from keras.src.engine.functional import Functional
+    from keras.src.engine.sequential import Sequential
 else:
     from keras.engine.input_layer import InputLayer
     from keras.engine.node import Node as KerasNode

--- a/model_compression_toolkit/core/keras/reader/connectivity_handler.py
+++ b/model_compression_toolkit/core/keras/reader/connectivity_handler.py
@@ -17,9 +17,8 @@
 import tensorflow as tf
 from packaging import version
 
-# As from Tensorflow 2.6, keras is a separate package and some classes should be imported differently.
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.node import Node as KerasNode
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.node import Node as KerasNode
 else:
     from keras.engine.node import Node as KerasNode
 

--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -20,10 +20,10 @@ from packaging import version
 from model_compression_toolkit.core.keras.custom_layer_validation import is_keras_custom_layer
 from model_compression_toolkit.logger import Logger
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.layers.core import TFOpLambda, SlicingOpLambda
-    from tensorflow.python.keras.engine.keras_tensor import KerasTensor
-    from tensorflow.python.keras.engine.node import Node as KerasNode
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import TFOpLambda, SlicingOpLambda
+    from keras.src.engine.keras_tensor import KerasTensor
+    from keras.src.engine.node import Node as KerasNode
 else:
     from keras.layers.core import TFOpLambda, SlicingOpLambda
     from keras.engine.keras_tensor import KerasTensor

--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -18,7 +18,11 @@ from typing import Dict, Callable
 
 import keras.models
 import tensorflow as tf
-from keras.engine.base_layer import Layer
+from packaging import version
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.base_layer import Layer
+else:
+    from keras.engine.base_layer import Layer
 
 from mct_quantizers import KerasQuantizationWrapper
 from mct_quantizers.logger import Logger
@@ -27,8 +31,8 @@ layers = keras.layers
 
 from model_compression_toolkit.exporter.model_exporter.keras.base_keras_exporter import BaseKerasExporter
 
-from keras.engine import base_layer_utils
-from keras import backend
+from tensorflow.python.keras.engine import base_layer_utils
+from tensorflow.python.keras import backend
 
 
 class FakelyQuantKerasExporter(BaseKerasExporter):

--- a/model_compression_toolkit/exporter/model_wrapper/keras/validate_layer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/keras/validate_layer.py
@@ -19,8 +19,15 @@ from model_compression_toolkit.constants import FOUND_TF
 from model_compression_toolkit.logger import Logger
 
 if FOUND_TF:
-    from keras.engine.base_layer import Layer
-    from keras.engine.input_layer import InputLayer
+    from packaging import version
+    import tensorflow as tf
+    if version.parse(tf.__version__) >= version.parse("2.13"):
+        from keras.src.engine.base_layer import Layer
+        from keras.src.engine.input_layer import InputLayer
+    else:
+        from keras.engine.base_layer import Layer
+        from keras.engine.input_layer import InputLayer
+
     from mct_quantizers import KerasQuantizationWrapper
 
     def is_keras_layer_exportable(layer: Any) -> bool:

--- a/model_compression_toolkit/gptq/keras/gptq_training.py
+++ b/model_compression_toolkit/gptq/keras/gptq_training.py
@@ -28,8 +28,8 @@ from model_compression_toolkit.gptq.keras.quantizer.quantization_builder import 
 from model_compression_toolkit.logger import Logger
 from mct_quantizers import KerasQuantizationWrapper, KerasActivationQuantizationHolder
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.base_layer import TensorFlowOpLayer
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.base_layer import TensorFlowOpLayer
 else:
     from keras.engine.base_layer import TensorFlowOpLayer
 

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v1/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v1/tpc_keras.py
@@ -15,9 +15,8 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Reshape, ZeroPadding2D, \
-        Dropout, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Flatten, Cropping2D
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Reshape, ZeroPadding2D, \

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v2/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v2/tpc_keras.py
@@ -16,10 +16,9 @@ import tensorflow as tf
 
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, \
-        MaxPooling2D, Activation, ReLU, PReLU, Flatten, Cropping2D
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, PReLU, Flatten, Cropping2D
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
         Dropout, MaxPooling2D, Activation, ReLU, PReLU, Flatten, Cropping2D

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v3/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v3/tpc_keras.py
@@ -15,10 +15,9 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, \
-        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
         Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v3_lut/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v3_lut/tpc_keras.py
@@ -16,10 +16,9 @@ import tensorflow as tf
 from packaging import version
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.v3_lut import __version__ as TPC_VERSION
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
-        Dropout, \
-        MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
+        Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, \
         Dropout, MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v4/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v4/tpc_keras.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute, \
         Conv2DTranspose
 else:

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v4_lut/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v4_lut/tpc_keras.py
@@ -16,8 +16,8 @@ import tensorflow as tf
 from packaging import version
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.v4_lut import __version__ as TPC_VERSION
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute, \
         Conv2DTranspose
 else:

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v5/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/default_tpc/v5/tpc_keras.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute, \
         Conv2DTranspose
 else:

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tpc_keras.py
@@ -15,8 +15,9 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute, \
         Conv2DTranspose
 else:

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tpc_keras.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute, \
         Conv2DTranspose
 else:

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/v1/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/v1/tpc_keras.py
@@ -17,9 +17,8 @@ import tensorflow as tf
 from packaging import version
 from model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1 import __version__ as TPC_VERSION
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Conv2DTranspose, Dense, BatchNormalization, ReLU, \
-        Activation
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Conv2DTranspose, Dense, BatchNormalization, ReLU, Activation
 else:
     from keras.layers import Conv2D, DepthwiseConv2D, Conv2DTranspose, Dense, BatchNormalization, ReLU, Activation
 

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/v1/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/v1/tpc_keras.py
@@ -15,9 +15,9 @@
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, Dense, Reshape, ZeroPadding2D, AveragePooling2D, Activation, \
-        DepthwiseConv2D, MaxPooling2D, ReLU, Add, Softmax, Concatenate, Multiply, Maximum, Minimum, BatchNormalization
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, Dense, Reshape, ZeroPadding2D, AveragePooling2D, Activation, DepthwiseConv2D, \
+        MaxPooling2D, ReLU, Add, Softmax, Concatenate, Multiply, Maximum, Minimum, BatchNormalization
 else:
     from keras.layers import Conv2D, Dense, Reshape, ZeroPadding2D, AveragePooling2D, Activation, DepthwiseConv2D, \
         MaxPooling2D, ReLU, Add, Softmax, Concatenate, Multiply, Maximum, Minimum, BatchNormalization

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/conv2d_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/conv2d_test.py
@@ -14,7 +14,13 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.layers import Conv2D, TFOpLambda
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, TFOpLambda
+else:
+    from keras.layers import Conv2D, TFOpLambda
+
 import numpy as np
 import tensorflow as tf
 

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/conv2dtranspose_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/conv2dtranspose_test.py
@@ -14,8 +14,12 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.applications import MobileNetV2
-from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense, Conv2DTranspose
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense, Conv2DTranspose
+else:
+    from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense, Conv2DTranspose
 import numpy as np
 import tensorflow as tf
 

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/dense_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/dense_test.py
@@ -14,8 +14,12 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.applications import MobileNetV2
-from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import TFOpLambda, Dense
+else:
+    from keras.layers import TFOpLambda, Dense
 import numpy as np
 import tensorflow as tf
 

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/dwconv2d_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/dwconv2d_test.py
@@ -14,8 +14,14 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.applications import MobileNetV2
-from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import DepthwiseConv2D
+    from keras.src.layers.core.tf_op_layer import TFOpLambda
+else:
+    from keras.layers import DepthwiseConv2D
+    from keras.layers.core.tf_op_layer import TFOpLambda
 import numpy as np
 import tensorflow as tf
 

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/multiple_inputs_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/multiple_inputs_test.py
@@ -14,10 +14,12 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.applications import MobileNetV2
-from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
-import numpy as np
+from packaging import version
 import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, Add
+else:
+    from keras.layers import Conv2D, Add
 
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/no_quant_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/no_quant_test.py
@@ -14,10 +14,13 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.applications import MobileNetV2
-from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
-import numpy as np
+from packaging import version
 import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D
+else:
+    from keras.layers import Conv2D
+import numpy as np
 
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc

--- a/tests/keras_tests/exporter_tests/keras_fake_quant/networks/tfoplambda_test.py
+++ b/tests/keras_tests/exporter_tests/keras_fake_quant/networks/tfoplambda_test.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 import keras
 from keras import Input
-from keras.applications import MobileNetV2
-from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
-import numpy as np
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
+else:
+    from keras.layers import Conv2D, TFOpLambda, Add, DepthwiseConv2D, Dense
 import tensorflow as tf
 
-from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
-from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
 from tests.keras_tests.exporter_tests.keras_fake_quant.keras_fake_quant_exporter_base_test import \
     KerasFakeQuantExporterBaseTest
 

--- a/tests/keras_tests/exporter_tests/tflite_int8/imx500_int8_tp_model.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/imx500_int8_tp_model.py
@@ -17,8 +17,8 @@ from typing import List, Tuple
 import tensorflow as tf
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
         MaxPooling2D, Activation, ReLU, Add, Subtract, Multiply, PReLU, Flatten, Cropping2D, LeakyReLU, Permute, \
         Conv2DTranspose
 else:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/experimental_exporter_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/experimental_exporter_test.py
@@ -15,8 +15,7 @@
 
 
 import tensorflow as tf
-from keras.engine.base_layer import Layer
-from mct_quantizers import KerasQuantizationWrapper, BaseInferableQuantizer, KerasActivationQuantizationHolder
+from mct_quantizers import BaseInferableQuantizer, KerasActivationQuantizationHolder
 
 from model_compression_toolkit.core.keras.constants import KERNEL
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest

--- a/tests/keras_tests/feature_networks_tests/feature_networks/multiple_output_nodes_multiple_tensors_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/multiple_output_nodes_multiple_tensors_test.py
@@ -14,20 +14,16 @@
 # ==============================================================================
 
 import tensorflow as tf
-from packaging import version
 
 from mct_quantizers import KerasQuantizationWrapper
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.functional import Functional
-    from tensorflow.python.keras.engine.sequential import Sequential
+from packaging import version
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.models import Functional, Sequential
 else:
     from keras.models import Functional, Sequential
 
-import model_compression_toolkit as mct
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
-import numpy as np
-from tests.common_tests.helpers.tensors_compare import cosine_similarity
 
 keras = tf.keras
 layers = keras.layers

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -19,9 +19,8 @@ import tensorflow as tf
 from tests.keras_tests.tpc_keras import get_16bit_tpc
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.functional import Functional
-    from tensorflow.python.keras.engine.sequential import Sequential
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.models import Functional, Sequential
 else:
     from keras.models import Functional, Sequential
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_outputs_test.py
@@ -20,9 +20,8 @@ import tensorflow as tf
 from tests.keras_tests.tpc_keras import get_16bit_tpc
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.functional import Functional
-    from tensorflow.python.keras.engine.sequential import Sequential
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.models import Functional, Sequential
 else:
     from keras.models import Functional, Sequential
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_unused_inputs_outputs_test.py
@@ -19,9 +19,8 @@ import tensorflow as tf
 from tests.keras_tests.tpc_keras import get_quantization_disabled_keras_tpc
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.functional import Functional
-    from tensorflow.python.keras.engine.sequential import Sequential
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.models import Functional, Sequential
 else:
     from keras.models import Functional, Sequential
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -18,9 +18,8 @@ import tensorflow as tf
 from tests.keras_tests.tpc_keras import get_quantization_disabled_keras_tpc
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.engine.functional import Functional
-    from tensorflow.python.keras.engine.sequential import Sequential
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.models import Functional, Sequential
 else:
     from keras.models import Functional, Sequential
 import model_compression_toolkit as mct

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import numpy as np
 import tensorflow as tf
-from keras.engine.input_layer import InputLayer
 
 from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.core import DebugConfig

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
@@ -15,8 +15,11 @@
 
 import numpy as np
 import tensorflow as tf
-from keras.engine.base_layer import Layer
-from keras.engine.input_layer import InputLayer
+from packaging import version
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.input_layer import InputLayer
+else:
+    from keras.engine.input_layer import InputLayer
 
 from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.core import QuantizationErrorMethod, DebugConfig

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -25,10 +25,11 @@ from packaging import version
 
 from tests.keras_tests.utils import get_layers_from_model_by_type
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.layers.core import TFOpLambda
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import TFOpLambda
 else:
     from keras.layers.core import TFOpLambda
+
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 import numpy as np
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/slicing_op_lambda_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/slicing_op_lambda_test.py
@@ -18,8 +18,8 @@ import model_compression_toolkit.target_platform_capabilities.target_platform.op
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from packaging import version
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.layers.core import SlicingOpLambda
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import SlicingOpLambda
 else:
     from keras.layers.core import SlicingOpLambda
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/split_concatenate_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/split_concatenate_test.py
@@ -15,7 +15,11 @@
 
 
 import tensorflow as tf
-from keras.layers import TFOpLambda
+from packaging import version
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import TFOpLambda
+else:
+    from keras.layers.core import TFOpLambda
 
 from mct_quantizers import KerasActivationQuantizationHolder
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest

--- a/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/symmetric_threshold_selection_activation_test.py
@@ -16,8 +16,6 @@
 
 import tensorflow as tf
 import numpy as np
-from keras.engine.base_layer import Layer
-from keras.layers import TFOpLambda
 
 from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -16,8 +16,7 @@
 
 import tensorflow as tf
 import numpy as np
-from keras.engine.base_layer import Layer
-from keras.layers import TFOpLambda
+
 
 from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc

--- a/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
+++ b/tests/keras_tests/function_tests/test_activation_weights_composition_substitution.py
@@ -17,7 +17,12 @@ import copy
 import keras
 import unittest
 
-from keras.layers import Conv2D, Conv2DTranspose, DepthwiseConv2D, Dense, BatchNormalization, ReLU, Input, Add
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, Conv2DTranspose, DepthwiseConv2D, Dense, BatchNormalization, ReLU, Input, Add
+else:
+    from keras.layers import Conv2D, Conv2DTranspose, DepthwiseConv2D, Dense, BatchNormalization, ReLU, Input, Add
 import numpy as np
 
 from model_compression_toolkit.core import DEFAULTCONFIG, MixedPrecisionQuantizationConfig

--- a/tests/keras_tests/function_tests/test_exporting_qat_models.py
+++ b/tests/keras_tests/function_tests/test_exporting_qat_models.py
@@ -19,7 +19,12 @@ import unittest
 import keras
 import numpy as np
 import tensorflow as tf
-from keras.layers import TFOpLambda
+
+from packaging import version
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import TFOpLambda
+else:
+    from keras.layers.core import TFOpLambda
 
 import model_compression_toolkit as mct
 from mct_quantizers import KerasActivationQuantizationHolder

--- a/tests/keras_tests/function_tests/test_keras_tp_model.py
+++ b/tests/keras_tests/function_tests/test_keras_tp_model.py
@@ -23,8 +23,9 @@ from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
 
 from model_compression_toolkit.core.common import BaseNode
 
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.keras.layers import Conv2D, Conv2DTranspose, ReLU, Activation, Input
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers import Conv2D, Conv2DTranspose, ReLU, Activation
+    from keras.src import Input
 else:
     from keras.layers import Conv2D, Conv2DTranspose, ReLU, Activation
     from keras import Input

--- a/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
+++ b/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
@@ -17,7 +17,12 @@ import unittest
 import numpy as np
 from keras.applications.densenet import DenseNet121
 from keras.applications.mobilenet_v2 import MobileNetV2
-from keras.layers import TFOpLambda
+
+from packaging import version
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.layers.core import TFOpLambda
+else:
+    from keras.layers.core import TFOpLambda
 
 from model_compression_toolkit.constants import AXIS
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import get_average_weights

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -1,8 +1,6 @@
 from typing import List, Any, Tuple
 
-import keras.layers
 import tensorflow as tf
-from keras.engine.base_layer import Layer
 from mct_quantizers import KerasQuantizationWrapper, KerasActivationQuantizationHolder
 
 from model_compression_toolkit.ptq import keras_post_training_quantization_experimental
@@ -10,18 +8,13 @@ from model_compression_toolkit.target_platform_capabilities.tpc_models.default_t
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from tests.keras_tests.tpc_keras import get_quantization_disabled_keras_tpc
 from packaging import version
-import model_compression_toolkit as mct
-
-if version.parse(tf.__version__) < version.parse("2.6"):
-    from tensorflow.python.keras.layers.core import TFOpLambda
-    from tensorflow.keras.models import Model
-    from tensorflow.keras.layers import Input
-    from tensorflow.keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src import Input, Model
+    from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
         Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, \
-        UpSampling2D, InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, ELU, Dot, LeakyReLU, Permute, \
+        UpSampling2D, InputLayer, Concatenate, Softmax, PReLU, Flatten, Cropping2D, Dot, ELU, LeakyReLU, Permute, \
         LayerNormalization
 else:
-    from keras.layers.core import TFOpLambda
     from keras import Input, Model
     from keras.layers import Conv2D, DepthwiseConv2D, Dense, Conv2DTranspose, Reshape, ZeroPadding2D, \
         Dropout, MaxPooling2D, Activation, ReLU, GlobalAveragePooling2D, Add, Multiply, AveragePooling2D, \
@@ -31,7 +24,6 @@ else:
 from model_compression_toolkit.core import FrameworkInfo
 from model_compression_toolkit.gptq import keras_gradient_post_training_quantization_experimental
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
-from model_compression_toolkit.core.keras.back2framework.keras_model_builder import is_layer_fake_quant
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
 from model_compression_toolkit.core.keras.keras_implementation import KerasImplementation
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode

--- a/tests/keras_tests/tpc_keras.py
+++ b/tests/keras_tests/tpc_keras.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-from keras.engine.input_layer import InputLayer
+from packaging import version
+import tensorflow as tf
+if version.parse(tf.__version__) >= version.parse("2.13"):
+    from keras.src.engine.input_layer import InputLayer
+else:
+    from keras.engine.input_layer import InputLayer
 import model_compression_toolkit as mct
 
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model, \

--- a/tests/pytorch_tests/exporter_tests/__init__.py
+++ b/tests/pytorch_tests/exporter_tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -136,10 +136,7 @@ if __name__ == '__main__':
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestGPTQLossFunctions))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(KerasTrainableInfrastructureTestRunner))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(keras_gptq_soft_quantizer_test))
-
-        # Keras test layers are supported in TF2.6 or higher versions
-        if version.parse(tf.__version__) >= version.parse("2.6"):
-            suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TFLayerTest))
+        suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TFLayerTest))
 
     if found_pytorch:
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestGPTQModelBuilderWithActivationHolderPytorch))


### PR DESCRIPTION
TF support 2.13:
1. remove support from version < 2.6
2. add imports for TF.2.13 and above
3. Adapt serialization for new TF.2.13 
