### PR TITLE
Add ported effdet keras tutorial

### DIFF
--- a/model_compression_toolkit/constants.py
+++ b/model_compression_toolkit/constants.py
@@ -22,6 +22,7 @@ FOUND_TF = importlib.util.find_spec(TENSORFLOW) is not None
 FOUND_TORCH = importlib.util.find_spec("torch") is not None
 FOUND_ONNX = importlib.util.find_spec("onnx") is not None
 FOUND_ONNXRUNTIME = importlib.util.find_spec("onnxruntime") is not None
+FOUND_SONY_CUSTOM_LAYERS = importlib.util.find_spec('sony_custom_layers') is not None
 
 WEIGHTS_SIGNED = True
 # Minimal threshold to use for quantization ranges:

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1/tpc_keras.py
@@ -14,7 +14,10 @@
 # ==============================================================================
 import tensorflow as tf
 from packaging import version
+from model_compression_toolkit.constants import FOUND_SONY_CUSTOM_LAYERS
 
+if FOUND_SONY_CUSTOM_LAYERS:
+    from sony_custom_layers.keras.object_detection.ssd_post_process import SSDPostProcess
 
 if version.parse(tf.__version__) >= version.parse("2.13"):
     from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
@@ -54,29 +57,34 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
 
     keras_tpc = tp.TargetPlatformCapabilities(tp_model, name=name, version=TPC_VERSION)
 
+    no_quant_list = [Reshape,
+                     tf.reshape,
+                     Permute,
+                     tf.transpose,
+                     Flatten,
+                     Cropping2D,
+                     ZeroPadding2D,
+                     Dropout,
+                     MaxPooling2D,
+                     tf.split,
+                     tf.quantization.fake_quant_with_min_max_vars,
+                     tf.math.argmax,
+                     tf.shape,
+                     tf.math.equal,
+                     tf.gather,
+                     tf.cast,
+                     tf.unstack,
+                     tf.compat.v1.gather,
+                     tf.nn.top_k,
+                     tf.__operators__.getitem,
+                     tf.image.combined_non_max_suppression,
+                     tf.compat.v1.shape]
+
+    if FOUND_SONY_CUSTOM_LAYERS:
+        no_quant_list.append(SSDPostProcess)
+
     with keras_tpc:
-        tp.OperationsSetToLayers("NoQuantization", [Reshape,
-                                                    tf.reshape,
-                                                    Permute,
-                                                    tf.transpose,
-                                                    Flatten,
-                                                    Cropping2D,
-                                                    ZeroPadding2D,
-                                                    Dropout,
-                                                    MaxPooling2D,
-                                                    tf.split,
-                                                    tf.quantization.fake_quant_with_min_max_vars,
-                                                    tf.math.argmax,
-                                                    tf.shape,
-                                                    tf.math.equal,
-                                                    tf.gather,
-                                                    tf.cast,
-                                                    tf.unstack,
-                                                    tf.compat.v1.gather,
-                                                    tf.nn.top_k,
-                                                    tf.__operators__.getitem,
-                                                    tf.image.combined_non_max_suppression,
-                                                    tf.compat.v1.shape])
+        tp.OperationsSetToLayers("NoQuantization", no_quant_list)
 
         tp.OperationsSetToLayers("Conv", [Conv2D,
                                           DepthwiseConv2D,

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v1_lut/tpc_keras.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 import tensorflow as tf
 from packaging import version
+from model_compression_toolkit.constants import FOUND_SONY_CUSTOM_LAYERS
+
+if FOUND_SONY_CUSTOM_LAYERS:
+    from sony_custom_layers.keras.object_detection.ssd_post_process import SSDPostProcess
 
 if version.parse(tf.__version__) >= version.parse("2.13"):
     from keras.src.layers import Conv2D, DepthwiseConv2D, Dense, Reshape, ZeroPadding2D, Dropout, \
@@ -53,28 +57,34 @@ def generate_keras_tpc(name: str, tp_model: tp.TargetPlatformModel):
 
     keras_tpc = tp.TargetPlatformCapabilities(tp_model, name=name, version=TPC_VERSION)
 
+    no_quant_list = [Reshape,
+                     tf.reshape,
+                     Permute,
+                     tf.transpose,
+                     Flatten,
+                     Cropping2D,
+                     ZeroPadding2D,
+                     Dropout,
+                     MaxPooling2D,
+                     tf.split,
+                     tf.quantization.fake_quant_with_min_max_vars,
+                     tf.math.argmax,
+                     tf.shape,
+                     tf.math.equal,
+                     tf.gather,
+                     tf.cast,
+                     tf.unstack,
+                     tf.compat.v1.gather,
+                     tf.nn.top_k,
+                     tf.__operators__.getitem,
+                     tf.image.combined_non_max_suppression,
+                     tf.compat.v1.shape]
+
+    if FOUND_SONY_CUSTOM_LAYERS:
+        no_quant_list.append(SSDPostProcess)
+
     with keras_tpc:
-        tp.OperationsSetToLayers("NoQuantization", [Reshape,
-                                                    tf.reshape,
-                                                    Permute,
-                                                    tf.transpose,
-                                                    Flatten,
-                                                    Cropping2D,
-                                                    ZeroPadding2D,
-                                                    Dropout,
-                                                    MaxPooling2D,
-                                                    tf.split,
-                                                    tf.quantization.fake_quant_with_min_max_vars,
-                                                    tf.math.argmax,
-                                                    tf.shape,
-                                                    tf.math.equal,
-                                                    tf.gather,
-                                                    tf.cast,
-                                                    tf.unstack,
-                                                    tf.compat.v1.gather,
-                                                    tf.nn.top_k,
-                                                    tf.__operators__.getitem,
-                                                    tf.compat.v1.shape])
+        tp.OperationsSetToLayers("NoQuantization", no_quant_list)
 
         tp.OperationsSetToLayers("Conv", [Conv2D,
                                           DepthwiseConv2D,

--- a/tutorials/notebooks/example_keras_effdet_lite0.ipynb
+++ b/tutorials/notebooks/example_keras_effdet_lite0.ipynb
@@ -9,11 +9,17 @@
     "\n",
     "## Overview\n",
     "\n",
-    "In this notebook, we'll demonstrate the post-training quantization using MCT for a pre-trained object detection model in Keras. Specifically, we'll integrate a post-processing custom layer from [sony-custom-layers](https://github.com/sony/custom_layers) into the model. This integration aligns with the imx500 target platform capabilities.\n",
+    "In this notebook, we'll demonstrate the post-training quantization using MCT for a pre-trained object detection model in Keras. In addition, we'll integrate a post-processing custom layer from [sony-custom-layers](https://github.com/sony/custom_layers) into the model. This integration aligns with the imx500 target platform capabilities.\n",
     "\n",
     "In this example we will use an existing pre-trained EfficientDet model taken from [efficientdet-pytorch](https://github.com/rwightman/efficientdet-pytorch). We will convert the model to a Keras functional model that includes the custom [PostProcess Layer](https://github.com/sony/custom_layers/blob/main/sony_custom_layers/keras/object_detection/ssd_post_process.py). Further, we will quantize the model using MCT post training quantization and evaluate the performance of the floating point model and the quantized model on the COCO dataset.\n",
     "\n",
-    "We'll use the [timm](https://github.com/huggingface/pytorch-image-models)'s data loader and evaluation capabilities used for the original pytorch pretrained model. The conversion to the Keras model will not be covered. You can go over the conversion [here](https://github.com/sony/model_optimization/tree/main/tutorials/resources/efficientdet)\n"
+    "We'll use the [timm](https://github.com/huggingface/pytorch-image-models)'s data loader and evaluation capabilities used for the original pytorch pretrained model. The conversion to the Keras model will not be covered. You can go over the conversion [here](https://github.com/sony/model_optimization/tree/main/tutorials/resources/efficientdet)\n",
+    "\n",
+    "Steps:\n",
+    "* **Setup environment**: install relevant packages, import them\n",
+    "* **Init dataset**: Download the COCO evaluation and prepare the evaluation code\n",
+    "* **Keras float model**: Create the Keras model, assign the pretrained weights and evaluate it\n",
+    "* **Quantize Keras mode**: Quantize the model and evaluate it"
    ],
    "metadata": {
     "collapsed": false
@@ -86,6 +92,8 @@
   {
    "cell_type": "markdown",
    "source": [
+    "## Init dataset\n",
+    "\n",
     "### Load COCO evaluation set"
    ],
    "metadata": {
@@ -179,7 +187,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Create the model and copy weights from pretrained PyTorch weights file"
+    "## Create the Keras model and copy weights from pretrained PyTorch weights file"
    ],
    "metadata": {
     "collapsed": false
@@ -213,7 +221,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Wrap model in a Torch Module so it can be evaluated with timm's evaluation code"
+    "### Wrap model in a Torch Module, so it can be evaluated with timm's evaluation code"
    ],
    "metadata": {
     "collapsed": false
@@ -275,7 +283,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Wrap quantized model in a Torch Module so it can be evaluated with timm's evaluation code"
+    "### Wrap quantized model in a Torch Module, so it can be evaluated with timm's evaluation code"
    ],
    "metadata": {
     "collapsed": false

--- a/tutorials/notebooks/example_keras_effdet_lite0.ipynb
+++ b/tutorials/notebooks/example_keras_effdet_lite0.ipynb
@@ -19,7 +19,9 @@
     "* **Setup environment**: install relevant packages, import them\n",
     "* **Init dataset**: Download the COCO evaluation and prepare the evaluation code\n",
     "* **Keras float model**: Create the Keras model, assign the pretrained weights and evaluate it\n",
-    "* **Quantize Keras mode**: Quantize the model and evaluate it"
+    "* **Quantize Keras mode**: Quantize the model and evaluate it\n",
+    "\n",
+    "**Note**: The following code should be run on a GPU."
    ],
    "metadata": {
     "collapsed": false
@@ -49,23 +51,12 @@
     "!pip install -q torchvision\n",
     "!pip install -q timm\n",
     "!pip install -q effdet\n",
-    "!pip install -q sony-custom-layers\n",
-    "!git clone -b add_ported_effdet_keras_tutorial https://github.com/sony/model_optimization.git local_mct"
+    "!pip install -q sony-custom-layers"
    ],
    "metadata": {
     "collapsed": false
    },
    "id": "6695a3ec84402e29"
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "In order to convert the PyTorch you'll need to use the conversion code in the [MCT tutorials folder](https://github.com/sony/model_optimization/tree/main/tutorials)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "eda6ab0d8f0b6b56"
   },
   {
    "cell_type": "code",
@@ -78,7 +69,40 @@
     "from effdet.config import get_efficientdet_config\n",
     "from effdet import create_dataset, create_loader, create_evaluator\n",
     "from effdet.data import resolve_input_config\n",
-    "import model_compression_toolkit as mct\n",
+    "import model_compression_toolkit as mct"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "735aee910cf92d42"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "In order to convert the PyTorch model, you'll need to use the conversion code in the [MCT tutorials folder](https://github.com/sony/model_optimization/tree/main/tutorials), so we'll clone the MCT repository to a local folder and only use that code. The installed MCT package will be used for quantization. "
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "eda6ab0d8f0b6b56"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!git clone -b add_ported_effdet_keras_tutorial https://github.com/sony/model_optimization.git local_mct"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "ca9a743c0e7ba067"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "import sys\n",
     "sys.path.insert(0,\"/content/local_mct\")\n",
     "from tutorials.resources.efficientdet import EfficientDetKeras, TorchWrapper\n",
@@ -121,7 +145,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Init data loader and evaluation functions"
+    "### Init data loader and evaluation functions\n",
+    "\n",
+    "These functions were adapted from the [efficientdet-pytorch](https://github.com/rwightman/efficientdet-pytorch) repository."
    ],
    "metadata": {
     "collapsed": false
@@ -134,6 +160,9 @@
    "outputs": [],
    "source": [
     "def get_coco_dataloader(batch_size=16, split='val', config=None):\n",
+    "    \"\"\"\n",
+    "    Get the torch data-loader and evaluation object\n",
+    "    \"\"\"\n",
     "    root = '/content/coco'\n",
     "\n",
     "    args = dict(interpolation='bilinear', mean=None, std=None, fill_color=None)\n",
@@ -157,6 +186,7 @@
     "\n",
     "\n",
     "def acc_eval(_model, batch_size=16, config=None):\n",
+    "    # EValuate input model\n",
     "    val_loader, evaluator = get_coco_dataloader(batch_size=batch_size, config=config)\n",
     "\n",
     "    batch_time = AverageMeter()\n",
@@ -187,7 +217,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Create the Keras model and copy weights from pretrained PyTorch weights file"
+    "## Keras model\n",
+    "\n",
+    "Create the Keras model and copy weights from pretrained PyTorch weights file. Saved as \"model.keras\"."
    ],
    "metadata": {
     "collapsed": false
@@ -221,7 +253,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Wrap model in a Torch Module, so it can be evaluated with timm's evaluation code"
+    "### Evaluate Keras model\n",
+    "\n",
+    "Wrap model in a Torch Module, so it can be evaluated with timm's evaluation code. We evaluate the model to verify the conversion succeeded and to compare it to the quantized model evaluation. The \"TorchWrapper\" object is a PyTorch module that serves as an API between the timm's Torch evaluation framework and the Keras model."
    ],
    "metadata": {
     "collapsed": false
@@ -245,7 +279,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Quantize Keras model\n"
+    "## Quantized Keras model\n",
+    "\n",
+    "The quantized model is saved as \"quant_model.keras\"."
    ],
    "metadata": {
     "collapsed": false
@@ -283,7 +319,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Wrap quantized model in a Torch Module, so it can be evaluated with timm's evaluation code"
+    "### Evaluate quantized Keras model\n",
+    "\n",
+    "Quantized Keras model evaluation applied the same as the original model."
    ],
    "metadata": {
     "collapsed": false
@@ -299,7 +337,7 @@
     "\n",
     "quant_map = acc_eval(wrapped_model, batch_size=64, config=config)\n",
     "\n",
-    "print(f' ===>> Float mAP = {100*float_map:2.3f}, Quantized model mAP = {100*quant_map:2.3f}')"
+    "print(f' ===>> Float model mAP = {100*float_map:2.3f}, Quantized model mAP = {100*quant_map:2.3f}')"
    ],
    "metadata": {
     "collapsed": false

--- a/tutorials/notebooks/example_keras_effdet_lite0.ipynb
+++ b/tutorials/notebooks/example_keras_effdet_lite0.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Post Training Quantization an EfficientDet Object Detection Model\n",
+    "\n",
+    "[Run this tutorial in Google Colab](https://colab.research.google.com/github/sony/model_optimization/blob/main/tutorials/notebooks/example_keras_effdet_lite0.ipynb)\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "In this notebook, we'll demonstrate the post-training quantization using MCT for a pre-trained object detection model in Keras. Specifically, we'll integrate a post-processing custom layer from [sony-custom-layers](https://github.com/sony/custom_layers) into the model. This integration aligns with the imx500 target platform capabilities.\n",
+    "\n",
+    "In this example we will use an existing pre-trained EfficientDet model taken from [efficientdet-pytorch](https://github.com/rwightman/efficientdet-pytorch). We will convert the model to a Keras functional model that includes the custom [PostProcess Layer](https://github.com/sony/custom_layers/blob/main/sony_custom_layers/keras/object_detection/ssd_post_process.py). Further, we will quantize the model using MCT post training quantization and evaluate the performance of the floating point model and the quantized model on the COCO dataset.\n",
+    "\n",
+    "We'll use the [timm](https://github.com/huggingface/pytorch-image-models)'s data loader and evaluation capabilities used for the original pytorch pretrained model. The conversion to the Keras model will not be covered. You can go over the conversion [here](https://github.com/sony/model_optimization/tree/main/tutorials/resources/efficientdet)\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "c9e7b10d2bfe67d4"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Setup\n",
+    "\n",
+    "install and import relevant packages"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "d0e81b09e6d30873"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install tensorflow\n",
+    "!pip install model-compression-toolkit\n",
+    "!pip install torch\n",
+    "!pip install torchvision\n",
+    "!pip install timm\n",
+    "!pip install effdet\n",
+    "!git clone https://github.com/sony/model_optimization/tree/main/tutorials/resources"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6695a3ec84402e29"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "In order to convert the PyTorch you'll need to use the conversion code in the [MCT tutorials folder](https://github.com/sony/model_optimization/tree/main/tutorials)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "eda6ab0d8f0b6b56"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from time import time\n",
+    "import torch\n",
+    "from timm.utils import AverageMeter\n",
+    "from effdet.config import get_efficientdet_config\n",
+    "from effdet import create_dataset, create_loader, create_evaluator\n",
+    "from effdet.data import resolve_input_config\n",
+    "import model_compression_toolkit as mct\n",
+    "from resources.efficientdet import EfficientDetKeras, TorchWrapper\n",
+    "from resources.utils import load_state_dict"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "38e460c939d89482"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Init data loader and evaluation functions"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6010ecf194d4a6a1"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def get_coco_dataloader(batch_size=16, split='val', config=None):\n",
+    "    root = '/data/projects/swat/datasets_src/COCO'\n",
+    "\n",
+    "    args = dict(interpolation='bilinear', mean=None, std=None, fill_color=None)\n",
+    "    dataset = create_dataset('coco', root, split)\n",
+    "    input_config = resolve_input_config(args, config)\n",
+    "    loader = create_loader(\n",
+    "        dataset,\n",
+    "        input_size=input_config['input_size'],\n",
+    "        batch_size=batch_size,\n",
+    "        use_prefetcher=True,\n",
+    "        interpolation=input_config['interpolation'],\n",
+    "        fill_color=input_config['fill_color'],\n",
+    "        mean=input_config['mean'],\n",
+    "        std=input_config['std'],\n",
+    "        num_workers=0,\n",
+    "        pin_mem=False,\n",
+    "    )\n",
+    "    evaluator = create_evaluator('coco', dataset, pred_yxyx=False)\n",
+    "\n",
+    "    return loader, evaluator\n",
+    "\n",
+    "\n",
+    "def acc_eval(_model, batch_size=16, config=None):\n",
+    "    val_loader, evaluator = get_coco_dataloader(batch_size=batch_size, config=config)\n",
+    "\n",
+    "    batch_time = AverageMeter()\n",
+    "    end = time()\n",
+    "    last_idx = len(val_loader) - 1\n",
+    "    with torch.no_grad():\n",
+    "        for i, (input, target) in enumerate(val_loader):\n",
+    "            output = _model(input, img_info=target)\n",
+    "\n",
+    "            evaluator.add_predictions(output, target)\n",
+    "\n",
+    "            # measure elapsed time\n",
+    "            batch_time.update(time() - end)\n",
+    "            end = time()\n",
+    "            if i % 10 == 0 or i == last_idx:\n",
+    "                print(\n",
+    "                    f'Test: [{i:>4d}/{len(val_loader)}]  '\n",
+    "                    f'Time: {batch_time.val:.3f}s ({batch_time.avg:.3f}s, {input.size(0) / batch_time.avg:>7.2f}/s)  '\n",
+    "                )\n",
+    "\n",
+    "    return evaluator.evaluate()"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "5833c805a1ca77aa"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create the model and copy weights from pretrained PyTorch weights file"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "7e589b01c6a45a9e"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "model_name = 'tf_efficientdet_lite0'\n",
+    "config = get_efficientdet_config(model_name)\n",
+    "\n",
+    "merged_outputs = True\n",
+    "use_custom_layer = True\n",
+    "pretrained_backbone = False\n",
+    "model = EfficientDetKeras(config,\n",
+    "                          pretrained_backbone=pretrained_backbone\n",
+    "                          ).get_model([*config.image_size] + [3],\n",
+    "                                      merge_outputs=merged_outputs,\n",
+    "                                      use_custom_layer=use_custom_layer)\n",
+    "\n",
+    "state_dict = torch.hub.load_state_dict_from_url(config.url, progress=False,\n",
+    "                                                map_location='cpu')\n",
+    "state_dict_numpy = {k: v.numpy() for k, v in state_dict.items()}\n",
+    "load_state_dict(model, state_dict_numpy)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6f1dacee7a949928"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Wrap model in a Torch Module so it can be evaluated with timm's evaluation code"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "ef6b474a69358e03"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "wrapped_model = TorchWrapper(model,\n",
+    "                             merged_outputs=merged_outputs,\n",
+    "                             used_custom_layer=use_custom_layer)\n",
+    "\n",
+    "float_map = acc_eval(wrapped_model, batch_size=64, config=config)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "dc2c87ab3460f395"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Quantize Keras model\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "aca80a0fc370eef3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "loader, _ = get_coco_dataloader(split='train', config=config)\n",
+    "\n",
+    "\n",
+    "def get_representative_dataset(n_iter):\n",
+    "\n",
+    "    def representative_dataset():\n",
+    "        ds_iter = iter(loader)\n",
+    "        for _ in range(n_iter):\n",
+    "            t = next(ds_iter)[0]\n",
+    "            yield [t.detach().cpu().numpy().transpose((0, 2, 3, 1))]\n",
+    "\n",
+    "    return representative_dataset\n",
+    "\n",
+    "\n",
+    "quant_model, _ = mct.ptq.keras_post_training_quantization_experimental(model,\n",
+    "                                                                       get_representative_dataset(20))"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6f1fa147c5a16df"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Wrap quantized model in a Torch Module so it can be evaluated with timm's evaluation code"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "79ae299b0b019953"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "wrapped_model = TorchWrapper(quant_model,\n",
+    "                             merged_outputs=merged_outputs,\n",
+    "                             used_custom_layer=use_custom_layer)\n",
+    "\n",
+    "quant_map = acc_eval(wrapped_model, batch_size=64, config=config)\n",
+    "\n",
+    "print(f' ===>> Float mAP = {100*float_map:2.3f}, Quantized model mAP = {100*quant_map:2.3f}')"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6f93b9b932fb39cc"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/notebooks/example_keras_effdet_lite0.ipynb
+++ b/tutorials/notebooks/example_keras_effdet_lite0.ipynb
@@ -37,13 +37,14 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "!pip install tensorflow\n",
-    "!pip install model-compression-toolkit\n",
-    "!pip install torch\n",
-    "!pip install torchvision\n",
-    "!pip install timm\n",
-    "!pip install effdet\n",
-    "!git clone https://github.com/sony/model_optimization/tree/main/tutorials/resources"
+    "!pip install -q tensorflow\n",
+    "!pip install -q model-compression-toolkit\n",
+    "!pip install -q torch\n",
+    "!pip install -q torchvision\n",
+    "!pip install -q timm\n",
+    "!pip install -q effdet\n",
+    "!pip install -q sony-custom-layers\n",
+    "!git clone -b add_ported_effdet_keras_tutorial https://github.com/sony/model_optimization.git local_mct"
    ],
    "metadata": {
     "collapsed": false
@@ -72,13 +73,42 @@
     "from effdet import create_dataset, create_loader, create_evaluator\n",
     "from effdet.data import resolve_input_config\n",
     "import model_compression_toolkit as mct\n",
-    "from resources.efficientdet import EfficientDetKeras, TorchWrapper\n",
-    "from resources.utils import load_state_dict"
+    "import sys\n",
+    "sys.path.insert(0,\"/content/local_mct\")\n",
+    "from tutorials.resources.efficientdet import EfficientDetKeras, TorchWrapper\n",
+    "from tutorials.resources.utils import load_state_dict"
    ],
    "metadata": {
     "collapsed": false
    },
    "id": "38e460c939d89482"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Load COCO evaluation set"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "f75abdac7950c038"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!wget -nc http://images.cocodataset.org/annotations/annotations_trainval2017.zip\n",
+    "!unzip -q -o annotations_trainval2017.zip -d /content/coco\n",
+    "!echo Done loading annotations\n",
+    "!wget -nc http://images.cocodataset.org/zips/val2017.zip\n",
+    "!unzip -q -o val2017.zip -d /content/coco\n",
+    "!echo Done loading val2017 images"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "1bf50c7706331ba8"
   },
   {
    "cell_type": "markdown",
@@ -96,7 +126,7 @@
    "outputs": [],
    "source": [
     "def get_coco_dataloader(batch_size=16, split='val', config=None):\n",
-    "    root = '/data/projects/swat/datasets_src/COCO'\n",
+    "    root = '/content/coco'\n",
     "\n",
     "    args = dict(interpolation='bilinear', mean=None, std=None, fill_color=None)\n",
     "    dataset = create_dataset('coco', root, split)\n",
@@ -164,19 +194,16 @@
     "model_name = 'tf_efficientdet_lite0'\n",
     "config = get_efficientdet_config(model_name)\n",
     "\n",
-    "merged_outputs = True\n",
-    "use_custom_layer = True\n",
-    "pretrained_backbone = False\n",
     "model = EfficientDetKeras(config,\n",
-    "                          pretrained_backbone=pretrained_backbone\n",
-    "                          ).get_model([*config.image_size] + [3],\n",
-    "                                      merge_outputs=merged_outputs,\n",
-    "                                      use_custom_layer=use_custom_layer)\n",
+    "                          pretrained_backbone=False\n",
+    "                          ).get_model([*config.image_size] + [3])\n",
     "\n",
     "state_dict = torch.hub.load_state_dict_from_url(config.url, progress=False,\n",
     "                                                map_location='cpu')\n",
     "state_dict_numpy = {k: v.numpy() for k, v in state_dict.items()}\n",
-    "load_state_dict(model, state_dict_numpy)"
+    "load_state_dict(model, state_dict_numpy)\n",
+    "\n",
+    "model.save('/content/model.keras')"
    ],
    "metadata": {
     "collapsed": false
@@ -198,9 +225,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "wrapped_model = TorchWrapper(model,\n",
-    "                             merged_outputs=merged_outputs,\n",
-    "                             used_custom_layer=use_custom_layer)\n",
+    "wrapped_model = TorchWrapper(model)\n",
     "\n",
     "float_map = acc_eval(wrapped_model, batch_size=64, config=config)"
    ],
@@ -224,7 +249,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "loader, _ = get_coco_dataloader(split='train', config=config)\n",
+    "loader, _ = get_coco_dataloader(split='val', config=config)\n",
     "\n",
     "\n",
     "def get_representative_dataset(n_iter):\n",
@@ -239,7 +264,8 @@
     "\n",
     "\n",
     "quant_model, _ = mct.ptq.keras_post_training_quantization_experimental(model,\n",
-    "                                                                       get_representative_dataset(20))"
+    "                                                                       get_representative_dataset(20))\n",
+    "quant_model.save('/content/quant_model.keras')"
    ],
    "metadata": {
     "collapsed": false
@@ -261,9 +287,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "wrapped_model = TorchWrapper(quant_model,\n",
-    "                             merged_outputs=merged_outputs,\n",
-    "                             used_custom_layer=use_custom_layer)\n",
+    "wrapped_model = TorchWrapper(quant_model)\n",
     "\n",
     "quant_map = acc_eval(wrapped_model, batch_size=64, config=config)\n",
     "\n",

--- a/tutorials/resources/efficientdet/__init__.py
+++ b/tutorials/resources/efficientdet/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from tutorials.resources.efficientdet.effdet_keras import EfficientDetKeras, TorchWrapper

--- a/tutorials/resources/efficientdet/effdet_keras.py
+++ b/tutorials/resources/efficientdet/effdet_keras.py
@@ -1,0 +1,704 @@
+import logging
+from collections import OrderedDict
+from functools import partial
+from typing import List, Optional, Union, Tuple
+
+import tensorflow as tf
+
+
+gpus = tf.config.list_physical_devices('GPU')
+if gpus:
+  try:
+    # Currently, memory growth needs to be the same across GPUs
+    for gpu in gpus:
+      tf.config.experimental.set_memory_growth(gpu, True)
+    logical_gpus = tf.config.list_logical_devices('GPU')
+    print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
+  except RuntimeError as e:
+    # Memory growth must be set before GPUs have been initialized
+    print(e)
+
+# from .anchors import Anchors, AnchorLabeler, generate_detections
+from effdet.anchors import Anchors, get_feat_sizes
+from effdet.config import get_fpn_config, set_config_writeable, set_config_readonly
+from effdet.efficientdet import get_feature_info
+from tutorials.resources.efficientdet.effnet_keras import create_model, handle_name
+from tutorials.resources.efficientdet.effnet_blocks_keras import create_conv2d, create_pool2d
+
+from sony_custom_layers.keras.object_detection.ssd_post_process import SSDPostProcess
+from sony_custom_layers.keras.object_detection import ScoreConverter
+
+_DEBUG = False
+_USE_SCALE = False
+_ACT_LAYER = tf.nn.swish
+
+
+import torch
+from typing import Dict
+
+
+class TorchWrapper(torch.nn.Module):
+    def __init__(self, model, merged_outputs=False, used_custom_layer=False):
+        super(TorchWrapper, self).__init__()
+        self.model = model
+        self.merged_outputs = merged_outputs
+        self.used_custom_layer = used_custom_layer
+
+    @property
+    def config(self):
+        return self.model.config
+
+    def forward(self, x, img_info: Optional[Dict[str, torch.Tensor]] = None):
+        device = x.device
+        keras_input = x.detach().cpu().numpy().transpose((0, 2, 3, 1))
+        outputs = self.model(keras_input)
+        if self.merged_outputs:
+            if self.used_custom_layer:
+                outs = [torch.Tensor(o.numpy()).to(device) for o in outputs]
+                outs[0] = outs[0][:, :, [1, 0, 3, 2]]  # reorder (y, x, y2, x2) to (x, y, x2, y2)
+                outs[0] = outs[0] * img_info['img_scale'].view((-1, 1, 1))  # scale to original image size
+                return torch.cat([outs[0], outs[1].unsqueeze(2), outs[2].unsqueeze(2)+1], 2)
+            else:
+                class_out, box_out = outputs
+                class_out = torch.Tensor(class_out.numpy()).to(device)
+                box_out = torch.Tensor(box_out.numpy()).to(device)
+                return [class_out, box_out]
+        else:
+            class_out, box_out = outputs
+            class_out = [torch.Tensor(c.numpy().transpose((0, 3, 1, 2))).to(device) for c in class_out]
+            box_out = [torch.Tensor(b.numpy().transpose((0, 3, 1, 2))).to(device) for b in box_out]
+            return [class_out, box_out]
+
+
+def get_act_layer(act_type):
+    if act_type == 'relu6':
+        return partial(tf.keras.layers.ReLU, max_value=6.0)
+    else:
+        raise NotImplemented
+
+
+class ConvBnAct2d:
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=1,
+            dilation=1,
+            padding='',
+            bias=False,
+            norm_layer=tf.keras.layers.BatchNormalization,
+            act_layer=_ACT_LAYER,
+            name=None
+    ):
+        name = handle_name(name)
+        self.conv = create_conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            padding=padding,
+            bias=bias,
+            name=name + '/conv'
+        )
+        self.bn = None if norm_layer is None else norm_layer(name=name + '/bn')
+        self.act = None if act_layer is None else act_layer()
+
+    def __call__(self, x):
+        x = self.conv(x)
+        if self.bn is not None:
+            x = self.bn(x)
+        if self.act is not None:
+            x = self.act(x)
+        return x
+
+
+class SeparableConv2d:
+    """ Separable Conv
+    """
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            dilation=1,
+            padding='',
+            bias=False,
+            channel_multiplier=1.0,
+            pw_kernel_size=1,
+            norm_layer=tf.keras.layers.BatchNormalization,
+            act_layer=_ACT_LAYER,
+            name=None
+    ):
+        name = handle_name(name)
+        self.conv_dw = create_conv2d(
+            in_channels,
+            int(in_channels * channel_multiplier),
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            padding=padding,
+            depthwise=True,
+            name=name + '/conv_dw'
+        )
+        self.conv_pw = create_conv2d(
+            int(in_channels * channel_multiplier),
+            out_channels,
+            pw_kernel_size,
+            padding=padding,
+            bias=bias,
+            name=name + '/conv_pw'
+        )
+        self.bn = None if norm_layer is None else norm_layer(name=name + '/bn')
+        self.act = None if act_layer is None else act_layer()
+
+    def __call__(self, x):
+        x = self.conv_dw(x)
+        x = self.conv_pw(x)
+        if self.bn is not None:
+            x = self.bn(x)
+        if self.act is not None:
+            x = self.act(x)
+        return x
+
+
+class Interpolate2d:
+    r"""Resamples a 2d Image
+
+    The input data is assumed to be of the form
+    `minibatch x channels x [optional depth] x [optional height] x width`.
+    Hence, for spatial inputs, we expect a 4D Tensor and for volumetric inputs, we expect a 5D Tensor.
+
+    The algorithms available for upsampling are nearest neighbor and linear,
+    bilinear, bicubic and trilinear for 3D, 4D and 5D input Tensor,
+    respectively.
+
+    One can either give a :attr:`scale_factor` or the target output :attr:`size` to
+    calculate the output size. (You cannot give both, as it is ambiguous)
+
+    Args:
+        size (int or Tuple[int] or Tuple[int, int] or Tuple[int, int, int], optional):
+            output spatial sizes
+        scale_factor (float or Tuple[float] or Tuple[float, float] or Tuple[float, float, float], optional):
+            multiplier for spatial size. Has to match input size if it is a tuple.
+        mode (str, optional): the upsampling algorithm: one of ``'nearest'``,
+            ``'linear'``, ``'bilinear'``, ``'bicubic'`` and ``'trilinear'``.
+            Default: ``'nearest'``
+        align_corners (bool, optional): if ``True``, the corner pixels of the input
+            and output tensors are aligned, and thus preserving the values at
+            those pixels. This only has effect when :attr:`mode` is
+            ``'linear'``, ``'bilinear'``, or ``'trilinear'``. Default: ``False``
+    """
+    __constants__ = ['size', 'scale_factor', 'mode', 'align_corners', 'name']
+    name: str
+    size: Optional[Union[int, Tuple[int, int]]]
+    scale_factor: Optional[Union[float, Tuple[float, float]]]
+    mode: str
+    align_corners: Optional[bool]
+
+    def __init__(
+            self,
+            size: Optional[Union[int, Tuple[int, int]]] = None,
+            scale_factor: Optional[Union[float, Tuple[float, float]]] = None,
+            mode: str = 'nearest',
+            align_corners: bool = False,
+    ) -> None:
+        self.name = type(self).__name__
+        self.size = size
+        if isinstance(scale_factor, tuple):
+            self.scale_factor = tuple(float(factor) for factor in scale_factor)
+        else:
+            self.scale_factor = float(scale_factor) if scale_factor else None
+        self.mode = mode
+        self.align_corners = None if mode == 'nearest' else align_corners
+
+        # tested in keras
+        assert self.align_corners in [None, False]
+        assert self.scale_factor is None
+        if self.mode == 'nearest':
+            self.mode = tf.image.ResizeMethod.NEAREST_NEIGHBOR
+        else:
+            raise NotImplemented
+
+    def __call__(self, input: tf.Tensor) -> tf.Tensor:
+        return tf.image.resize(input, self.size, method=self.mode)
+
+
+class ResampleFeatureMap:
+
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            input_size,
+            output_size,
+            pad_type='',
+            downsample=None,
+            upsample=None,
+            norm_layer=tf.keras.layers.BatchNormalization,
+            apply_bn=False,
+            redundant_bias=False,
+            name=None
+    ):
+        name = handle_name(name)
+        downsample = downsample or 'max'
+        upsample = upsample or 'nearest'
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.input_size = input_size
+        self.output_size = output_size
+
+        self.layers = []
+        if in_channels != out_channels:
+            self.layers.append(ConvBnAct2d(
+                in_channels,
+                out_channels,
+                kernel_size=1,
+                padding=pad_type,
+                norm_layer=norm_layer if apply_bn else None,
+                bias=not apply_bn or redundant_bias,
+                act_layer=None,
+                name=f'{name}/conv'#/{len(self.layers)}'
+            ))
+
+        if input_size[0] > output_size[0] and input_size[1] > output_size[1]:
+            if downsample in ('max', 'avg'):
+                stride_size_h = int((input_size[0] - 1) // output_size[0] + 1)
+                stride_size_w = int((input_size[1] - 1) // output_size[1] + 1)
+                if stride_size_h == stride_size_w:
+                    kernel_size = stride_size_h + 1
+                    stride = stride_size_h
+                else:
+                    # FIXME need to support tuple kernel / stride input to padding fns
+                    kernel_size = (stride_size_h + 1, stride_size_w + 1)
+                    stride = (stride_size_h, stride_size_w)
+                down_inst = create_pool2d(downsample, kernel_size=kernel_size, stride=stride, padding=pad_type,
+                                          name=name + '/downsample')
+            else:
+                if _USE_SCALE:  # FIXME not sure if scale vs size is better, leaving both in to test for now
+                    scale = (output_size[0] / input_size[0], output_size[1] / input_size[1])
+                    down_inst = Interpolate2d(scale_factor=scale, mode=downsample)
+                else:
+                    down_inst = Interpolate2d(size=output_size, mode=downsample, name=name)
+            self.layers.append(down_inst)
+        else:
+            if input_size[0] < output_size[0] or input_size[1] < output_size[1]:
+                if _USE_SCALE:
+                    scale = (output_size[0] / input_size[0], output_size[1] / input_size[1])
+                    self.add_module('upsample', Interpolate2d(scale_factor=scale, mode=upsample))
+                else:
+                    self.layers.append(Interpolate2d(size=output_size, mode=upsample))  # 'upsample'
+
+    def __call__(self, x: tf.Tensor) -> List[tf.Tensor]:
+        for module in self.layers:
+            x = module(x)
+        return x
+
+
+class FpnCombine:
+    def __init__(
+            self,
+            feature_info,
+            fpn_channels,
+            inputs_offsets,
+            output_size,
+            pad_type='',
+            downsample=None,
+            upsample=None,
+            norm_layer=tf.keras.layers.BatchNormalization,
+            apply_resample_bn=False,
+            redundant_bias=False,
+            weight_method='attn',
+            name=None
+    ):
+        name = handle_name(name)
+        self.inputs_offsets = inputs_offsets
+        self.weight_method = weight_method
+
+        self.resample = []  # nn.ModuleDict()
+        for idx, offset in enumerate(inputs_offsets):
+            self.resample.append(ResampleFeatureMap(
+                feature_info[offset]['num_chs'],
+                fpn_channels,
+                input_size=feature_info[offset]['size'],
+                output_size=output_size,
+                pad_type=pad_type,
+                downsample=downsample,
+                upsample=upsample,
+                norm_layer=norm_layer,
+                apply_bn=apply_resample_bn,
+                redundant_bias=redundant_bias,
+                name = name + f'/resample/{offset}'
+            ))
+
+        if weight_method == 'attn' or weight_method == 'fastattn':
+            self.edge_weights = nn.Parameter(torch.ones(len(inputs_offsets)), requires_grad=True)  # WSM
+        else:
+            self.edge_weights = None
+
+    def __call__(self, x: List[tf.Tensor]):
+        dtype = x[0].dtype
+        nodes = []
+        for offset, resample in zip(self.inputs_offsets, self.resample):
+            input_node = x[offset]
+            input_node = resample(input_node)
+            nodes.append(input_node)
+
+        if self.weight_method == 'attn':
+            normalized_weights = torch.softmax(self.edge_weights.to(dtype=dtype), dim=0)
+            out = torch.stack(nodes, dim=-1) * normalized_weights
+            out = torch.sum(out, dim=-1)
+        elif self.weight_method == 'fastattn':
+            edge_weights = nn.functional.relu(self.edge_weights.to(dtype=dtype))
+            weights_sum = torch.sum(edge_weights)
+            out = torch.stack(
+                [(nodes[i] * edge_weights[i]) / (weights_sum + 0.0001) for i in range(len(nodes))], dim=-1)
+            out = torch.sum(out, dim=-1)
+        elif self.weight_method == 'sum':
+            out = tf.keras.layers.Add()(nodes[:2])
+            for i in range(2, len(nodes)):
+                out = tf.keras.layers.Add()([out, nodes[i]])
+        else:
+            raise ValueError('unknown weight_method {}'.format(self.weight_method))
+        return out
+
+
+class Fnode:
+    """ A simple wrapper used in place of nn.Sequential for torchscript typing
+    Handles input type List[Tensor] -> output type Tensor
+    """
+    def __init__(self, combine, after_combine):
+        self.combine = combine
+        self.after_combine = after_combine
+
+    def __call__(self, x: List[tf.Tensor]) -> tf.Tensor:
+        x = self.combine(x)
+        for fn in self.after_combine:
+            x = fn(x)
+        return x
+
+
+class BiFpnLayer:
+    def __init__(
+            self,
+            feature_info,
+            feat_sizes,
+            fpn_config,
+            fpn_channels,
+            num_levels=5,
+            pad_type='',
+            downsample=None,
+            upsample=None,
+            norm_layer=tf.keras.layers.BatchNormalization,
+            act_layer=_ACT_LAYER,
+            apply_resample_bn=False,
+            pre_act=True,
+            separable_conv=True,
+            redundant_bias=False,
+            name=None
+    ):
+        name = handle_name(name)
+        self.num_levels = num_levels
+        # fill feature info for all FPN nodes (chs and feat size) before creating FPN nodes
+        fpn_feature_info = feature_info + [
+            dict(num_chs=fpn_channels, size=feat_sizes[fc['feat_level']]) for fc in fpn_config.nodes]
+
+        self.fnode = []  # nn.ModuleList()
+        for i, fnode_cfg in enumerate(fpn_config.nodes):
+            logging.debug('fnode {} : {}'.format(i, fnode_cfg))
+            combine = FpnCombine(
+                fpn_feature_info,
+                fpn_channels,
+                tuple(fnode_cfg['inputs_offsets']),
+                output_size=feat_sizes[fnode_cfg['feat_level']],
+                pad_type=pad_type,
+                downsample=downsample,
+                upsample=upsample,
+                norm_layer=norm_layer,
+                apply_resample_bn=apply_resample_bn,
+                redundant_bias=redundant_bias,
+                weight_method=fnode_cfg['weight_method'],
+                name=f'{name}/fnode/{i}/combine'
+            )
+
+            after_combine = []  # nn.Sequential()
+            conv_kwargs = dict(
+                in_channels=fpn_channels,
+                out_channels=fpn_channels,
+                kernel_size=3,
+                padding=pad_type,
+                bias=False,
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+            )
+            if pre_act:
+                conv_kwargs['bias'] = redundant_bias
+                conv_kwargs['act_layer'] = None
+                after_combine.append(act_layer())  # 'act'
+            after_combine.append(
+                SeparableConv2d(name=f'{name}/fnode/{i}/after_combine/conv', **conv_kwargs) if separable_conv
+                else ConvBnAct2d(name=f'{name}/fnode/{i}/after_combine/conv', **conv_kwargs))
+
+            self.fnode.append(Fnode(combine=combine, after_combine=after_combine))
+
+        self.feature_info = fpn_feature_info[-num_levels::]
+
+    def __call__(self, x: List[tf.Tensor]):
+        for fn in self.fnode:
+            x.append(fn(x))
+        return x[-self.num_levels::]
+
+
+class BiFpn:
+
+    def __init__(self, config, feature_info, name):
+        self.num_levels = config.num_levels
+        norm_layer = config.norm_layer or tf.keras.layers.BatchNormalization
+        norm_kwargs = {**config.norm_kwargs}
+        norm_kwargs['epsilon'] = norm_kwargs.pop('eps', 0.001)
+        if config.norm_kwargs:
+            norm_layer = partial(norm_layer, **norm_kwargs)
+        act_layer = get_act_layer(config.act_type) or _ACT_LAYER
+        fpn_config = config.fpn_config or get_fpn_config(
+            config.fpn_name, min_level=config.min_level, max_level=config.max_level)
+
+        feat_sizes = get_feat_sizes(config.image_size, max_level=config.max_level)
+        prev_feat_size = feat_sizes[config.min_level]
+        self.resample = []  # nn.ModuleDict()
+        for level in range(config.num_levels):
+            feat_size = feat_sizes[level + config.min_level]
+            if level < len(feature_info):
+                in_chs = feature_info[level]['num_chs']
+                feature_info[level]['size'] = feat_size
+            else:
+                # Adds a coarser level by downsampling the last feature map
+                self.resample.append(ResampleFeatureMap(
+                    in_channels=in_chs,
+                    out_channels=config.fpn_channels,
+                    input_size=prev_feat_size,
+                    output_size=feat_size,
+                    pad_type=config.pad_type,
+                    downsample=config.downsample_type,
+                    upsample=config.upsample_type,
+                    norm_layer=norm_layer,
+                    apply_bn=config.apply_resample_bn,
+                    redundant_bias=config.redundant_bias,
+                    name=name + f'/resample/{level}'
+                ))
+                in_chs = config.fpn_channels
+                feature_info.append(dict(num_chs=in_chs, size=feat_size))
+            prev_feat_size = feat_size
+
+        self.cell = []  # SequentialList()
+        for rep in range(config.fpn_cell_repeats):
+            logging.debug('building cell {}'.format(rep))
+            fpn_layer = BiFpnLayer(
+                feature_info=feature_info,
+                feat_sizes=feat_sizes,
+                fpn_config=fpn_config,
+                fpn_channels=config.fpn_channels,
+                num_levels=config.num_levels,
+                pad_type=config.pad_type,
+                downsample=config.downsample_type,
+                upsample=config.upsample_type,
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+                separable_conv=config.separable_conv,
+                apply_resample_bn=config.apply_resample_bn,
+                pre_act=not config.conv_bn_relu_pattern,
+                redundant_bias=config.redundant_bias,
+                name=name + f'/cell/{rep}'
+            )
+            self.cell.append(fpn_layer)
+            feature_info = fpn_layer.feature_info
+
+    def __call__(self, x: List[tf.Tensor]):
+        for resample in self.resample:
+            x.append(resample(x[-1]))
+        for _cell in self.cell:
+            x = _cell(x)
+        return x
+
+
+class HeadNet:
+
+    def __init__(self, config, num_outputs, name):
+        self.num_levels = config.num_levels
+        self.bn_level_first = getattr(config, 'head_bn_level_first', False)
+        norm_layer = config.norm_layer or tf.keras.layers.BatchNormalization
+        if config.norm_kwargs:
+            norm_kwargs = {**config.norm_kwargs}
+            if 'eps' in norm_kwargs:
+                eps = norm_kwargs.pop('eps')
+                norm_kwargs['epsilon'] = eps
+            norm_layer = partial(norm_layer, **norm_kwargs)
+        act_type = config.head_act_type if getattr(config, 'head_act_type', None) else config.act_type
+        act_layer = get_act_layer(act_type) or _ACT_LAYER
+
+        # Build convolution repeats
+        conv_fn = SeparableConv2d if config.separable_conv else ConvBnAct2d
+        conv_kwargs = dict(
+            in_channels=config.fpn_channels,
+            out_channels=config.fpn_channels,
+            kernel_size=3,
+            padding=config.pad_type,
+            bias=config.redundant_bias,
+            act_layer=None,
+            norm_layer=None,
+        )
+        self.conv_rep = [conv_fn(name=f'{name}/conv_rep/{_}', **conv_kwargs) for _ in range(config.box_class_repeats)]
+
+        # Build batchnorm repeats. There is a unique batchnorm per feature level for each repeat.
+        # This can be organized with repeats first or feature levels first in module lists, the original models
+        # and weights were setup with repeats first, levels first is required for efficient torchscript usage.
+        self.bn_rep = []  # nn.ModuleList()
+        if self.bn_level_first:
+            for _ in range(self.num_levels):
+                self.bn_rep.append([
+                    norm_layer(config.fpn_channels, name=f'{name}/bn_rep/{_}/', ) for _ in range(config.box_class_repeats)])
+        else:
+            for _ in range(config.box_class_repeats):
+                self.bn_rep.append([norm_layer(name=f'{name}/bn_rep/{_}/{_level}/bn') for _level in range(self.num_levels)])
+
+        self.act = act_layer
+
+        # Prediction (output) layer. Has bias with special init reqs, see init fn.
+        num_anchors = len(config.aspect_ratios) * config.num_scales
+        predict_kwargs = dict(
+            in_channels=config.fpn_channels,
+            out_channels=num_outputs * num_anchors,
+            kernel_size=3,
+            padding=config.pad_type,
+            bias=True,
+            norm_layer=None,
+            act_layer=None,
+            name=f'{name}/predict'
+        )
+        self.predict = conv_fn(**predict_kwargs)
+
+    def toggle_bn_level_first(self):
+        """ Toggle the batchnorm layers between feature level first vs repeat first access pattern
+        Limitations in torchscript require feature levels to be iterated over first.
+
+        This function can be used to allow loading weights in the original order, and then toggle before
+        jit scripting the model.
+        """
+        new_bn_rep = []  # nn.ModuleList()
+        for i in range(len(self.bn_rep[0])):
+            bn_first = []  # nn.ModuleList()
+            for r in self.bn_rep.children():
+                m = r[i]
+                # NOTE original rep first model def has extra Sequential container with 'bn', this was
+                # flattened in the level first definition.
+                bn_first.append(m[0] if isinstance(m, nn.Sequential) else nn.Sequential(OrderedDict([('bn', m)])))
+            new_bn_rep.append(bn_first)
+        self.bn_level_first = not self.bn_level_first
+        self.bn_rep = new_bn_rep
+
+    def _forward(self, x: List[tf.Tensor]) -> List[tf.Tensor]:
+        outputs = []
+        for level in range(self.num_levels):
+            x_level = x[level]
+            for conv, bn in zip(self.conv_rep, self.bn_rep):
+                x_level = conv(x_level)
+                x_level = bn[level](x_level)  # this is not allowed in torchscript
+                x_level = self.act()(x_level)
+            outputs.append(self.predict(x_level))
+        return outputs
+
+    def _forward_level_first(self, x: List[tf.Tensor]) -> List[tf.Tensor]:
+        outputs = []
+        for level, bn_rep in enumerate(self.bn_rep):  # iterating over first bn dim first makes TS happy
+            x_level = x[level]
+            for conv, bn in zip(self.conv_rep, bn_rep):
+                x_level = conv(x_level)
+                x_level = bn(x_level)
+                x_level = self.act()(x_level)
+            outputs.append(self.predict(x_level))
+        return outputs
+
+    def __call__(self, x: List[tf.Tensor]) -> List[tf.Tensor]:
+        if self.bn_level_first:
+            return self._forward_level_first(x)
+        else:
+            return self._forward(x)
+
+
+class EfficientDetKeras:
+
+    def __init__(self, config, pretrained_backbone=True, alternate_init=False):
+        self.config = config
+        set_config_readonly(self.config)
+        self.backbone = create_model(
+            config.backbone_name,
+            features_only=True,
+            out_indices=self.config.backbone_indices or (2, 3, 4),
+            pretrained=pretrained_backbone,
+            **config.backbone_args,
+        )
+        feature_info = get_feature_info(self.backbone)
+        self.fpn = BiFpn(self.config, feature_info, 'fpn')
+        self.class_net = HeadNet(self.config, num_outputs=self.config.num_classes, name='class_net')
+        self.box_net = HeadNet(self.config, num_outputs=4, name='box_net')
+
+    def reset_head(self, num_classes=None, aspect_ratios=None, num_scales=None, alternate_init=False):
+        reset_class_head = False
+        reset_box_head = False
+        set_config_writeable(self.config)
+        if num_classes is not None:
+            reset_class_head = True
+            self.config.num_classes = num_classes
+        if aspect_ratios is not None:
+            reset_box_head = True
+            self.config.aspect_ratios = aspect_ratios
+        if num_scales is not None:
+            reset_box_head = True
+            self.config.num_scales = num_scales
+        set_config_readonly(self.config)
+
+        if reset_class_head:
+            self.class_net = HeadNet(self.config, num_outputs=self.config.num_classes)
+            # for n, m in self.class_net.named_modules(prefix='class_net'):
+            #     if alternate_init:
+            #         _init_weight_alt(m, n)
+            #     else:
+            #         _init_weight(m, n)
+
+        if reset_box_head:
+            self.box_net = HeadNet(self.config, num_outputs=4)
+            # for n, m in self.box_net.named_modules(prefix='box_net'):
+            #     if alternate_init:
+            #         _init_weight_alt(m, n)
+            #     else:
+            #         _init_weight(m, n)
+
+    def toggle_head_bn_level_first(self):
+        """ Toggle the head batchnorm layers between being access with feature_level first vs repeat
+        """
+        self.class_net.toggle_bn_level_first()
+        self.box_net.toggle_bn_level_first()
+
+    def get_model(self, input_shape, merge_outputs=False, use_custom_layer=False):
+        _input = tf.keras.layers.Input(shape=input_shape)
+        x = self.backbone(_input)
+        x = self.fpn(x)
+        x_class = self.class_net(x)
+        x_box = self.box_net(x)
+        outputs = [x_class, x_box]
+        if merge_outputs:
+            x_class = [tf.keras.layers.Reshape((-1, self.config.num_classes))(_x) for _x in x_class]
+            x_class = tf.keras.layers.Concatenate(axis=1)(x_class)
+            x_box = [tf.keras.layers.Reshape((-1, 4))(_x) for _x in x_box]
+            x_box = tf.keras.layers.Concatenate(axis=1)(x_box)
+            if use_custom_layer:
+                anchors = tf.constant(Anchors.from_config(self.config).boxes.detach().cpu().numpy())
+
+                ssd_pp = SSDPostProcess(anchors, [1, 1, 1, 1], [*self.config.image_size],
+                                        ScoreConverter.SIGMOID, score_threshold=0.001, iou_threshold=0.5,
+                                        max_detections=self.config.max_det_per_image)
+                outputs = ssd_pp((x_box, x_class))
+            else:
+                outputs = [x_class, x_box]
+        return tf.keras.Model(inputs=_input, outputs=outputs)

--- a/tutorials/resources/efficientdet/effdet_keras.py
+++ b/tutorials/resources/efficientdet/effdet_keras.py
@@ -23,19 +23,19 @@ import tensorflow as tf
 
 gpus = tf.config.list_physical_devices('GPU')
 if gpus:
-  try:
-    # Currently, memory growth needs to be the same across GPUs
-    for gpu in gpus:
-      tf.config.experimental.set_memory_growth(gpu, True)
-    logical_gpus = tf.config.list_logical_devices('GPU')
-    print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
-  except RuntimeError as e:
-    # Memory growth must be set before GPUs have been initialized
-    print(e)
+    try:
+        # Currently, memory growth needs to be the same across GPUs
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        logical_gpus = tf.config.list_logical_devices('GPU')
+        print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
+    except RuntimeError as e:
+        # Memory growth must be set before GPUs have been initialized
+        print(e)
 
-# from .anchors import Anchors, AnchorLabeler, generate_detections
+
 from effdet.anchors import Anchors, get_feat_sizes
-from effdet.config import get_fpn_config, set_config_writeable, set_config_readonly
+from effdet.config import get_fpn_config, set_config_readonly
 from effdet.efficientdet import get_feature_info
 from tutorials.resources.efficientdet.effnet_keras import create_model, handle_name
 from tutorials.resources.efficientdet.effnet_blocks_keras import create_conv2d, create_pool2d

--- a/tutorials/resources/efficientdet/effnet_blocks_keras.py
+++ b/tutorials/resources/efficientdet/effnet_blocks_keras.py
@@ -130,11 +130,10 @@ def create_conv2d_pad(in_chs, out_chs, kernel_size, **kwargs):
 def create_pool2d(pool_type, kernel_size, stride=None, **kwargs):
     stride = stride or kernel_size
     padding = kwargs.pop('padding', '')
-    # padding, is_dynamic = get_padding_value(padding, kernel_size, stride=stride, **kwargs)
-    # padding = 'same', kernel_size = 3, stride = 2, kwargs = {} ==> padding, is_dynamic = 0, True
     padding, is_dynamic = padding.lower(), True
     if is_dynamic:
         if pool_type == 'avg':
+            raise NotImplemented
             return AvgPool2dSame(kernel_size, stride=stride, **kwargs)
         elif pool_type == 'max':
             # return MaxPool2dSame(kernel_size, stride=stride, **kwargs)
@@ -142,6 +141,7 @@ def create_pool2d(pool_type, kernel_size, stride=None, **kwargs):
         else:
             assert False, f'Unsupported pool type {pool_type}'
     else:
+        raise NotImplemented
         if pool_type == 'avg':
             return nn.AvgPool2d(kernel_size, stride=stride, padding=padding, **kwargs)
         elif pool_type == 'max':

--- a/tutorials/resources/efficientdet/effnet_blocks_keras.py
+++ b/tutorials/resources/efficientdet/effnet_blocks_keras.py
@@ -1,0 +1,523 @@
+import types
+from functools import partial
+import tensorflow as tf
+
+from timm.layers import DropPath, make_divisible
+
+__all__ = [
+    'SqueezeExcite', 'ConvBnAct', 'DepthwiseSeparableConv', 'InvertedResidual', 'CondConvResidual', 'EdgeResidual']
+
+
+def handle_name(_name):
+    return '' if _name is None or _name == '' else _name
+
+
+def num_groups(group_size, channels):
+    if not group_size:  # 0 or None
+        return 1  # normal conv with 1 group
+    else:
+        # NOTE group_size == 1 -> depthwise conv
+        assert channels % group_size == 0
+        return channels // group_size
+
+
+def create_act_layer(act_name, **kwargs):
+    if isinstance(act_name, str):
+        raise NotImplemented
+    elif isinstance(act_name, tf.keras.layers.Layer):
+        return act_name(**kwargs)
+    else:
+        return act_name
+
+
+def get_attn(attn_type):
+    if isinstance(attn_type, tf.keras.layers.Layer):
+        return attn_type
+    module_cls = None
+    if attn_type:
+        if isinstance(attn_type, str):
+            raise NotImplemented
+            attn_type = attn_type.lower()
+            # Lightweight attention modules (channel and/or coarse spatial).
+            # Typically added to existing network architecture blocks in addition to existing convolutions.
+            if attn_type == 'se':
+                module_cls = SEModule
+            elif attn_type == 'ese':
+                module_cls = EffectiveSEModule
+            elif attn_type == 'eca':
+                module_cls = EcaModule
+            elif attn_type == 'ecam':
+                module_cls = partial(EcaModule, use_mlp=True)
+            elif attn_type == 'ceca':
+                module_cls = CecaModule
+            elif attn_type == 'ge':
+                module_cls = GatherExcite
+            elif attn_type == 'gc':
+                module_cls = GlobalContext
+            elif attn_type == 'gca':
+                module_cls = partial(GlobalContext, fuse_add=True, fuse_scale=False)
+            elif attn_type == 'cbam':
+                module_cls = CbamModule
+            elif attn_type == 'lcbam':
+                module_cls = LightCbamModule
+
+            # Attention / attention-like modules w/ significant params
+            # Typically replace some of the existing workhorse convs in a network architecture.
+            # All of these accept a stride argument and can spatially downsample the input.
+            elif attn_type == 'sk':
+                module_cls = SelectiveKernel
+            elif attn_type == 'splat':
+                module_cls = SplitAttn
+
+            # Self-attention / attention-like modules w/ significant compute and/or params
+            # Typically replace some of the existing workhorse convs in a network architecture.
+            # All of these accept a stride argument and can spatially downsample the input.
+            elif attn_type == 'lambda':
+                return LambdaLayer
+            elif attn_type == 'bottleneck':
+                return BottleneckAttn
+            elif attn_type == 'halo':
+                return HaloAttn
+            elif attn_type == 'nl':
+                module_cls = NonLocalAttn
+            elif attn_type == 'bat':
+                module_cls = BatNonLocalAttn
+
+            # Woops!
+            else:
+                assert False, "Invalid attn module (%s)" % attn_type
+        elif isinstance(attn_type, bool):
+            raise NotImplemented
+            if attn_type:
+                module_cls = SEModule
+        else:
+            module_cls = attn_type
+    return module_cls
+
+
+def create_conv2d_pad(in_chs, out_chs, kernel_size, **kwargs):
+    padding = kwargs.pop('padding', '')
+    s = kwargs.pop('stride', None)
+    if s is not None:
+        kwargs.update({'strides': s})
+    d = kwargs.pop('dilation', None)
+    if d is not None:
+        kwargs.update({'dilation_rate': d})
+    assert padding in ['valid', 'same'], 'Not Implemented'
+    kwargs.setdefault('use_bias', kwargs.pop('bias', False))
+    if kwargs.get('groups', -1) == in_chs:
+        kwargs.pop('groups', None)
+        return tf.keras.layers.DepthwiseConv2D(kernel_size, padding=padding, **kwargs)
+    else:
+        return tf.keras.layers.Conv2D(out_chs, kernel_size, padding=padding, **kwargs)
+
+
+def create_pool2d(pool_type, kernel_size, stride=None, **kwargs):
+    stride = stride or kernel_size
+    padding = kwargs.pop('padding', '')
+    # padding, is_dynamic = get_padding_value(padding, kernel_size, stride=stride, **kwargs)
+    # padding = 'same', kernel_size = 3, stride = 2, kwargs = {} ==> padding, is_dynamic = 0, True
+    padding, is_dynamic = padding.lower(), True
+    if is_dynamic:
+        if pool_type == 'avg':
+            return AvgPool2dSame(kernel_size, stride=stride, **kwargs)
+        elif pool_type == 'max':
+            # return MaxPool2dSame(kernel_size, stride=stride, **kwargs)
+            return tf.keras.layers.MaxPooling2D(kernel_size, strides=stride, padding=padding.lower())
+        else:
+            assert False, f'Unsupported pool type {pool_type}'
+    else:
+        if pool_type == 'avg':
+            return nn.AvgPool2d(kernel_size, stride=stride, padding=padding, **kwargs)
+        elif pool_type == 'max':
+            return nn.MaxPool2d(kernel_size, stride=stride, padding=padding, **kwargs)
+        else:
+            assert False, f'Unsupported pool type {pool_type}'
+
+
+def create_conv2d(in_channels, out_channels, kernel_size, **kwargs):
+    """ Select a 2d convolution implementation based on arguments
+    Creates and returns one of torch.nn.Conv2d, Conv2dSame, MixedConv2d, or CondConv2d.
+
+    Used extensively by EfficientNet, MobileNetv3 and related networks.
+    """
+    if isinstance(kernel_size, list):
+        raise NotImplemented
+        assert 'num_experts' not in kwargs  # MixNet + CondConv combo not supported currently
+        if 'groups' in kwargs:
+            groups = kwargs.pop('groups')
+            if groups == in_channels:
+                kwargs['depthwise'] = True
+            else:
+                assert groups == 1
+        # We're going to use only lists for defining the MixedConv2d kernel groups,
+        # ints, tuples, other iterables will continue to pass to normal conv and specify h, w.
+        m = MixedConv2d(in_channels, out_channels, kernel_size, **kwargs)
+    else:
+        depthwise = kwargs.pop('depthwise', False)
+        # for DW out_channels must be multiple of in_channels as must have out_channels % groups == 0
+        groups = in_channels if depthwise else kwargs.pop('groups', 1)
+        if 'num_experts' in kwargs and kwargs['num_experts'] > 0:
+            raise NotImplemented
+            m = CondConv2d(in_channels, out_channels, kernel_size, groups=groups, **kwargs)
+        else:
+            m = create_conv2d_pad(in_channels, out_channels, kernel_size, groups=groups, **kwargs)
+    return m
+
+
+class SqueezeExcite:
+    """ Squeeze-and-Excitation w/ specific features for EfficientNet/MobileNet family
+
+    Args:
+        in_chs (int): input channels to layer
+        rd_ratio (float): ratio of squeeze reduction
+        act_layer (nn.Module): activation layer of containing block
+        gate_layer (Callable): attention gate function
+        force_act_layer (nn.Module): override block's activation fn if this is set/bound
+        rd_round_fn (Callable): specify a fn to calculate rounding of reduced chs
+    """
+
+    def __init__(
+            self, in_chs, rd_ratio=0.25, rd_channels=None, act_layer=tf.keras.layers.ReLU,
+            gate_layer=tf.sigmoid, force_act_layer=None, rd_round_fn=None, name=None):
+        name = handle_name(name)
+        if rd_channels is None:
+            rd_round_fn = rd_round_fn or round
+            rd_channels = rd_round_fn(in_chs * rd_ratio)
+        act_layer = force_act_layer or act_layer
+        # self.conv_reduce = nn.Conv2d(in_chs, rd_channels, 1, bias=True)
+        self.conv_reduce = tf.keras.layers.Conv2D(rd_channels, 1, name=name + 'conv_reduce')
+        self.act1 = create_act_layer(act_layer, name=name + 'act1')
+        # self.conv_expand = nn.Conv2d(rd_channels, in_chs, 1, bias=True)
+        self.conv_expand = tf.keras.layers.Conv2D(in_chs, 1, name=name + 'conv_expand')
+        self.gate = create_act_layer(gate_layer)
+
+    def __call__(self, x):
+        x_se = x.mean((2, 3), keepdim=True)
+        x_se = self.conv_reduce(x_se)
+        x_se = self.act1(x_se)
+        x_se = self.conv_expand(x_se)
+        return x * self.gate(x_se)
+
+
+class ConvBnAct:
+    """ Conv + Norm Layer + Activation w/ optional skip connection
+    """
+    def __init__(
+            self, in_chs, out_chs, kernel_size, stride=1, dilation=1, group_size=0, pad_type='',
+            skip=False, act_layer=tf.keras.layers.ReLU, norm_layer=tf.keras.layers.BatchNormalization,
+            drop_path_rate=0., name=None):
+        norm_act_layer = get_norm_act_layer(norm_layer, act_layer)
+        groups = num_groups(group_size, in_chs)
+        self.has_skip = skip and stride == 1 and in_chs == out_chs
+
+        self.conv = create_conv2d(
+            in_chs, out_chs, kernel_size, stride=stride, dilation=dilation, groups=groups, padding=pad_type)
+        self.bn1 = norm_act_layer(out_chs, inplace=True)
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate else nn.Identity()
+
+    def feature_info(self, location):
+        if location == 'expansion':  # output of conv after act, same as block coutput
+            return dict(module='bn1', hook_type='forward', num_chs=self.conv.filters)
+        else:  # location == 'bottleneck', block output
+            return dict(module='', num_chs=self.conv.filters)
+
+    def __call__(self, x):
+        shortcut = x
+        x = self.conv(x)
+        x = self.bn1(x)
+        if self.has_skip:
+            x = self.drop_path(x) + shortcut
+        return x
+
+
+class DepthwiseSeparableConv:
+    """ DepthwiseSeparable block
+    Used for DS convs in MobileNet-V1 and in the place of IR blocks that have no expansion
+    (factor of 1.0). This is an alternative to having a IR with an optional first pw conv.
+    """
+    def __init__(
+            self, in_chs, out_chs, dw_kernel_size=3, stride=1, dilation=1, group_size=1, pad_type='',
+            noskip=False, pw_kernel_size=1, pw_act=False, act_layer=tf.keras.layers.ReLU,
+            norm_layer=tf.keras.layers.BatchNormalization, se_layer=None, drop_path_rate=0., name=None):
+        norm_act_layer = get_norm_act_layer(norm_layer, act_layer)
+        groups = num_groups(group_size, in_chs)
+        self.has_skip = (stride == 1 and in_chs == out_chs) and not noskip
+        self.has_pw_act = pw_act  # activation after point-wise conv
+
+        self.conv_dw = create_conv2d(
+            in_chs, in_chs, dw_kernel_size, stride=stride, dilation=dilation, padding=pad_type,
+            groups=groups, name=name + '/conv_dw')
+        self.bn1 = norm_act_layer(in_chs, name=name + '/bn1')
+
+        # Squeeze-and-excitation
+        self.se = se_layer(in_chs, act_layer=act_layer, name=name + '/se') if se_layer else None
+
+        self.conv_pw = create_conv2d(in_chs, out_chs, pw_kernel_size, padding=pad_type, name=name + '/conv_pw')
+        self.bn2 = norm_act_layer(out_chs, inplace=True, apply_act=self.has_pw_act, name=name + '/bn2')
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate else None
+
+    def feature_info(self, location):
+        if location == 'expansion':  # after SE, input to PW
+            return dict(module='conv_pw', hook_type='forward_pre', num_chs=self.conv_pw.in_channels)
+        else:  # location == 'bottleneck', block output
+            return dict(module='', num_chs=self.conv_pw.filters)
+
+    def __call__(self, x):
+        shortcut = x
+        x = self.conv_dw(x)
+        x = self.bn1(x)
+        if self.se is not None:
+            x = self.se(x)
+        x = self.conv_pw(x)
+        x = self.bn2(x)
+        if self.has_skip:
+            if self.drop_path is not None:
+                x = self.drop_path(x)
+            x = x + shortcut
+        return x
+
+
+class InvertedResidual:
+    """ Inverted residual block w/ optional SE
+
+    Originally used in MobileNet-V2 - https://arxiv.org/abs/1801.04381v4, this layer is often
+    referred to as 'MBConv' for (Mobile inverted bottleneck conv) and is also used in
+      * MNasNet - https://arxiv.org/abs/1807.11626
+      * EfficientNet - https://arxiv.org/abs/1905.11946
+      * MobileNet-V3 - https://arxiv.org/abs/1905.02244
+    """
+
+    def __init__(
+            self, in_chs, out_chs, dw_kernel_size=3, stride=1, dilation=1, group_size=1, pad_type='',
+            noskip=False, exp_ratio=1.0, exp_kernel_size=1, pw_kernel_size=1, act_layer=tf.keras.layers.ReLU,
+            norm_layer=tf.keras.layers.BatchNormalization, se_layer=None, conv_kwargs=None, drop_path_rate=0.,
+            name=None):
+        norm_act_layer = get_norm_act_layer(norm_layer, act_layer)
+        conv_kwargs = conv_kwargs or {}
+        mid_chs = make_divisible(in_chs * exp_ratio)
+        groups = num_groups(group_size, mid_chs)
+        self.has_skip = (in_chs == out_chs and stride == 1) and not noskip
+
+        # Point-wise expansion
+        self.conv_pw = create_conv2d(in_chs, mid_chs, exp_kernel_size, padding=pad_type, name=name + '/conv_pw', **conv_kwargs)
+        self.bn1 = norm_act_layer(mid_chs, name=name + '/bn1')
+
+        # Depth-wise convolution
+        self.conv_dw = create_conv2d(
+            mid_chs, mid_chs, dw_kernel_size, stride=stride, dilation=dilation,
+            groups=groups, padding=pad_type, name=name + '/conv_dw', **conv_kwargs)
+        self.bn2 = norm_act_layer(mid_chs, name=name + '/bn2')
+
+        # Squeeze-and-excitation
+        self.se = se_layer(mid_chs, act_layer=act_layer) if se_layer else None
+
+        # Point-wise linear projection
+        self.conv_pwl = create_conv2d(mid_chs, out_chs, pw_kernel_size, padding=pad_type,
+                                      name=name + '/conv_pwl', **conv_kwargs)
+        self.bn3 = norm_act_layer(out_chs, apply_act=False, name=name + '/bn3')
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate else None
+
+    def feature_info(self, location):
+        if location == 'expansion':  # after SE, input to PWL
+            return dict(module='conv_pwl', hook_type='forward_pre', num_chs=self.conv_pwl.in_channels)
+        else:  # location == 'bottleneck', block output
+            return dict(module='', num_chs=self.conv_pwl.filters)
+
+    def __call__(self, x):
+        shortcut = x
+        x = self.conv_pw(x)
+        x = self.bn1(x)
+        x = self.conv_dw(x)
+        x = self.bn2(x)
+        if self.se is not None:
+            x = self.se(x)
+        x = self.conv_pwl(x)
+        x = self.bn3(x)
+        if self.has_skip:
+            if self.drop_path is not None:
+                x = self.drop_path(x)
+            x = x + shortcut
+        return x
+
+
+class CondConvResidual(InvertedResidual):
+    """ Inverted residual block w/ CondConv routing"""
+
+    def __init__(
+            self, in_chs, out_chs, dw_kernel_size=3, stride=1, dilation=1, group_size=1, pad_type='',
+            noskip=False, exp_ratio=1.0, exp_kernel_size=1, pw_kernel_size=1, act_layer=tf.keras.layers.ReLU,
+            norm_layer=tf.keras.layers.BatchNormalization, se_layer=None, num_experts=0, drop_path_rate=0.,
+            name=None):
+
+        self.num_experts = num_experts
+        conv_kwargs = dict(num_experts=self.num_experts)
+
+        super(CondConvResidual, self).__init__(
+            in_chs, out_chs, dw_kernel_size=dw_kernel_size, stride=stride, dilation=dilation, group_size=group_size,
+            pad_type=pad_type, act_layer=act_layer, noskip=noskip, exp_ratio=exp_ratio, exp_kernel_size=exp_kernel_size,
+            pw_kernel_size=pw_kernel_size, se_layer=se_layer, norm_layer=norm_layer, conv_kwargs=conv_kwargs,
+            drop_path_rate=drop_path_rate)
+
+        # self.routing_fn = nn.Linear(in_chs, self.num_experts)
+        self.routing_fn = tf.keras.layers.Dense(self.num_experts)
+
+    def __call__(self, x):
+        shortcut = x
+        pooled_inputs = F.adaptive_avg_pool2d(x, 1).flatten(1)  # CondConv routing
+        routing_weights = torch.sigmoid(self.routing_fn(pooled_inputs))
+        x = self.conv_pw(x, routing_weights)
+        x = self.bn1(x)
+        x = self.conv_dw(x, routing_weights)
+        x = self.bn2(x)
+        x = self.se(x)
+        x = self.conv_pwl(x, routing_weights)
+        x = self.bn3(x)
+        if self.has_skip:
+            x = self.drop_path(x) + shortcut
+        return x
+
+
+class EdgeResidual:
+    """ Residual block with expansion convolution followed by pointwise-linear w/ stride
+
+    Originally introduced in `EfficientNet-EdgeTPU: Creating Accelerator-Optimized Neural Networks with AutoML`
+        - https://ai.googleblog.com/2019/08/efficientnet-edgetpu-creating.html
+
+    This layer is also called FusedMBConv in the MobileDet, EfficientNet-X, and EfficientNet-V2 papers
+      * MobileDet - https://arxiv.org/abs/2004.14525
+      * EfficientNet-X - https://arxiv.org/abs/2102.05610
+      * EfficientNet-V2 - https://arxiv.org/abs/2104.00298
+    """
+
+    def __init__(
+            self, in_chs, out_chs, exp_kernel_size=3, stride=1, dilation=1, group_size=0, pad_type='',
+            force_in_chs=0, noskip=False, exp_ratio=1.0, pw_kernel_size=1, act_layer=tf.keras.layers.ReLU,
+            norm_layer=tf.keras.layers.BatchNormalization, se_layer=None, drop_path_rate=0.,
+            name=None):
+        norm_act_layer = get_norm_act_layer(norm_layer, act_layer)
+        if force_in_chs > 0:
+            mid_chs = make_divisible(force_in_chs * exp_ratio)
+        else:
+            mid_chs = make_divisible(in_chs * exp_ratio)
+        groups = num_groups(group_size, in_chs)
+        self.has_skip = (in_chs == out_chs and stride == 1) and not noskip
+
+        # Expansion convolution
+        self.conv_exp = create_conv2d(
+            in_chs, mid_chs, exp_kernel_size, stride=stride, dilation=dilation, groups=groups, padding=pad_type)
+        self.bn1 = norm_act_layer(mid_chs, inplace=True)
+
+        # Squeeze-and-excitation
+        self.se = se_layer(mid_chs, act_layer=act_layer) if se_layer else nn.Identity()
+
+        # Point-wise linear projection
+        self.conv_pwl = create_conv2d(mid_chs, out_chs, pw_kernel_size, padding=pad_type)
+        self.bn2 = norm_act_layer(out_chs, apply_act=False)
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate else nn.Identity()
+
+    def feature_info(self, location):
+        if location == 'expansion':  # after SE, before PWL
+            return dict(module='conv_pwl', hook_type='forward_pre', num_chs=self.conv_pwl.in_channels)
+        else:  # location == 'bottleneck', block output
+            return dict(module='', num_chs=self.conv_pwl.filters)
+
+    def __call__(self, x):
+        shortcut = x
+        x = self.conv_exp(x)
+        x = self.bn1(x)
+        x = self.se(x)
+        x = self.conv_pwl(x)
+        x = self.bn2(x)
+        if self.has_skip:
+            x = self.drop_path(x) + shortcut
+        return x
+
+
+class BatchNormAct2d:
+    """BatchNorm + Activation
+
+    This module performs BatchNorm + Activation in a manner that will remain backwards
+    compatible with weights trained with separate bn, act. This is why we inherit from BN
+    instead of composing it as a .bn member.
+    """
+    def __init__(
+            self,
+            num_features,
+            epsilon=1e-5,
+            momentum=0.1,
+            affine=True,
+            track_running_stats=True,
+            apply_act=True,
+            act_layer=tf.keras.layers.ReLU,
+            act_kwargs=None,
+            inplace=True,
+            drop_layer=None,
+            device=None,
+            dtype=None,
+            name=None
+    ):
+        assert affine, 'Not Implemented'
+        self.bn = tf.keras.layers.BatchNormalization(momentum=momentum, epsilon=epsilon, name=name)
+        if act_kwargs is None:
+            act_kwargs = {}
+        self.act = act_layer(**act_kwargs) if apply_act else None
+
+    def __call__(self, x):
+        x = self.bn(x)
+        if self.act is not None:
+            x = self.act(x)
+        return x
+
+
+_NORM_ACT_MAP = dict(batchnorm=BatchNormAct2d)
+_NORM_ACT_TYPES = {m for n, m in _NORM_ACT_MAP.items()}
+_NORM_ACT_REQUIRES_ARG = {BatchNormAct2d}
+
+
+def get_norm_act_layer(norm_layer, act_layer=None):
+    assert isinstance(norm_layer, (type, str,  types.FunctionType, partial))
+    # assert act_layer is None or isinstance(act_layer, (type, str, types.FunctionType, partial))
+    norm_act_kwargs = {}
+
+    # unbind partial fn, so args can be rebound later
+    if isinstance(norm_layer, partial):
+        norm_act_kwargs.update(norm_layer.keywords)
+        norm_layer = norm_layer.func
+
+    if isinstance(norm_layer, str):
+        raise NotImplemented
+        layer_name = norm_layer.replace('_', '').lower().split('-')[0]
+        norm_act_layer = _NORM_ACT_MAP.get(layer_name, None)
+    elif norm_layer in _NORM_ACT_TYPES:
+        norm_act_layer = norm_layer
+    elif isinstance(norm_layer,  types.FunctionType):
+        raise NotImplemented
+        # if function type, must be a lambda/fn that creates a norm_act layer
+        norm_act_layer = norm_layer
+    else:
+        type_name = norm_layer.__name__.lower()
+        if type_name.startswith('batchnormalization'):
+            norm_act_layer = BatchNormAct2d
+        elif type_name.startswith('groupnorm'):
+            raise NotImplemented
+            norm_act_layer = GroupNormAct
+        elif type_name.startswith('groupnorm1'):
+            raise NotImplemented
+            norm_act_layer = functools.partial(GroupNormAct, num_groups=1)
+        elif type_name.startswith('layernorm2d'):
+            raise NotImplemented
+            norm_act_layer = LayerNormAct2d
+        elif type_name.startswith('layernorm'):
+            raise NotImplemented
+            norm_act_layer = LayerNormAct
+        else:
+            assert False, f"No equivalent norm_act layer for {type_name}"
+
+    if norm_act_layer in _NORM_ACT_REQUIRES_ARG:
+        # pass `act_layer` through for backwards compat where `act_layer=None` implies no activation.
+        # In the future, may force use of `apply_act` with `act_layer` arg bound to relevant NormAct types
+        norm_act_kwargs.setdefault('act_layer', act_layer)
+    if norm_act_kwargs:
+        norm_act_layer = partial(norm_act_layer, **norm_act_kwargs)  # bind/rebind args
+    return norm_act_layer

--- a/tutorials/resources/efficientdet/effnet_blocks_keras.py
+++ b/tutorials/resources/efficientdet/effnet_blocks_keras.py
@@ -1,3 +1,18 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import types
 from functools import partial
 import tensorflow as tf

--- a/tutorials/resources/efficientdet/effnet_keras.py
+++ b/tutorials/resources/efficientdet/effnet_keras.py
@@ -7,8 +7,9 @@ from timm.models import parse_model_name, split_model_name_tag, is_model, build_
 from timm.models._efficientnet_builder import BN_EPS_TF_DEFAULT, decode_arch_def, round_channels
 from timm.models._builder import pretrained_cfg_for_features
 
-from effdet.effnet_blocks_keras import create_conv2d, SqueezeExcite, get_attn, handle_name, get_norm_act_layer, \
-    CondConvResidual, InvertedResidual, DepthwiseSeparableConv, EdgeResidual, ConvBnAct, BatchNormAct2d
+from tutorials.resources.efficientdet.effnet_blocks_keras import create_conv2d, SqueezeExcite, get_attn, \
+    handle_name, get_norm_act_layer, CondConvResidual, InvertedResidual, DepthwiseSeparableConv, EdgeResidual, \
+    ConvBnAct, BatchNormAct2d
 
 
 __all__ = ["EfficientNetBuilder", "decode_arch_def", "efficientnet_init_weights",

--- a/tutorials/resources/efficientdet/effnet_keras.py
+++ b/tutorials/resources/efficientdet/effnet_keras.py
@@ -1,0 +1,465 @@
+import os
+from functools import partial
+from typing import Any, Dict, Optional, Union, List
+from urllib.parse import urlsplit
+import tensorflow as tf
+from timm.models import parse_model_name, split_model_name_tag, is_model, build_model_with_cfg, FeatureInfo
+from timm.models._efficientnet_builder import BN_EPS_TF_DEFAULT, decode_arch_def, round_channels
+from timm.models._builder import pretrained_cfg_for_features
+
+from effdet.effnet_blocks_keras import create_conv2d, SqueezeExcite, get_attn, handle_name, get_norm_act_layer, \
+    CondConvResidual, InvertedResidual, DepthwiseSeparableConv, EdgeResidual, ConvBnAct, BatchNormAct2d
+
+
+__all__ = ["EfficientNetBuilder", "decode_arch_def", "efficientnet_init_weights",
+           'resolve_bn_args', 'resolve_act_layer', 'round_channels', 'BN_MOMENTUM_TF_DEFAULT', 'BN_EPS_TF_DEFAULT']
+
+
+def _log_info_if(_str, _versbose):
+    if _versbose:
+        print(_str)
+
+
+class EfficientNetBuilder:
+    """ Build Trunk Blocks
+
+    This ended up being somewhat of a cross between
+    https://github.com/tensorflow/tpu/blob/master/models/official/mnasnet/mnasnet_models.py
+    and
+    https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/maskrcnn_benchmark/modeling/backbone/fbnet_builder.py
+
+    """
+    def __init__(self, output_stride=32, pad_type='', round_chs_fn=round_channels, se_from_exp=False,
+                 act_layer=None, norm_layer=None, se_layer=None, drop_path_rate=0., feature_location=''):
+        self.output_stride = output_stride
+        self.pad_type = pad_type
+        self.round_chs_fn = round_chs_fn
+        self.se_from_exp = se_from_exp  # calculate se channel reduction from expanded (mid) chs
+        self.act_layer = act_layer
+        self.norm_layer = norm_layer
+        self.se_layer = get_attn(se_layer)
+        try:
+            self.se_layer(8, rd_ratio=1.0)  # test if attn layer accepts rd_ratio arg
+            self.se_has_ratio = True
+        except TypeError:
+            self.se_has_ratio = False
+        self.drop_path_rate = drop_path_rate
+        if feature_location == 'depthwise':
+            # old 'depthwise' mode renamed 'expansion' to match TF impl, old expansion mode didn't make sense
+            # _logger.warning("feature_location=='depthwise' is deprecated, using 'expansion'")
+            feature_location = 'expansion'
+        self.feature_location = feature_location
+        assert feature_location in ('bottleneck', 'expansion', '')
+        self.verbose = False
+
+        # state updated during build, consumed by model
+        self.in_chs = None
+        self.features = []
+
+    def _make_block(self, ba, block_idx, block_count, name):
+        drop_path_rate = self.drop_path_rate * block_idx / block_count
+        bt = ba.pop('block_type')
+        ba['name'] = name
+        ba['in_chs'] = self.in_chs
+        ba['out_chs'] = self.round_chs_fn(ba['out_chs'])
+        if 'force_in_chs' in ba and ba['force_in_chs']:
+            # NOTE this is a hack to work around mismatch in TF EdgeEffNet impl
+            ba['force_in_chs'] = self.round_chs_fn(ba['force_in_chs'])
+        ba['pad_type'] = self.pad_type
+        # block act fn overrides the model default
+        ba['act_layer'] = ba['act_layer'] if ba['act_layer'] is not None else self.act_layer
+        assert ba['act_layer'] is not None
+        ba['norm_layer'] = self.norm_layer
+        ba['drop_path_rate'] = drop_path_rate
+        if bt != 'cn':
+            se_ratio = ba.pop('se_ratio')
+            if se_ratio and self.se_layer is not None:
+                if not self.se_from_exp:
+                    # adjust se_ratio by expansion ratio if calculating se channels from block input
+                    se_ratio /= ba.get('exp_ratio', 1.0)
+                if self.se_has_ratio:
+                    ba['se_layer'] = partial(self.se_layer, rd_ratio=se_ratio)
+                else:
+                    ba['se_layer'] = self.se_layer
+
+        if bt == 'ir':
+            if self.verbose:
+                print('  InvertedResidual {}, Args: {}'.format(block_idx, str(ba)))
+            block = CondConvResidual(**ba) if ba.get('num_experts', 0) else InvertedResidual(**ba)
+        elif bt == 'ds' or bt == 'dsa':
+            if self.verbose:
+                print('  DepthwiseSeparable {}, Args: {}'.format(block_idx, str(ba)))
+            block = DepthwiseSeparableConv(**ba)
+        elif bt == 'er':
+            _log_info_if('  EdgeResidual {}, Args: {}'.format(block_idx, str(ba)), self.verbose)
+            block = EdgeResidual(**ba)
+        elif bt == 'cn':
+            _log_info_if('  ConvBnAct {}, Args: {}'.format(block_idx, str(ba)), self.verbose)
+            block = ConvBnAct(**ba)
+        else:
+            assert False, 'Uknkown block type (%s) while building model.' % bt
+
+        self.in_chs = ba['out_chs']  # update in_chs for arg of next block
+        return block
+
+    def __call__(self, in_chs, model_block_args, name=None):
+        """ Build the blocks
+        Args:
+            in_chs: Number of input-channels passed to first block
+            model_block_args: A list of lists, outer list defines stages, inner
+                list contains strings defining block configuration(s)
+        Return:
+             List of block stacks (each stack wrapped in nn.Sequential)
+        """
+        name = handle_name(name)
+        if self.verbose:
+            print('Building model trunk with %d stages...' % len(model_block_args))
+        self.in_chs = in_chs
+        total_block_count = sum([len(x) for x in model_block_args])
+        total_block_idx = 0
+        current_stride = 2
+        current_dilation = 1
+        stages = []
+        if model_block_args[0][0]['stride'] > 1:
+            # if the first block starts with a stride, we need to extract first level feat from stem
+            feature_info = dict(module='bn1', num_chs=in_chs, stage=0, reduction=current_stride)
+            self.features.append(feature_info)
+
+        # outer list of block_args defines the stacks
+        for stack_idx, stack_args in enumerate(model_block_args):
+            last_stack = stack_idx + 1 == len(model_block_args)
+            if self.verbose:
+                print('Stack: {}'.format(stack_idx))
+            assert isinstance(stack_args, list)
+
+            blocks = []
+            # each stack (stage of blocks) contains a list of block arguments
+            for block_idx, block_args in enumerate(stack_args):
+                last_block = block_idx + 1 == len(stack_args)
+                if self.verbose:
+                    print(' Block: {}'.format(block_idx))
+
+                assert block_args['stride'] in (1, 2)
+                if block_idx >= 1:   # only the first block in any stack can have a stride > 1
+                    block_args['stride'] = 1
+
+                extract_features = False
+                if last_block:
+                    next_stack_idx = stack_idx + 1
+                    extract_features = next_stack_idx >= len(model_block_args) or \
+                        model_block_args[next_stack_idx][0]['stride'] > 1
+
+                next_dilation = current_dilation
+                if block_args['stride'] > 1:
+                    next_output_stride = current_stride * block_args['stride']
+                    if next_output_stride > self.output_stride:
+                        next_dilation = current_dilation * block_args['stride']
+                        block_args['stride'] = 1
+                        if self.verbose:
+                            print('  Converting stride to dilation to maintain output_stride=={}'.format(
+                            self.output_stride))
+                    else:
+                        current_stride = next_output_stride
+                block_args['dilation'] = current_dilation
+                if next_dilation != current_dilation:
+                    current_dilation = next_dilation
+
+                # create the block
+                block = self._make_block(block_args, total_block_idx, total_block_count, f'{name}/{stack_idx}/{block_idx}')
+                blocks.append(block)
+
+                # stash feature module name and channel info for model feature extraction
+                if extract_features:
+                    feature_info = dict(
+                        stage=stack_idx + 1,
+                        reduction=current_stride,
+                        **block.feature_info(self.feature_location),
+                    )
+                    leaf_name = feature_info.get('module', '')
+                    if leaf_name:
+                        feature_info['module'] = '/'.join([f'blocks.{stack_idx}.{block_idx}', leaf_name])
+                    else:
+                        assert last_block
+                        feature_info['module'] = f'blocks.{stack_idx}'
+                    self.features.append(feature_info)
+
+                total_block_idx += 1  # incr global block idx (across all stacks)
+            stages.append(blocks)
+        return stages
+
+
+class EfficientNetFeatures:
+    """ EfficientNet Feature Extractor
+
+    A work-in-progress feature extraction module for EfficientNet, to use as a backbone for segmentation
+    and object detection models.
+    """
+
+    def __init__(
+            self,
+            block_args,
+            out_indices=(0, 1, 2, 3, 4),
+            feature_location='bottleneck',
+            in_chans=3,
+            stem_size=32,
+            fix_stem=False,
+            output_stride=32,
+            pad_type='',
+            round_chs_fn=round_channels,
+            act_layer=None,
+            norm_layer=None,
+            se_layer=None,
+            drop_rate=0.,
+            drop_path_rate=0.,
+            name=None
+    ):
+        name = handle_name(name)
+        act_layer = act_layer or tf.keras.layers.ReLU
+        norm_layer = norm_layer or tf.keras.layers.BatchNormalization
+        norm_act_layer = get_norm_act_layer(norm_layer, act_layer)
+        se_layer = se_layer or SqueezeExcite
+        self.drop_rate = drop_rate
+        self.grad_checkpointing = False
+
+        # Stem
+        if not fix_stem:
+            stem_size = round_chs_fn(stem_size)
+        self.conv_stem = create_conv2d(in_chans, stem_size, 3, stride=2, padding=pad_type, name=name + '/conv_stem')
+        self.bn1 = norm_act_layer(stem_size, name=name + '/bn1')
+
+        # Middle stages (IR/ER/DS Blocks)
+        builder = EfficientNetBuilder(
+            output_stride=output_stride,
+            pad_type=pad_type,
+            round_chs_fn=round_chs_fn,
+            act_layer=act_layer,
+            norm_layer=norm_layer,
+            se_layer=se_layer,
+            drop_path_rate=drop_path_rate,
+            feature_location=feature_location,
+        )
+        self.blocks = builder(stem_size, block_args, name=name + '/blocks')
+        self.feature_info = FeatureInfo(builder.features, out_indices)
+        self._stage_out_idx = {f['stage']: f['index'] for f in self.feature_info.get_dicts()}
+
+        # efficientnet_init_weights(self)
+
+        # Register feature extraction hooks with FeatureHooks helper
+        self.feature_hooks = None
+        if feature_location != 'bottleneck':
+            raise NotImplemented
+            hooks = self.feature_info.get_dicts(keys=('module', 'hook_type'))
+        #     self.feature_hooks = FeatureHooks(hooks, self.named_modules())
+
+    def set_grad_checkpointing(self, enable=True):
+        self.grad_checkpointing = enable
+
+    def __call__(self, x) -> List[tf.Tensor]:
+        x = self.conv_stem(x)
+        x = self.bn1(x)
+        if self.feature_hooks is None:
+            features = []
+            if 0 in self._stage_out_idx:
+                features.append(x)  # add stem out
+            for i, b in enumerate(self.blocks):
+                for bb in b:
+                    # print(i, type(b), type(bb))
+                    x = bb(x)
+                if i + 1 in self._stage_out_idx:
+                    features.append(x)
+            return features
+        else:
+            self.blocks(x)
+            out = self.feature_hooks.get_output(x.device)
+            return list(out.values())
+
+
+def _create_effnet(variant, pretrained=False, **kwargs):
+    features_mode = ''
+    model_cls = None  # EfficientNet
+    kwargs_filter = None
+    if kwargs.pop('features_only', False):
+        if 'feature_cfg' in kwargs:
+            features_mode = 'cfg'
+        else:
+            kwargs_filter = ('num_classes', 'num_features', 'head_conv', 'global_pool')
+            model_cls = EfficientNetFeatures
+            features_mode = 'cls'
+    else:
+        raise NotImplemented
+
+    model = build_model_with_cfg(
+        model_cls,
+        variant,
+        pretrained,
+        features_only=features_mode == 'cfg',
+        pretrained_strict=features_mode != 'cls',
+        kwargs_filter=kwargs_filter,
+        **kwargs,
+    )
+    if features_mode == 'cls':
+        model.pretrained_cfg = model.default_cfg = pretrained_cfg_for_features(model.pretrained_cfg)
+    return model
+
+
+def resolve_bn_args(kwargs):
+    bn_args = {}
+    bn_momentum = kwargs.pop('bn_momentum', None)
+    if bn_momentum is not None:
+        bn_args['momentum'] = bn_momentum
+    bn_eps = kwargs.pop('bn_eps', None)
+    if bn_eps is not None:
+        bn_args['epsilon'] = bn_eps
+    return bn_args
+
+
+def resolve_act_layer(kwargs, default='relu'):
+    act_name = kwargs.pop('act_layer', default)
+    if act_name == 'relu':
+        return tf.keras.layers.ReLU
+    elif act_name == 'relu6':
+        return partial(tf.keras.layers.ReLU, max_value=6.0)
+    else:
+        raise NotImplemented
+
+
+def _gen_efficientnet_lite(variant, channel_multiplier=1.0, depth_multiplier=1.0, pretrained=False, **kwargs):
+    """Creates an EfficientNet-Lite model.
+
+    Ref impl: https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet/lite
+    Paper: https://arxiv.org/abs/1905.11946
+
+    EfficientNet params
+    name: (channel_multiplier, depth_multiplier, resolution, dropout_rate)
+      'efficientnet-lite0': (1.0, 1.0, 224, 0.2),
+      'efficientnet-lite1': (1.0, 1.1, 240, 0.2),
+      'efficientnet-lite2': (1.1, 1.2, 260, 0.3),
+      'efficientnet-lite3': (1.2, 1.4, 280, 0.3),
+      'efficientnet-lite4': (1.4, 1.8, 300, 0.3),
+
+    Args:
+      channel_multiplier: multiplier to number of channels per layer
+      depth_multiplier: multiplier to number of repeats per stage
+    """
+    arch_def = [
+        ['ds_r1_k3_s1_e1_c16'],
+        ['ir_r2_k3_s2_e6_c24'],
+        ['ir_r2_k5_s2_e6_c40'],
+        ['ir_r3_k3_s2_e6_c80'],
+        ['ir_r3_k5_s1_e6_c112'],
+        ['ir_r4_k5_s2_e6_c192'],
+        ['ir_r1_k3_s1_e6_c320'],
+    ]
+    model_kwargs = dict(
+        block_args=decode_arch_def(arch_def, depth_multiplier, fix_first_last=True),
+        num_features=1280,
+        stem_size=32,
+        fix_stem=True,
+        round_chs_fn=partial(round_channels, multiplier=channel_multiplier),
+        act_layer=resolve_act_layer(kwargs, 'relu6'),
+        norm_layer=kwargs.pop('norm_layer', None) or partial(tf.keras.layers.BatchNormalization, **resolve_bn_args(kwargs)),
+        **kwargs,
+    )
+    model = _create_effnet(variant, pretrained, **model_kwargs)
+    return model
+
+
+def tf_efficientnet_lite0(pretrained=False, **kwargs):
+    """ EfficientNet-Lite0 """
+    # NOTE for train, drop_rate should be 0.2, drop_path_rate should be 0.2
+    kwargs['bn_eps'] = BN_EPS_TF_DEFAULT
+    kwargs['pad_type'] = 'same'
+    kwargs['name'] = 'backbone'
+    model = _gen_efficientnet_lite(
+        'tf_efficientnet_lite0', channel_multiplier=1.0, depth_multiplier=1.0, pretrained=pretrained, **kwargs)
+    return model
+
+
+model_entrypoints = {'tf_efficientnet_lite0': tf_efficientnet_lite0}
+
+
+def create_model(
+        model_name: str,
+        pretrained: bool = False,
+        pretrained_cfg: Optional[Union[str, Dict[str, Any], Any]] = None,
+        pretrained_cfg_overlay:  Optional[Dict[str, Any]] = None,
+        checkpoint_path: str = '',
+        scriptable: Optional[bool] = None,
+        exportable: Optional[bool] = None,
+        no_jit: Optional[bool] = None,
+        **kwargs,
+):
+    """Create a model.
+
+    Lookup model's entrypoint function and pass relevant args to create a new model.
+
+    <Tip>
+        **kwargs will be passed through entrypoint fn to ``timm.models.build_model_with_cfg()``
+        and then the model class __init__(). kwargs values set to None are pruned before passing.
+    </Tip>
+
+    Args:
+        model_name: Name of model to instantiate.
+        pretrained: If set to `True`, load pretrained ImageNet-1k weights.
+        pretrained_cfg: Pass in an external pretrained_cfg for model.
+        pretrained_cfg_overlay: Replace key-values in base pretrained_cfg with these.
+        checkpoint_path: Path of checkpoint to load _after_ the model is initialized.
+        scriptable: Set layer config so that model is jit scriptable (not working for all models yet).
+        exportable: Set layer config so that model is traceable / ONNX exportable (not fully impl/obeyed yet).
+        no_jit: Set layer config so that model doesn't utilize jit scripted layers (so far activations only).
+
+    Keyword Args:
+        drop_rate (float): Classifier dropout rate for training.
+        drop_path_rate (float): Stochastic depth drop rate for training.
+        global_pool (str): Classifier global pooling type.
+
+    Example:
+
+    ```py
+    >>> from timm import create_model
+
+    >>> # Create a MobileNetV3-Large model with no pretrained weights.
+    >>> model = create_model('mobilenetv3_large_100')
+
+    >>> # Create a MobileNetV3-Large model with pretrained weights.
+    >>> model = create_model('mobilenetv3_large_100', pretrained=True)
+    >>> model.num_classes
+    1000
+
+    >>> # Create a MobileNetV3-Large model with pretrained weights and a new head with 10 classes.
+    >>> model = create_model('mobilenetv3_large_100', pretrained=True, num_classes=10)
+    >>> model.num_classes
+    10
+    ```
+    """
+    # Parameters that aren't supported by all models or are intended to only override model defaults if set
+    # should default to None in command line args/cfg. Remove them if they are present and not set so that
+    # non-supporting models don't break and default args remain in effect.
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+    model_source, model_name = parse_model_name(model_name)
+    if model_source == 'hf-hub':
+        assert not pretrained_cfg, 'pretrained_cfg should not be set when sourcing model from Hugging Face Hub.'
+        # For model names specified in the form `hf-hub:path/architecture_name@revision`,
+        # load model weights + pretrained_cfg from Hugging Face hub.
+        raise NotImplemented
+        # pretrained_cfg, model_name = load_model_config_from_hf(model_name)
+    else:
+        model_name, pretrained_tag = split_model_name_tag(model_name)
+        if pretrained_tag and not pretrained_cfg:
+            # a valid pretrained_cfg argument takes priority over tag in model name
+            pretrained_cfg = pretrained_tag
+
+    if not is_model(model_name):
+        raise RuntimeError('Unknown model (%s)' % model_name)
+
+    create_fn = model_entrypoints[model_name]
+    # with set_layer_config(scriptable=scriptable, exportable=exportable, no_jit=no_jit):
+    model = create_fn(
+        pretrained=pretrained,
+        pretrained_cfg=pretrained_cfg,
+        pretrained_cfg_overlay=pretrained_cfg_overlay,
+        **kwargs,
+    )
+
+    return model

--- a/tutorials/resources/efficientdet/effnet_keras.py
+++ b/tutorials/resources/efficientdet/effnet_keras.py
@@ -1,7 +1,20 @@
-import os
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 from functools import partial
 from typing import Any, Dict, Optional, Union, List
-from urllib.parse import urlsplit
 import tensorflow as tf
 from timm.models import parse_model_name, split_model_name_tag, is_model, build_model_with_cfg, FeatureInfo
 from timm.models._efficientnet_builder import BN_EPS_TF_DEFAULT, decode_arch_def, round_channels
@@ -14,6 +27,12 @@ from tutorials.resources.efficientdet.effnet_blocks_keras import create_conv2d, 
 
 __all__ = ["EfficientNetBuilder", "decode_arch_def", "efficientnet_init_weights",
            'resolve_bn_args', 'resolve_act_layer', 'round_channels', 'BN_MOMENTUM_TF_DEFAULT', 'BN_EPS_TF_DEFAULT']
+
+
+# #######################################################################################
+# This file generates the Keras model. It's based on the EfficientNet code in the timm
+# repository, and switched the Torch Modules with Keras layers
+# #######################################################################################
 
 
 def _log_info_if(_str, _versbose):

--- a/tutorials/resources/utils/__init__.py
+++ b/tutorials/resources/utils/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 # ==============================================================================
 
-from tutorials.resources.utils.weights_translation import load_state_dict
+from tutorials.resources.utils.torch2keras_weights_translation import load_state_dict

--- a/tutorials/resources/utils/__init__.py
+++ b/tutorials/resources/utils/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from tutorials.resources.utils.weights_translation import load_state_dict

--- a/tutorials/resources/utils/weights_translation.py
+++ b/tutorials/resources/utils/weights_translation.py
@@ -1,0 +1,107 @@
+from typing import Dict
+import tensorflow as tf
+import numpy as np
+
+
+ln_patch = False
+
+
+def weight_translation(keras_name, pytorch_weights_dict, layer):
+    keras_name = keras_name.replace('/', '.')
+    if ln_patch and (isinstance(layer, tf.keras.layers.LayerNormalization) or
+                     (isinstance(layer, tf.keras.layers.BatchNormalization) and '_bn_patch' in layer.name)):
+        if isinstance(layer, tf.keras.layers.LayerNormalization):
+            if '.beta:0' in keras_name:
+                value = layer.weights[1].numpy()
+                assert np.all(value == 0), 'Ahh'
+            elif '.gamma:0' in keras_name:
+                value = layer.weights[0].numpy()
+                assert np.all(value == 1), 'Ahh'
+            else:
+                raise Exception('ahh')
+        elif isinstance(layer, tf.keras.layers.BatchNormalization):
+            if '.beta:0' in keras_name:
+                value = pytorch_weights_dict.pop(keras_name.replace('_bn_patch', '').replace(".beta:0", ".bias"))
+            elif '.gamma:0' in keras_name:
+                value = pytorch_weights_dict.pop(keras_name.replace('_bn_patch', '').replace(".gamma:0", ".weight"))
+            elif '.moving_mean:0' in keras_name:
+                value = layer.weights[2].numpy()
+                assert np.all(value == 0), 'Ahh'
+            elif '.moving_variance:0' in keras_name:
+                value = layer.weights[3].numpy()
+                assert np.all(value == 1), 'Ahh'
+            else:
+                raise Exception('ahh')
+        else:
+            raise NotImplemented
+    # Handling MHA layers
+    elif isinstance(layer, tf.keras.layers.MultiHeadAttention):
+        if '.bias:0' in keras_name:
+            if '.query.' in keras_name:
+                value = pytorch_weights_dict[keras_name.replace(".query.bias:0", ".qkv_proj.bias")]
+                value = value[:int(value.shape[0]/3)].reshape((layer._num_heads, -1))
+            elif '.key.' in keras_name:
+                value = pytorch_weights_dict[keras_name.replace(".key.bias:0", ".qkv_proj.bias")]
+                value = value[int(value.shape[0] / 3):2*int(value.shape[0] / 3)].reshape((layer._num_heads, -1))
+            elif '.value.' in keras_name:
+                value = pytorch_weights_dict[keras_name.replace(".value.bias:0", ".qkv_proj.bias")]
+                value = value[2*int(value.shape[0] / 3):].reshape((layer._num_heads, -1))
+            elif '.attention_output.' in keras_name:  # or '.key.' in keras_name or '.value.' in keras_name:
+                value = pytorch_weights_dict[keras_name.replace(".attention_output.bias:0", ".out_proj.bias")]
+            else:
+                raise Exception('ahh')
+        elif '.query.' in keras_name:
+            value = pytorch_weights_dict[keras_name.replace(".query.kernel:0", ".qkv_proj.weight")]
+            value = value[:int(value.shape[0]/3), :].transpose().reshape((int(value.shape[0]/3), layer._num_heads, -1))
+        elif '.key.' in keras_name:
+            value = pytorch_weights_dict[keras_name.replace(".key.kernel:0", ".qkv_proj.weight")]
+            value = value[int(value.shape[0] / 3):2 * int(value.shape[0] / 3), :].transpose().reshape((int(value.shape[0]/3), layer._num_heads, -1))
+        elif '.value.' in keras_name:
+            value = pytorch_weights_dict[keras_name.replace(".value.kernel:0", ".qkv_proj.weight")]
+            value = value[2*int(value.shape[0] / 3):, :].transpose().reshape((int(value.shape[0]/3), layer._num_heads, -1))
+        elif '.attention_output.' in keras_name:  # or '.key.' in keras_name or '.value.' in keras_name:
+            value = pytorch_weights_dict[keras_name.replace(".attention_output.kernel:0", ".out_proj.weight")]
+            value = value.transpose().reshape((layer._num_heads, -1, value.shape[-1]))
+        else:
+            raise Exception('unknown weight in MHA')
+
+    # Handle Convolution layers
+    elif '.depthwise_kernel:0' in keras_name:
+        value = pytorch_weights_dict.pop(keras_name.replace(".depthwise_kernel:0", ".weight")).transpose((2, 3, 0, 1))
+    elif '.kernel:0' in keras_name:
+        if isinstance(layer, tf.keras.layers.Dense):
+            value = pytorch_weights_dict.pop(keras_name.replace(".kernel:0", ".weight")).transpose((1, 0))
+        else:
+            value = pytorch_weights_dict.pop(keras_name.replace(".kernel:0", ".weight"))
+            if len(value.shape) == 2:
+                assert layer.kernel_size == (1, 1), "Error: Thie code is for converting Dense kernels to conv1x1"
+                value = value.transpose().reshape(layer.kernel._shape_tuple())
+            else:
+                value = value.transpose((2, 3, 1, 0))
+    elif '.bias:0' in keras_name:
+        value = pytorch_weights_dict.pop(keras_name.replace(".bias:0", ".bias"))
+
+    # Handle normalization layers
+    elif '.beta:0' in keras_name:
+        value = pytorch_weights_dict.pop(keras_name.replace(".beta:0", ".bias"))
+    elif '.gamma:0' in keras_name:
+        value = pytorch_weights_dict.pop(keras_name.replace(".gamma:0", ".weight"))
+    elif '.moving_mean:0' in keras_name:
+        value = pytorch_weights_dict.pop(keras_name.replace(".moving_mean:0", ".running_mean"))
+    elif '.moving_variance:0' in keras_name:
+        value = pytorch_weights_dict.pop(keras_name.replace(".moving_variance:0", ".running_var"))
+    else:
+        value = pytorch_weights_dict.pop(keras_name)
+    return value
+
+
+def load_state_dict(model: tf.keras.Model, state_dict: Dict[str, np.ndarray]):
+    for layer in model.layers:
+        for w in layer.weights:
+            w.assign(weight_translation(w.name, state_dict, layer))
+
+    # look for variables not assigned in torch state dict
+    for k in state_dict:
+        if 'num_batches_tracked' in k:
+            continue
+        print(f'  WARNING: {k} not assigned to keras model !!!')


### PR DESCRIPTION
This PR adds the code for porting the EfficientDet-lite0 pretrained model from [EffDet](https://github.com/rwightman/efficientdet-pytorch) to a keras model with a custom post-processing layer from [sony-custom-layer](https://github.com/sony/custom_layers).

Also added a tutorail notebook for porting the model and quantizing it with MCT