### PR TITLE
Add nanodet-plus tutorial

### DIFF
--- a/tutorials/notebooks/example_keras_nanodet_plus.ipynb
+++ b/tutorials/notebooks/example_keras_nanodet_plus.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4c261298-309f-41e8-9338-a5e205f09b05",
+   "metadata": {},
+   "source": [
+    "# Post Training Quantization a Nanodet-Plus Object Detection Model\n",
+    "\n",
+    "[Run this tutorial in Google Colab](https://colab.research.google.com/github/sony/model_optimization/blob/main/tutorials/notebooks/example_keras_nanodet_plus.ipynb)\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "\n",
+    "In this tutorial, we'll demonstrate the post-training quantization using MCT for a pre-trained object detection model in Keras. Specifically, we'll integrate post-processing, including the non-maximum suppression (NMS) layer, into the model. This integration aligns with the imx500 target platform capabilities.\n",
+    "\n",
+    "In this example we will use off the shelf pre-trained Nanodet-Plus model taken from [https://github.com/RangiLyu/nanodet](https://github.com/RangiLyu/nanodet). We will convert the model to a Tensorflow model that includes box decoding and NMS layer. Further, we will quantize the model using MCT post training quantization and evaluate the performance of the floating point model and the quantize model on COCO dataset.   \n",
+    "\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "In this tutorial we will cover:\n",
+    "\n",
+    "1. Post-Training Quantization using MCT of Keras object detection model.\n",
+    "2. Loading and preprocessing COCO's validation dataset.\n",
+    "3. Loading and preprocessing an unlabeled representative dataset from the COCO trainset.\n",
+    "4. Accuracy evaluation of the floating-point and the quantized models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Setup\n",
+    "Install and import the relevant packages.\n",
+    "Note that we only install 'torch' in order to load the pre-trained weights from the Nanodet PyTorch model. \n",
+    "We assume that the folder 'resources' is cloned from [https://github.com/sony/model_optimization/tree/main/tutorials](https://github.com/sony/model_optimization/tree/main/tutorials) into the user's current directory."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "d74f9c855ec54081"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install -q torch\n",
+    "!pip install -q tensorflow\n",
+    "!pip install -q pycocotools\n",
+    "!pip install -q model-compression-toolkit\n",
+    "!git clone https://github.com/sony/model_optimization/tree/main/tutorials/resources"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "7c7fa04c9903736f"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "084c2b8b-3175-4d46-a18a-7c4d8b6fcb38",
+   "metadata": {},
+   "source": [
+    "## Floating Point Model\n",
+    "\n",
+    "### Load the pre-trained weights of Nanodet-Plus\n",
+    "We begin by loading the pre-trained weights of `nanodet-plus-m-1.5x-416` using `torch.load`, as the original model is in PyTorch format. Please make sure to download the pretrained weights from [here](https://github.com/RangiLyu/nanodet/tree/main) into the current directory or specify the correct file path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8395b28-4732-4d18-b081-5d3bdf508691",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "PRETRAINED_WEIGHTS_FILE = 'nanodet-plus-m-1.5x_416.pth'\n",
+    "pretrained_weights = torch.load(PRETRAINED_WEIGHTS_FILE, map_location=torch.device('cpu'))['state_dict']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Generate Nanoedet-Plus Keras model\n",
+    "In the following steps, we proceed to create a Keras model based on [Nanodet](https://github.com/RangiLyu/nanodet/tree/main). We then initialize the model weights to match those of the original model.\n",
+    "\n",
+    "To this base model, we integrate the post-processing components, which include box decoding layers following by tensorflow `combined_non_max_suppression` layer.\n",
+    "For further insights into the model's implementation details, please refer to the [`resources` folder](https://github.com/sony/model_optimization/tree/main/tutorials/resources)."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "7f148e78b769f1dc"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "from keras.models import Model\n",
+    "from tutorials.resources.nanodet_keras_model import nanodet_plus_m, nanodet_box_decoding, set_model_weights\n",
+    "\n",
+    "# Parameters of nanodet-plus-m-1.5x_416\n",
+    "INPUT_RESOLUTION = 416\n",
+    "INPUT_SHAPE = (INPUT_RESOLUTION, INPUT_RESOLUTION, 3)\n",
+    "SCALE_FACTOR = 1.5\n",
+    "BOTTLENECK_RATIO = 0.5\n",
+    "FEATURE_CHANNELS = 128\n",
+    "\n",
+    "# Generate Nanodet base model \n",
+    "model = nanodet_plus_m(INPUT_SHAPE, SCALE_FACTOR, BOTTLENECK_RATIO, FEATURE_CHANNELS)\n",
+    "\n",
+    "# Set the pre-trained weights\n",
+    "set_model_weights(model, pretrained_weights)\n",
+    "\n",
+    "# Add Nanodet Box decoding layer (decode the model outputs to bounding box coordinates)\n",
+    "scores, boxes = nanodet_box_decoding(model.output, res=INPUT_RESOLUTION)\n",
+    "\n",
+    "# Add Tensorflow NMS layer\n",
+    "outputs = tf.image.combined_non_max_suppression(\n",
+    "    boxes,\n",
+    "    scores,\n",
+    "    max_output_size_per_class=300,\n",
+    "    max_total_size=300,\n",
+    "    iou_threshold=0.65,\n",
+    "    score_threshold=0.001,\n",
+    "    pad_per_class=False,\n",
+    "    clip_boxes=False\n",
+    "    )\n",
+    "\n",
+    "model = Model(model.input, outputs, name='Nanodet_plus_m_1.5x_416')\n",
+    "\n",
+    "print('Model is ready for evaluation')"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "698ce1d40f2cdf1f"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cde2f8e-0642-4374-a1f4-df2775fe7767",
+   "metadata": {},
+   "source": [
+    "#### Evaluate the floating point model\n",
+    "Next, we evaluate the floating point model by using `cocoeval` library alongside additional dataset utilities. We can verify the mAP accuracy aligns with that of the original model.\n",
+    "Please ensure that the dataset path has been set correctly before running this code cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56393342-cecf-4f64-b9ca-2f515c765942",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "from tutorials.resources.coco_evaluation import coco_dataset_generator, CocoEval\n",
+    "\n",
+    "EVAL_DATASET_FOLDER = '/path/to/coco/training/images/val2017'\n",
+    "EVAL_DATASET_ANNOTATION_FILE = '/path/to/coco/annotations/instances_val2017.json'\n",
+    "BATCH_SIZE = 5\n",
+    "\n",
+    "def nanodet_preprocess(x):\n",
+    "    img_mean = [103.53, 116.28, 123.675]\n",
+    "    img_std = [57.375, 57.12, 58.395]\n",
+    "    x = cv2.resize(x, (416, 416))\n",
+    "    x = (x - img_mean) / img_std\n",
+    "    return x\n",
+    "\n",
+    "# Load COCO evaluation set\n",
+    "val_dataset = coco_dataset_generator(dataset_folder=EVAL_DATASET_FOLDER,\n",
+    "                                     annotation_file=EVAL_DATASET_ANNOTATION_FILE,\n",
+    "                                     preprocess=nanodet_preprocess,\n",
+    "                                     batch_size=BATCH_SIZE)\n",
+    "\n",
+    "# Initialize the evaluation metric object\n",
+    "coco_metric = CocoEval(EVAL_DATASET_ANNOTATION_FILE)\n",
+    "\n",
+    "# Iterate and the evaluation set\n",
+    "for batch_idx, (images, targets) in enumerate(val_dataset):\n",
+    "    \n",
+    "    # Run inference on the batch\n",
+    "    outputs = model(images)\n",
+    "\n",
+    "    # Add the model outputs to metric object (a dictionary of outputs after postprocess: boxes, scores & classes)\n",
+    "    coco_metric.add_batch_detections(outputs, targets)\n",
+    "    if (batch_idx + 1) % 100 == 0:\n",
+    "        print(f'processed {(batch_idx + 1) * BATCH_SIZE} images')\n",
+    "\n",
+    "# Print float model mAP results\n",
+    "print(\"Float model mAP: {:.4f}\".format(coco_metric.result()[0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015e760b-6555-45b4-aaf9-500e974c1d86",
+   "metadata": {},
+   "source": [
+    "## Quantize Model\n",
+    "\n",
+    "### Post training quantization using Model Compression Toolkit \n",
+    "\n",
+    "Now we are ready to use MCT's post training quantization! We will define a representative dataset based on the training dataset and preform the model quantization. We will use 32 representative images for calibration.\n",
+    "Same as the above section, please ensure that the dataset path has been set correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01e90967-594b-480f-b2e6-45e2c9ce9cee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import model_compression_toolkit as mct\n",
+    "\n",
+    "TRAIN_DATASET_FOLDER = '/path/to/coco/training/images/train2017'\n",
+    "TRAIN_DATASET_ANNOTATION_FILE = '/path/to/coco/annotations/instances_train2017.json'\n",
+    "n_iters = 20\n",
+    "\n",
+    "# Load COCO train set\n",
+    "train_dataset = coco_dataset_generator(dataset_folder=TRAIN_DATASET_FOLDER,\n",
+    "                                       annotation_file=TRAIN_DATASET_ANNOTATION_FILE,\n",
+    "                                       preprocess=nanodet_preprocess,\n",
+    "                                       batch_size=BATCH_SIZE)\n",
+    "\n",
+    "# Define representative dataset generator\n",
+    "def get_representative_dataset(n_iter, train_loader):\n",
+    "\n",
+    "    def representative_dataset():\n",
+    "        ds_iter = iter(train_loader)\n",
+    "        for _ in range(n_iter):\n",
+    "            yield [next(ds_iter)[0]]\n",
+    "\n",
+    "    return representative_dataset\n",
+    "\n",
+    "# Preform post training quantization \n",
+    "quant_model, _ = mct.ptq.keras_post_training_quantization_experimental(model,\n",
+    "                                                                       get_representative_dataset(n_iters, train_dataset))\n",
+    "\n",
+    "print('Quantized model is ready')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb6bffc-23d1-4852-8ec5-9007361c8eeb",
+   "metadata": {},
+   "source": [
+    "### Evaluate quantized model\n",
+    "Lastly, we can evaluate the performance of the quantize model. There is a slight decrease in performance that can be further mitigated by either expanding the representative dataset or employing MCT's advanced quantization methods, such as EPTQ (Enhanced Post Training Quantization)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dc7b87c-a9f4-4568-885a-fe009c8f4e8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-load COCO evaluation set\n",
+    "val_dataset = coco_dataset_generator(dataset_folder=EVAL_DATASET_FOLDER,\n",
+    "                                     annotation_file=EVAL_DATASET_ANNOTATION_FILE,\n",
+    "                                     preprocess=nanodet_preprocess,\n",
+    "                                     batch_size=BATCH_SIZE)\n",
+    "\n",
+    "# Initialize the evaluation metric object\n",
+    "coco_metric = CocoEval(EVAL_DATASET_ANNOTATION_FILE)\n",
+    "\n",
+    "# Iterate and the evaluation set\n",
+    "for batch_idx, (images, targets) in enumerate(val_dataset):\n",
+    "    # Run inference on the batch\n",
+    "    outputs = quant_model(images)\n",
+    "\n",
+    "    # Add the model outputs to metric object (a dictionary of outputs after postprocess: boxes, scores & classes)\n",
+    "    coco_metric.add_batch_detections(outputs, targets)\n",
+    "    if (batch_idx + 1) % 100 == 0:\n",
+    "        print(f'processed {(batch_idx + 1) * BATCH_SIZE} images')\n",
+    "\n",
+    "# Print float model mAP results\n",
+    "print(\"Float model mAP: {:.4f}\".format(coco_metric.result()[0]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/resources/coco_evaluation.py
+++ b/tutorials/resources/coco_evaluation.py
@@ -1,0 +1,241 @@
+import json
+import cv2
+import os
+import numpy as np
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+
+
+def coco80_to_coco91(x):
+    """
+    Converts COCO 80-class indices to COCO 91-class indices.
+
+    Args:
+        x (numpy.ndarray): An array of COCO 80-class indices.
+
+    Returns:
+        numpy.ndarray: An array of corresponding COCO 91-class indices.
+    """
+    coco91Indexs = np.array(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 28, 31, 32, 33, 34,
+         35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+         63, 64, 65, 67, 70, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 84, 85, 86, 87, 88, 89, 90])
+    return coco91Indexs[x.astype(np.int32)]
+
+
+def clip_boxes(boxes, h, w):
+    """
+    Clip bounding boxes to stay within the image boundaries.
+
+    Args:
+        boxes (numpy.ndarray): Array of bounding boxes in format [y_min, x_min, y_max, x_max].
+        h (int): Height of the image.
+        w (int): Width of the image.
+
+    Returns:
+        numpy.ndarray: Clipped bounding boxes.
+    """
+    boxes[..., 0] = np.clip(boxes[..., 0], a_min=0, a_max=h)
+    boxes[..., 1] = np.clip(boxes[..., 1], a_min=0, a_max=w)
+    boxes[..., 2] = np.clip(boxes[..., 2], a_min=0, a_max=h)
+    boxes[..., 3] = np.clip(boxes[..., 3], a_min=0, a_max=w)
+    return boxes
+
+
+def scale_boxes(boxes, H, W, h_image, w_image):
+    """
+    Scale and offset bounding boxes based on model output size and original image size.
+
+    Args:
+        boxes (numpy.ndarray): Array of bounding boxes in format [y_min, x_min, y_max, x_max].
+        H (int): Model output height.
+        W (int): Model output width.
+        h_image (int): Original image height.
+        w_image (int): Original image width.
+
+    Returns:
+        numpy.ndarray: Scaled and offset bounding boxes.
+    """
+    deltaH, deltaW = 0, 0
+    scale_H, scale_W = h_image / H, w_image / W
+
+    # Scale and offset boxes
+    boxes[..., 0] = (boxes[..., 0] - deltaH) * scale_H
+    boxes[..., 1] = (boxes[..., 1] - deltaW) * scale_W
+    boxes[..., 2] = (boxes[..., 2] - deltaH) * scale_H
+    boxes[..., 3] = (boxes[..., 3] - deltaW) * scale_W
+
+    # Clip boxes
+    boxes = clip_boxes(boxes, h_image, w_image)
+    return boxes
+
+
+def format_results(outputs, img_ids, orig_img_dims):
+    """
+    Format model outputs into a list of detection dictionaries.
+
+    Args:
+        outputs (list): List of model outputs, typically containing bounding boxes, scores, and labels.
+        img_ids (list): List of image IDs corresponding to each output.
+        orig_img_dims (list): List of tuples representing the original image dimensions for each output.
+
+    Returns:
+        list: A list of detection dictionaries, each containing information about the detected object.
+    """
+    detections = []
+
+    # Process model outputs and convert to detection format
+    for idx, output in enumerate(outputs):
+        image_id = img_ids[idx]
+        scores = output[1].numpy().squeeze() # Extract scores
+        labels = (coco80_to_coco91(
+            output[2].numpy())).squeeze()  # Convert COCO 80-class indices to COCO 91-class indices
+        boxes = output[0].numpy().squeeze() # Extract bounding boxes
+        boxes = scale_boxes(boxes, 1, 1, orig_img_dims[idx][0], orig_img_dims[idx][1])
+
+        for score, label, box in zip(scores, labels, boxes):
+            detection = {
+                "image_id": image_id,
+                "category_id": label,
+                "bbox": [box[1], box[0], box[3] - box[1], box[2] - box[0]],
+                "score": score
+            }
+            detections.append(detection)
+
+    return detections
+
+# COCO evaluation class
+class CocoEval:
+    def __init__(self, path2json):
+        """
+        Initialize the CocoEval class.
+
+        Args:
+            path2json (str): Path to the COCO JSON file containing ground truth annotations.
+        """
+        # Load ground truth annotations
+        self.coco_gt = COCO(path2json)
+
+        # A list of reformatted model outputs
+        self.all_detections = []
+
+    def add_batch_detections(self, outputs, targets):
+        """
+        Add batch detections to the evaluation.
+
+        Args:
+            outputs (list): List of model outputs, typically containing bounding boxes, scores, and labels.
+            targets (list): List of ground truth annotations for the batch.
+        """
+        img_ids, _outs = [], []
+        orig_img_dims = []
+        for idx, t in enumerate(targets):
+            if len(t) > 0:
+                img_ids.append(t[0]['image_id'])
+                orig_img_dims.append(t[0]['orig_img_dims'])
+                _outs.append([outputs[0][idx], outputs[1][idx], outputs[2][idx], outputs[3][idx]])
+
+        batch_detections = format_results(_outs, img_ids, orig_img_dims)
+
+        self.all_detections.extend(batch_detections)
+
+    def result(self):
+        """
+        Calculate and print evaluation results.
+
+        Returns:
+            list: COCO evaluation statistics.
+        """
+        # Initialize COCO evaluation object
+        self.coco_dt = self.coco_gt.loadRes(self.all_detections)
+        coco_eval = COCOeval(self.coco_gt, self.coco_dt, 'bbox')
+
+        # Run evaluation
+        coco_eval.evaluate()
+        coco_eval.accumulate()
+        coco_eval.summarize()
+
+        # Print mAP results
+        print("mAP: {:.4f}".format(coco_eval.stats[0]))
+
+        return coco_eval.stats
+
+    def reset(self):
+        """
+        Reset the list of detections to prepare for a new evaluation.
+        """
+        self.all_detections = []
+
+def load_and_preprocess_image(image_path, preprocess):
+    """
+    Load and preprocess an image from a given file path.
+
+    Args:
+        image_path (str): Path to the image file.
+        preprocess (function): Preprocessing function to apply to the loaded image.
+
+    Returns:
+        numpy.ndarray: Preprocessed image.
+    """
+    image = cv2.imread(image_path)
+    image = preprocess(image)
+    return image
+
+def coco_dataset_generator(dataset_folder, annotation_file, preprocess, batch_size=1):
+    """
+    Generator function for loading and preprocessing images and their annotations from a COCO-style dataset.
+
+    Args:
+        dataset_folder (str): Path to the dataset folder containing image files.
+        annotation_file (str): Path to the COCO-style annotation JSON file.
+        preprocess (function): Preprocessing function to apply to each loaded image.
+        batch_size (int): The desired batch size.
+
+    Yields:
+        Tuple[numpy.ndarray, list]: A tuple containing a batch of images (as a NumPy array) and a list of annotations
+        for each image in the batch.
+    """
+    # Load COCO annotations from a JSON file (e.g., 'annotations.json')
+    with open(annotation_file, 'r') as f:
+        coco_annotations = json.load(f)
+
+    # Initialize a dictionary to store annotations grouped by image ID
+    annotations_by_image = {}
+
+    # Iterate through the annotations and group them by image ID
+    for annotation in coco_annotations['annotations']:
+        image_id = annotation['image_id']
+        if image_id not in annotations_by_image:
+            annotations_by_image[image_id] = []
+        annotations_by_image[image_id].append(annotation)
+
+    # Initialize a list to collect images and annotations for the current batch
+    batch_images = []
+    batch_annotations = []
+    total_images = len(coco_annotations['images'])
+
+    # Iterate through the images and create a list of tuples (image, annotations)
+    for image_count, image_info in enumerate(coco_annotations['images']):
+        image_id = image_info['id']
+        # Load and preprocess the image (you can use your own image loading logic)
+        image = load_and_preprocess_image(os.path.join(dataset_folder, image_info['file_name']), preprocess)
+        annotations = annotations_by_image.get(image_id, [])
+        if len(annotations) > 0:
+            annotations[0]['orig_img_dims'] = (image_info['height'], image_info['width'])
+
+            # Add the image and annotations to the current batch
+            batch_images.append(image)
+            batch_annotations.append(annotations)
+
+            # Check if the current batch is of the desired batch size
+            if len(batch_images) == batch_size:
+                # Yield the current batch
+                yield np.array(batch_images), batch_annotations
+
+                # Reset the batch lists for the next batch
+                batch_images = []
+                batch_annotations = []
+
+        # After processing all images, yield any remaining images in the last batch
+        if len(batch_images) > 0 and (total_images == image_count + 1):
+            yield np.array(batch_images), batch_annotations

--- a/tutorials/resources/nanodet_keras_model.py
+++ b/tutorials/resources/nanodet_keras_model.py
@@ -1,0 +1,405 @@
+"""
+Nanodet-Plus Object Detection Model
+
+This code defines a TensorFlow/Keras implementation of Nanodet-Plus object detection model, following
+https://github.com/RangiLyu/nanodet. This implementation also integrates the Nanodet-plus post-processing into the
+model.
+
+The Nanodet-Plus model is optimized for real-time and resource-constrained environments while maintaining competitive
+detection performance. It is particularly suitable for edge devices and embedded systems.
+
+The code is organized as follows:
+- Function definitions for building the Nanodet-Plus model.
+- Model definition
+- Utility functions for setting model weights
+
+For more details on the Nanodet-Plus model, refer to the original repository:
+https://github.com/RangiLyu/nanodet
+
+"""
+
+import numpy as np
+from keras.utils import plot_model
+from keras.utils.layer_utils import get_source_inputs
+from keras.layers import Input, Conv2D, MaxPool2D, GlobalMaxPooling2D, GlobalAveragePooling2D, \
+    BatchNormalization, DepthwiseConv2D, Concatenate, Lambda, UpSampling2D, Add, Reshape, ZeroPadding2D, LeakyReLU, \
+    Resizing, ReLU, Softmax
+from keras.layers import Activation, Dense
+from keras.models import Model
+import keras.backend as K
+import tensorflow as tf
+
+# Nanodet-Plus building blocks
+def channel_split(x):
+    in_channles = x.shape.as_list()[-1]
+    ip = in_channles // 2
+    c_hat = x[:, :, :, 0:ip]
+    c = x[:, :, :, ip:]
+    return c_hat, c
+
+def channel_shuffle(x):
+    height, width, channels = x.shape.as_list()[1:]
+    channels_per_split = channels // 2
+    x = tf.reshape(x, [-1, height, width, 2, channels_per_split])
+    x = tf.transpose(x, perm=[0,1,2,4,3])
+    x = tf.reshape(x, [-1, height, width, channels])
+    return x
+
+def shuffle_unit(inputs, out_channels, bottleneck_ratio,strides=2,stage=1,block=1):
+    if K.image_data_format() == 'channels_last':
+        bn_axis = -1
+    else:
+        raise ValueError('Only channels last supported')
+
+    prefix = 'backbone.stage{}.{}'.format(stage, block-1)
+    bottleneck_channels = int(out_channels * bottleneck_ratio)
+    if strides < 2:
+        c_hat, c = channel_split(inputs)
+        inputs = c
+
+    x = Conv2D(bottleneck_channels, kernel_size=(1,1), strides=1, padding='same', use_bias=False, name='{}.branch2.0'.format(prefix))(inputs)
+    x = BatchNormalization(axis=bn_axis, epsilon=1e-05, name='{}.branch2.1'.format(prefix))(x)
+    x = LeakyReLU(alpha=0.1, name='{}.branch2.2'.format(prefix))(x)
+    if strides > 1:
+        x = ZeroPadding2D(padding=((1, 0), (1, 0)))(x)
+        x = DepthwiseConv2D(kernel_size=3, strides=strides, padding='valid', use_bias=False, name='{}.branch2.3'.format(prefix))(x)
+    else:
+        x = DepthwiseConv2D(kernel_size=3, strides=strides, padding='same', use_bias=False, name='{}.branch2.3'.format(prefix))(x)
+    x = BatchNormalization(axis=bn_axis, epsilon=1e-05, name='{}.branch2.4'.format(prefix))(x)
+    x = Conv2D(bottleneck_channels, kernel_size=1,strides=1,padding='same', use_bias=False, name='{}.branch2.5'.format(prefix))(x)
+    x = BatchNormalization(axis=bn_axis, epsilon=1e-05, name='{}.branch2.6'.format(prefix))(x)
+    x = LeakyReLU(alpha=0.1, name='{}.branch2.7'.format(prefix))(x)
+
+    if strides < 2:
+        ret = Concatenate(axis=bn_axis, name='{}/concat_1'.format(prefix))([c_hat, x])
+    else:
+        inputs = ZeroPadding2D(padding=((1, 0), (1, 0)))(inputs)
+        s2 = DepthwiseConv2D(kernel_size=3, strides=2, padding='valid', use_bias=False, name='{}.branch1.0'.format(prefix))(inputs)
+        s2 = BatchNormalization(axis=bn_axis, epsilon=1e-05, name='{}.branch1.1'.format(prefix))(s2)
+        s2 = Conv2D(bottleneck_channels, kernel_size=1,strides=1,padding='same', use_bias=False, name='{}.branch1.2'.format(prefix))(s2)
+        s2 = BatchNormalization(axis=bn_axis, epsilon=1e-05, name='{}.branch1.3'.format(prefix))(s2)
+        s2 = LeakyReLU(alpha=0.1, name='{}.branch1.4'.format(prefix))(s2)
+        ret = Concatenate(axis=bn_axis, name='{}/concat_2'.format(prefix))([s2, x])
+
+    ret = channel_shuffle(ret)
+    return ret
+
+
+def block(x, channel_map, bottleneck_ratio, repeat=1, stage=1):
+    x = shuffle_unit(x, out_channels=channel_map[stage-1],
+                      strides=2,bottleneck_ratio=bottleneck_ratio,stage=stage,block=1)
+
+    for i in range(1, repeat+1):
+        x = shuffle_unit(x, out_channels=channel_map[stage-1],strides=1,
+                          bottleneck_ratio=bottleneck_ratio,stage=stage, block=(1+i))
+
+    return x
+
+def nanodet_shufflenet_v2(input_tensor=None,
+                 scale_factor=1.5,
+                 input_shape=(416,416,3),
+                 num_shuffle_units=[3,7,3],
+                 bottleneck_ratio=0.5):
+    if scale_factor == 1.0:
+        out_channels_in_stage = np.array([24, 116, 232, 464, 1024])
+    else: #scale_factor == 1.5:
+        out_channels_in_stage = np.array([24, 176, 352, 704, 1024])
+
+    out_channels_in_stage = out_channels_in_stage.astype(int)
+
+    if input_tensor is None:
+        img_input = Input(shape=input_shape)
+    else:
+        if not K.is_keras_tensor(input_tensor):
+            img_input = Input(tensor=input_tensor, shape=input_shape)
+        else:
+            img_input = input_tensor
+
+    # create shufflenet architecture
+    x = ZeroPadding2D(padding=((1,0),(1,0)))(img_input)
+    x = Conv2D(filters=out_channels_in_stage[0], kernel_size=(3, 3), padding='valid', use_bias=False, strides=(2, 2),
+               name='backbone.conv1.0')(x)
+    x = BatchNormalization(epsilon=1e-05, name='backbone.conv1.1')(x)
+    x = LeakyReLU(alpha=0.1)(x)
+    x = ZeroPadding2D(padding=((1,0),(1,0)))(x)
+    x = MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='maxpool1')(x)
+
+    # create stages containing shufflenet units beginning at stage 2
+    out = []
+    for stage in range(len(num_shuffle_units)):
+        repeat = num_shuffle_units[stage]
+        x = block(x, out_channels_in_stage,
+                   repeat=repeat,
+                   bottleneck_ratio=bottleneck_ratio,
+                   stage=stage + 2)
+        out.append(x)
+
+    if input_tensor:
+        inputs = get_source_inputs(input_tensor)
+
+    else:
+        inputs = img_input
+
+    return inputs, out
+
+
+def conv_module(x, out_channels, kernel, name_prefix='ConvModule'):
+    x = Conv2D(out_channels, kernel, use_bias=False, name=name_prefix+'.conv')(x)
+    x = BatchNormalization(epsilon=1e-05, name=name_prefix+'.bn')(x)
+    x = LeakyReLU(alpha=0.1)(x)
+    return x
+
+def ghost_blocks(x, out_channels=128, name_prefix='GhostBlocks'):
+    residual = x
+    x1 = Conv2D(out_channels // 2, 1, use_bias=False, name=name_prefix+'.ghost1.primary_conv.0')(x)
+    x1 = BatchNormalization(epsilon=1e-05, name=name_prefix+'.ghost1.primary_conv.1')(x1)
+    x1 = LeakyReLU(alpha=0.1)(x1)
+    x2 = DepthwiseConv2D(3, padding="same", use_bias=False, name=name_prefix+'.ghost1.cheap_operation.0')(x1)
+    x2 = BatchNormalization(epsilon=1e-05, name=name_prefix+'.ghost1.cheap_operation.1')(x2)
+    x2 = LeakyReLU(alpha=0.1)(x2)
+    x = Concatenate()([x1, x2])
+
+    x1 = Conv2D(out_channels // 2, 1, use_bias=False, name=name_prefix+'.ghost2.primary_conv.0')(x)
+    x1 = BatchNormalization(epsilon=1e-05, name=name_prefix+'.ghost2.primary_conv.1')(x1)
+    x2 = DepthwiseConv2D(3, padding="same", use_bias=False, name=name_prefix+'.ghost2.cheap_operation.0')(x1)
+    x2 = BatchNormalization(epsilon=1e-05, name=name_prefix+'.ghost2.cheap_operation.1')(x2)
+    x = Concatenate()([x1, x2])
+
+    residual = DepthwiseConv2D(5, padding="same", use_bias=False, name=name_prefix+'.shortcut.0')(residual)
+    residual = BatchNormalization(epsilon=1e-05, name=name_prefix+'.shortcut.1')(residual)
+    residual = Conv2D(out_channels, 1, use_bias=False, name=name_prefix+'.shortcut.2')(residual)
+    residual = BatchNormalization(epsilon=1e-05, name=name_prefix+'.shortcut.3')(residual)
+
+    x = Add()([residual, x])
+    return x
+
+def depthwise_conv_module(x, out_channels=128, stride=2, name_prefix='DepthwiseConvModule'):
+    if stride > 1:
+        x = ZeroPadding2D(padding=((2, 2), (2, 2)))(x)
+        x = DepthwiseConv2D(5, strides=(stride, stride), padding="valid", use_bias=False, name=name_prefix + '.depthwise')(x)
+    else:
+        x = DepthwiseConv2D(5, strides=(stride, stride), padding="same", use_bias=False, name=name_prefix+'.depthwise')(x)
+    x = BatchNormalization(epsilon=1e-05, name=name_prefix+'.dwnorm')(x)
+    x = LeakyReLU(alpha=0.1)(x)
+    x = Conv2D(out_channels, 1, use_bias=False, name=name_prefix+'.pointwise')(x)
+    x = BatchNormalization(epsilon=1e-05, name=name_prefix+'.pwnorm')(x)
+    x = LeakyReLU(alpha=0.1)(x)
+
+    return x
+
+
+def nanodet_ghostpan(x,
+                     in_channels=[176, 352, 704],
+                     out_channels=128,
+                     res=416):
+
+    for idx in range(len(in_channels)):
+        x[idx] = conv_module(x[idx], out_channels, 1, name_prefix='fpn.reduce_layers.'+str(idx))
+
+    # top-down path
+    p4 = x[2]
+    x_upsampled = Resizing(int(res/16),int(res/16),interpolation="bilinear")(x[2])
+    x_concate = Concatenate(axis=-1, name='p3_input')([x_upsampled, x[1]])
+    p3 = ghost_blocks(x_concate, out_channels, name_prefix='fpn.top_down_blocks.0.blocks.0')
+
+    x_upsampled = Resizing(int(res/8),int(res/8),interpolation="bilinear")(p3)
+    x_concate = Concatenate(axis=-1, name='p2_input')([x_upsampled, x[0]])
+    p2 = ghost_blocks(x_concate, out_channels, name_prefix='fpn.top_down_blocks.1.blocks.0')
+
+    # bottom up path
+    n2 = p2
+
+    x_downsampled = depthwise_conv_module(n2, out_channels, name_prefix='fpn.downsamples.0')
+    x_concate = Concatenate(axis=-1, name='n3_input')([x_downsampled, p3])
+    n3 = ghost_blocks(x_concate, out_channels, name_prefix='fpn.bottom_up_blocks.0.blocks.0')
+
+    x_downsampled = depthwise_conv_module(n3, out_channels, name_prefix='fpn.downsamples.1')
+    x_concate = Concatenate(axis=-1, name='n4_input')([x_downsampled, p4])
+    n4 = ghost_blocks(x_concate, out_channels, name_prefix='fpn.bottom_up_blocks.1.blocks.0')
+
+    n5_a = depthwise_conv_module(n4, out_channels, name_prefix='fpn.extra_lvl_out_conv.0')
+    n5_b = depthwise_conv_module(p4, out_channels, name_prefix='fpn.extra_lvl_in_conv.0')
+
+    n5 = Add()([n5_a, n5_b])
+    return [n2, n3, n4, n5]
+
+def distance2bbox(points, distance):
+    """Decode distance prediction to bounding box.
+
+    Args:
+        points (Tensor): Shape (n, 2), [x, y].
+        distance (Tensor): Distance from the given point to 4
+            boundaries (left, top, right, bottom).
+        max_shape (tuple): Shape of the image.
+
+    Returns:
+        Tensor: Decoded bboxes.
+    """
+    d0, d1, d2, d3 = tf.unstack(distance, 4, -1)
+    a0, a1, a2, a3 = tf.unstack(points, 4, -1)
+    x1 = tf.math.add(a0, -d0)
+    y1 = tf.math.add(a1, -d1)
+    x2 = tf.math.add(a0, d2)
+    y2 = tf.math.add(a1, d3)
+    return x1, y1, x2, y2
+
+
+def dfl(x, c1=8):
+    """Distributed focal loss calculation.
+    Args:
+        c1:
+        x:
+
+    Returns:
+        Tensor: bboxes after integral calculation.
+    """
+    x_shape = x.shape
+    x = tf.reshape(x, [-1, x_shape[1] * x_shape[2], 4*c1])
+    x = tf.reshape(x, [-1, x_shape[1] * x_shape[2], 4, c1])
+    x = Softmax(-1)(x)
+    w = np.expand_dims(np.expand_dims(np.expand_dims(np.arange(c1), 0),0),-1)
+    conv = Conv2D(1, 1, use_bias=False, weights=[w])
+    return tf.squeeze(conv(x),-1)
+
+def nanodet_generate_anchors(batch_size, featmap_sizes, strides):
+    anchors_list = []
+    for i, stride in enumerate(strides):
+        h, w = featmap_sizes[i]
+        x_range = np.arange(w) * stride
+        y_range = np.arange(h) * stride
+        y, x = np.meshgrid(y_range, x_range)
+        y = y.flatten()
+        x = x.flatten()
+        strides = np.ones_like(x) * stride
+        anchors = np.stack([y, x, strides, strides], axis=-1)
+        anchors = np.expand_dims(anchors, axis=0)
+        anchors = np.repeat(anchors, batch_size, axis=0)
+        anchors_list.append(anchors)
+    return np.concatenate(anchors_list, axis=1, dtype=float)
+
+def nanodet_plus_head(n, feat_channels=128):
+    h = n
+    for idx in range(4):
+        h[idx] = depthwise_conv_module(n[idx], out_channels=feat_channels, stride=1, name_prefix='head.cls_convs.' + str(idx) + '.0')
+        h[idx] = depthwise_conv_module(h[idx], out_channels=feat_channels, stride=1, name_prefix='head.cls_convs.' + str(idx) + '.1')
+        h[idx] = Conv2D(112, 1, name='head.gfl_cls.' + str(idx))(h[idx])
+    return h
+
+def nanodet_box_decoding(h, res):
+    strides = [8, 16, 32, 64]
+    batch_size = 1
+    featmap_sizes = [(np.ceil(res / stride), np.ceil(res / stride)) for stride in strides]
+    all_anchors = 1 / res * nanodet_generate_anchors(batch_size, featmap_sizes, strides)
+    nn = res / 8 * res / 8
+    anchors_list = np.split(all_anchors,[int(nn), int(1.25*nn), int(1.3125*nn)],axis=1)
+    h_cls = []
+    h_bbox = []
+    for idx in range(4):
+        # Split to 80 classes and 4 * 8 bounding boxes regression
+        cls, regr = tf.split(h[idx], [80, 32],-1)
+        ndet = cls.shape[1] * cls.shape[2]
+
+        # Distributed Focal loss integral
+        d = dfl(regr, 8)
+
+        # Box decoding
+        anchors = tf.constant(anchors_list[idx],dtype=tf.float32)
+        d = tf.math.multiply(d, anchors[...,2,None])
+        bbox0, bbox1, bbox2, bbox3 = distance2bbox(anchors, d)
+        bbox0, bbox1, bbox2, bbox3 = ReLU()(bbox0), ReLU()(bbox1), ReLU()(bbox2), ReLU()(bbox3)
+        bbox = tf.stack([bbox1, bbox0, bbox3, bbox2], -1)
+        bbox = tf.expand_dims(bbox,2)
+
+        cls = tf.reshape(cls, [-1, ndet, 80])
+        h_cls.append(cls)
+        h_bbox.append(bbox)
+    classes = Concatenate(axis=1)([h_cls[0], h_cls[1], h_cls[2], h_cls[3]])
+    boxes = Concatenate(axis=1)([h_bbox[0], h_bbox[1], h_bbox[2], h_bbox[3]])
+    classes = tf.math.sigmoid(classes)
+    return classes, boxes
+
+# Nanodet-Plus model definition
+def nanodet_plus_m(input_shape, scale_factor, bottleneck_ratio, feat_channels):
+    """
+    Create the Nanodet-Plus object detection model.
+
+    Args:
+        input_shape (tuple): The shape of input images (height, width, channels).
+        scale_factor (float): Scale factor for ShuffleNetV2 backbone.
+        bottleneck_ratio (float): Bottleneck ratio for ShuffleNetV2 backbone.
+        feat_channels (int): Number of feature channels.
+
+    Returns:
+        tf.keras.Model: The Nanodet-Plus model.
+
+    Configuration options:
+        nanodet-plus-m-1.5x-416:  input_shape = (416,416,3), scale_factor=1.5, feat_channels=128
+        nanodet-plus-m-1.5x-320:  input_shape = (320,320,3), scale_factor=1.5, feat_channels=128
+        nanodet-plus-m-416:  input_shape = (416,416,3), scale_factor=1.0, feat_channels=96
+        nanodet-plus-m-320:  input_shape = (320,320,3), scale_factor=1.0, feat_channels=96
+
+    """
+    # Nanodet backbone
+    inputs, x = nanodet_shufflenet_v2(scale_factor=scale_factor, input_shape=input_shape, bottleneck_ratio=bottleneck_ratio)
+
+    # Nanodet neck
+    x = nanodet_ghostpan(x, out_channels=feat_channels, res=input_shape[0])
+
+    # Nanodet head
+    x = nanodet_plus_head(x, feat_channels=feat_channels)
+
+    # Define Keras model
+    return Model(inputs, x, name=f'Nanodet_plus_m_{scale_factor}x_{input_shape[0]}')
+
+
+def set_model_weights(model, loaded_weights):
+    """
+    Set the weights of a Keras model using weights loaded from a PyTorch model.
+
+    Args:
+        model (tf.keras.Model): The Keras model to which the weights will be assigned.
+        loaded_weights (dict): Dictionary containing the weights loaded from a PyTorch model.
+
+    Note:
+        This function assumes that the weights in the loaded PyTorch model have a similar naming structure to the
+        layers in the Keras model.
+
+    Returns:
+        None
+    """
+    # Extract the weight names from Keras model
+    w_keras = {w.name: (w.dtype, w.shape) for w in model.weights}
+
+    for idx, k in enumerate(w_keras.keys()):
+        l_name = k.split("/")[0]
+        l_type = k.split("/")[1]
+
+        # Map Keras weight types to PyTorch weight names
+        if l_type == 'kernel:0' or l_type == 'depthwise_kernel:0':
+            torch_name = l_name + ".weight"
+        elif l_type == 'gamma:0':
+            torch_name = l_name + ".weight"
+        elif l_type == 'beta:0' or l_type == 'bias:0':
+            torch_name = l_name + ".bias"
+        elif l_type == 'moving_mean:0':
+            torch_name = l_name + ".running_mean"
+        elif l_type == 'moving_variance:0':
+            torch_name = l_name + ".running_var"
+
+        # Iterate over loaded PyTorch weights to find a matching weight
+        for key, value in loaded_weights.items():
+            if key.startswith(torch_name):
+                if len(value.shape) == 4:
+                    if l_type == 'depthwise_kernel:0':
+                        # Transpose and assign weights for depthwise convolution
+                        w = np.transpose(value.numpy(), (2, 3, 0, 1))
+                    else:
+                        # Transpose and assign weights for standard convolution
+                        w = np.transpose(value.numpy(), (2,3,1,0))
+                elif len(value.shape) == 1:
+                    # Assign bias or other 1D weights directly
+                    w = value.numpy()
+
+                # Assign the weights to the Keras model
+                model.weights[idx].assign(w)
+                break


### PR DESCRIPTION
Add "Nanodet-Plus" model quantization example
I've added an example demonstrating the quantization of a Keras-based object detection model, specifically model that includes post-processing inside the model.
Modifications:
1. Notebook of this example
2. Utility functions to support the model generation and the coco evaluation process
3. Update TPC to ininclude the TensorFlow combined NMS layer
