### PR TITLE
Fix missing prior info for new nodes in SNC

### DIFF
--- a/model_compression_toolkit/core/common/node_prior_info.py
+++ b/model_compression_toolkit/core/common/node_prior_info.py
@@ -41,6 +41,30 @@ class NodePriorInfo:
         self.mean_output = mean_output
         self.std_output = std_output
 
+    def get_shifted_prior_info(self, shift_val: float):
+        """
+        Get a prior info of this NodePriorInfo if its output was shifted by shift_val.
+        Args:
+            shift_val: Shift value for the node's output to update.
+
+        Returns:
+            A NodePriorInfo with values of this NodePriorInfo if its output was shifted.
+        """
+        shifted_min_output, shifted_max_output, shifted_mean_output, shifted_std_output = None, None, None, None
+        if self.min_output is not None:
+            shifted_min_output = self.min_output + shift_val
+        if self.max_output is not None:
+            shifted_max_output = self.max_output + shift_val
+        if self.mean_output is not None:
+            shifted_mean_output = self.mean_output + shift_val
+        if self.std_output is not None:
+            shifted_std_output = self.std_output
+
+        return NodePriorInfo(shifted_min_output,
+                             shifted_max_output,
+                             shifted_mean_output,
+                             shifted_std_output)
+
     def is_output_bounded(self) -> bool:
         """
 

--- a/model_compression_toolkit/core/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/core/common/substitutions/shift_negative_activation.py
@@ -311,6 +311,12 @@ def shift_negative_function(graph: Graph,
     add_node = create_add_node(shift_value,
                                non_linear_node.name,
                                non_linear_node.input_shape)
+
+    # Create prior info for the add node
+    if non_linear_node.prior_info is not None:
+        add_prior_info = non_linear_node.prior_info.get_shifted_prior_info(shift_value)
+        add_node.prior_info = add_prior_info
+
     insert_node_after_node(graph,
                            node_to_insert=add_node,
                            first_node=non_linear_node)


### PR DESCRIPTION
Add to NodePriorInfo a method to create a shifted version of it. Use it in SNC to attach prior info for new Add nodes.