### PR TITLE
Add SIMD info to TPC

### DIFF
--- a/model_compression_toolkit/core/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/node_quantization_config.py
@@ -260,6 +260,7 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
         self.enable_weights_quantization = op_cfg.enable_weights_quantization
         self.min_threshold = qc.min_threshold
         self.l_p_value = qc.l_p_value
+        self.simd_size = op_cfg.simd_size
 
 
     @property
@@ -367,7 +368,8 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
                self.weights_per_channel_threshold == other.weights_per_channel_threshold and \
                self.enable_weights_quantization == other.enable_weights_quantization and \
                self.min_threshold == other.min_threshold and \
-               self.l_p_value == other.l_p_value
+               self.l_p_value == other.l_p_value and \
+               self.simd_size == other.simd_size
 
     def __hash__(self):
         return hash((self.weights_quantization_fn,
@@ -381,4 +383,5 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
                      self.weights_per_channel_threshold,
                      self.enable_weights_quantization,
                      self.min_threshold,
-                     self.l_p_value))
+                     self.l_p_value,
+                     self.simd_size))

--- a/model_compression_toolkit/target_platform_capabilities/target_platform/op_quantization_config.py
+++ b/model_compression_toolkit/target_platform_capabilities/target_platform/op_quantization_config.py
@@ -35,7 +35,8 @@ class OpQuantizationConfig:
                  quantization_preserving: bool,
                  fixed_scale: float,
                  fixed_zero_point: int,
-                 weights_multiplier_nbits: int  # If None - set 8 in hptq, o.w use it
+                 weights_multiplier_nbits: int,  # If None - set 8 in hptq, o.w use it
+                 simd_size: int
                  ):
         """
 
@@ -51,6 +52,8 @@ class OpQuantizationConfig:
             fixed_scale (float): Scale to use for an operator quantization parameters.
             fixed_zero_point (int): Zero-point to use for an operator quantization parameters.
             weights_multiplier_nbits (int): Number of bits to use when quantizing in look-up-table.
+            simd_size (int): An integer representing the Single Instruction, Multiple Data (SIMD) width of an operator. It indicates the number of data elements that can be fetched and processed simultaneously in a single instruction.
+
         """
 
         self.activation_quantization_method = activation_quantization_method
@@ -64,6 +67,7 @@ class OpQuantizationConfig:
         self.fixed_scale = fixed_scale
         self.fixed_zero_point = fixed_zero_point
         self.eights_lut_values_bitwidth = weights_multiplier_nbits
+        self.simd_size = simd_size
 
     def get_info(self):
         """
@@ -108,7 +112,8 @@ class OpQuantizationConfig:
                self.weights_n_bits == other.weights_n_bits and \
                self.weights_per_channel_threshold == other.weights_per_channel_threshold and \
                self.enable_weights_quantization == other.enable_weights_quantization and \
-               self.enable_activation_quantization == other.enable_activation_quantization
+               self.enable_activation_quantization == other.enable_activation_quantization and \
+               self.simd_size==other.simd_size
 
 
 class QuantizationConfigOptions(object):

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tp_model.py
@@ -73,9 +73,9 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
     # using 2, 4 or 8 bits, and when using 2 or 4 bits, it's possible
     # to quantize the operations' activations using LUT.
     four_bits = eight_bits.clone_and_edit(weights_n_bits=4,
-                                          simd_size=64)
+                                          simd_size=eight_bits.simd_size*2)
     two_bits = eight_bits.clone_and_edit(weights_n_bits=2,
-                                         simd_size=128)
+                                         simd_size=eight_bits.simd_size*4)
 
     mixed_precision_cfg_list = [eight_bits, four_bits, two_bits]
 

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tp_model.py
@@ -64,15 +64,19 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None)
+        weights_multiplier_nbits=None,
+        simd_size=32)
 
     # To quantize a model using mixed-precision, create
     # a list with more than one OpQuantizationConfig.
     # In this example, we quantize some operations' weights
     # using 2, 4 or 8 bits, and when using 2 or 4 bits, it's possible
     # to quantize the operations' activations using LUT.
-    four_bits = eight_bits.clone_and_edit(weights_n_bits=4)
-    two_bits = eight_bits.clone_and_edit(weights_n_bits=2)
+    four_bits = eight_bits.clone_and_edit(weights_n_bits=4,
+                                          simd_size=64)
+    two_bits = eight_bits.clone_and_edit(weights_n_bits=2,
+                                         simd_size=128)
+
     mixed_precision_cfg_list = [eight_bits, four_bits, two_bits]
 
     return eight_bits, mixed_precision_cfg_list

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tp_model.py
@@ -64,7 +64,8 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None)
+        weights_multiplier_nbits=None,
+        simd_size=32)
 
     # To quantize a model using mixed-precision, create
     # a list with more than one OpQuantizationConfig.
@@ -72,9 +73,11 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
     # using 2, 4 or 8 bits, and when using 2 or 4 bits, it's possible
     # to quantize the operations' activations using LUT.
     four_bits_lut = eight_bits.clone_and_edit(weights_n_bits=4,
-                                              weights_quantization_method=tp.QuantizationMethod.LUT_SYM_QUANTIZER)
+                                              weights_quantization_method=tp.QuantizationMethod.LUT_SYM_QUANTIZER,
+                                              simd_size=64)
     two_bits_lut = eight_bits.clone_and_edit(weights_n_bits=2,
-                                             weights_quantization_method=tp.QuantizationMethod.LUT_SYM_QUANTIZER)
+                                             weights_quantization_method=tp.QuantizationMethod.LUT_SYM_QUANTIZER,
+                                             simd_size=128)
     mixed_precision_cfg_list = [eight_bits, four_bits_lut, two_bits_lut]
 
     return eight_bits, mixed_precision_cfg_list

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tp_model.py
@@ -74,10 +74,10 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
     # to quantize the operations' activations using LUT.
     four_bits_lut = eight_bits.clone_and_edit(weights_n_bits=4,
                                               weights_quantization_method=tp.QuantizationMethod.LUT_SYM_QUANTIZER,
-                                              simd_size=64)
+                                              simd_size=eight_bits.simd_size*2)
     two_bits_lut = eight_bits.clone_and_edit(weights_n_bits=2,
                                              weights_quantization_method=tp.QuantizationMethod.LUT_SYM_QUANTIZER,
-                                             simd_size=128)
+                                             simd_size=eight_bits.simd_size*4)
     mixed_precision_cfg_list = [eight_bits, four_bits_lut, two_bits_lut]
 
     return eight_bits, mixed_precision_cfg_list

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_pot/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_pot/tp_model.py
@@ -64,15 +64,18 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None)
+        weights_multiplier_nbits=None,
+        simd_size=32)
 
     # To quantize a model using mixed-precision, create
     # a list with more than one OpQuantizationConfig.
     # In this example, we quantize some operations' weights
     # using 2, 4 or 8 bits, and when using 2 or 4 bits, it's possible
     # to quantize the operations' activations using LUT.
-    four_bits = eight_bits.clone_and_edit(weights_n_bits=4)
-    two_bits = eight_bits.clone_and_edit(weights_n_bits=2)
+    four_bits = eight_bits.clone_and_edit(weights_n_bits=4,
+                                          simd_size=64)
+    two_bits = eight_bits.clone_and_edit(weights_n_bits=2,
+                                         simd_size=128)
     mixed_precision_cfg_list = [eight_bits, four_bits, two_bits]
 
     return eight_bits, mixed_precision_cfg_list

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_pot/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_pot/tp_model.py
@@ -73,9 +73,9 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
     # using 2, 4 or 8 bits, and when using 2 or 4 bits, it's possible
     # to quantize the operations' activations using LUT.
     four_bits = eight_bits.clone_and_edit(weights_n_bits=4,
-                                          simd_size=64)
+                                          simd_size=eight_bits.simd_size*2)
     two_bits = eight_bits.clone_and_edit(weights_n_bits=2,
-                                         simd_size=128)
+                                         simd_size=eight_bits.simd_size*4)
     mixed_precision_cfg_list = [eight_bits, four_bits, two_bits]
 
     return eight_bits, mixed_precision_cfg_list

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/v1/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/v1/tp_model.py
@@ -66,7 +66,8 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None
+        weights_multiplier_nbits=None,
+        simd_size=None
     )
 
     mixed_precision_cfg_list = [] # No mixed precision

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/v1/tp_model.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/v1/tp_model.py
@@ -66,7 +66,8 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None
+        weights_multiplier_nbits=None,
+        simd_size=None
     )
 
     mixed_precision_cfg_list = []  # No mixed precision

--- a/tests/common_tests/test_tp_model.py
+++ b/tests/common_tests/test_tp_model.py
@@ -31,8 +31,9 @@ TEST_QC = tp.OpQuantizationConfig(enable_activation_quantization=True,
                                    quantization_preserving=False,
                                    fixed_scale=None,
                                    fixed_zero_point=None,
-                                   weights_multiplier_nbits=None
-                                   )
+                                   weights_multiplier_nbits=None,
+                                   simd_size=None)
+
 TEST_QCO = tp.QuantizationConfigOptions([TEST_QC])
 
 

--- a/tests/keras_tests/exporter_tests/tflite_int8/imx500_int8_tp_model.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/imx500_int8_tp_model.py
@@ -59,9 +59,13 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None)
-    four_bits = eight_bits.clone_and_edit(weights_n_bits=4)
-    two_bits = eight_bits.clone_and_edit(weights_n_bits=2)
+        weights_multiplier_nbits=None,
+        simd_size=32
+    )
+    four_bits = eight_bits.clone_and_edit(weights_n_bits=4,
+                                          simd_size=64)
+    two_bits = eight_bits.clone_and_edit(weights_n_bits=2,
+                                         simd_size=128)
     mixed_precision_cfg_list = [eight_bits, four_bits, two_bits]
     return eight_bits, mixed_precision_cfg_list
 

--- a/tests/keras_tests/exporter_tests/tflite_int8/imx500_int8_tp_model.py
+++ b/tests/keras_tests/exporter_tests/tflite_int8/imx500_int8_tp_model.py
@@ -63,9 +63,9 @@ def get_op_quantization_configs() -> Tuple[OpQuantizationConfig, List[OpQuantiza
         simd_size=32
     )
     four_bits = eight_bits.clone_and_edit(weights_n_bits=4,
-                                          simd_size=64)
+                                          simd_size=eight_bits.simd_size*2)
     two_bits = eight_bits.clone_and_edit(weights_n_bits=2,
-                                         simd_size=128)
+                                         simd_size=eight_bits.simd_size*4)
     mixed_precision_cfg_list = [eight_bits, four_bits, two_bits]
     return eight_bits, mixed_precision_cfg_list
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/lut_quantizer.py
@@ -68,7 +68,8 @@ class LUTWeightsQuantizerTest(BaseKerasFeatureNetworkTest):
                                      quantization_preserving=False,
                                      fixed_scale=None,
                                      fixed_zero_point=None,
-                                     weights_multiplier_nbits=None
+                                     weights_multiplier_nbits=None,
+                                     simd_size=None
                                      )])
         return tp.TargetPlatformCapabilities(tp.TargetPlatformModel(qco))
 
@@ -121,7 +122,8 @@ class LUTActivationQuantizerTest(BaseKerasFeatureNetworkTest):
                                      quantization_preserving=False,
                                      fixed_scale=None,
                                      fixed_zero_point=None,
-                                     weights_multiplier_nbits=None
+                                     weights_multiplier_nbits=None,
+                                     simd_size=None
                                      )])
         return tp.TargetPlatformCapabilities(tp.TargetPlatformModel(qco))
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
@@ -45,7 +45,8 @@ def get_base_eight_bits_config_op():
             quantization_preserving=False,
             fixed_scale=None,
             fixed_zero_point=None,
-            weights_multiplier_nbits=None
+            weights_multiplier_nbits=None,
+            simd_size=None
         )
 
 

--- a/tests/keras_tests/function_tests/test_cfg_candidates_filter.py
+++ b/tests/keras_tests/function_tests/test_cfg_candidates_filter.py
@@ -44,7 +44,8 @@ def get_base_config():
         quantization_preserving=False,
         fixed_scale=None,
         fixed_zero_point=None,
-        weights_multiplier_nbits=None
+        weights_multiplier_nbits=None,
+        simd_size=None
     )
 
 


### PR DESCRIPTION
Add simd_size for op configuration in the TPC.
For IMX500 TPCs: Ops with 8bits use SIMD 32, ops with 4bits use SIMD 64, and ops with 2bits use SIMD 128. In other TPCs it's set to None.