### PR TITLE
Hessian scores variables and methods names modification

### DIFF
--- a/model_compression_toolkit/constants.py
+++ b/model_compression_toolkit/constants.py
@@ -118,9 +118,9 @@ WEIGHTS_CHANNELS_AXIS = 'weights_channels_axis'
 DUMMY_NODE = 'dummy_node'
 DUMMY_TENSOR = 'dummy_tensor'
 
-# Jacobian-weights constants
-MIN_JACOBIANS_ITER = 10
-JACOBIANS_COMP_TOLERANCE = 1e-3
+# Hessian scores constants
+MIN_HESSIAN_ITER = 10
+HESSIAN_COMP_TOLERANCE = 1e-3
 
 
 # Hessian configuration default constants

--- a/model_compression_toolkit/core/common/hessian/hessian_info_utils.py
+++ b/model_compression_toolkit/core/common/hessian/hessian_info_utils.py
@@ -17,7 +17,7 @@ import numpy as np
 from model_compression_toolkit.constants import EPS
 
 
-def normalize_weights(hessian_approximations: List) -> np.ndarray:
+def normalize_scores(hessian_approximations: List) -> np.ndarray:
     """
     Normalize Hessian information approximations by dividing the trace Hessian approximations value by the sum of all
     other values.

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_quantization_config.py
@@ -30,8 +30,8 @@ class MixedPrecisionQuantizationConfigV2:
                  num_of_images: int = 32,
                  configuration_overwrite: List[int] = None,
                  num_interest_points_factor: float = 1.0,
-                 use_grad_based_weights: bool = True,
-                 norm_weights: bool = True,
+                 use_hessian_based_scores: bool = True,
+                 norm_scores: bool = True,
                  refine_mp_solution: bool = True,
                  metric_normalization_threshold: float = 1e10):
         """
@@ -45,8 +45,8 @@ class MixedPrecisionQuantizationConfigV2:
             num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
             configuration_overwrite (List[int]): A list of integers that enables overwrite of mixed precision with a predefined one.
             num_interest_points_factor (float): A multiplication factor between zero and one (represents percentage) to reduce the number of interest points used to calculate the distance metric.
-            use_grad_based_weights (bool): Whether to use Hessian-based scores for weighted average distance metric computation.
-            norm_weights (bool): Whether to normalize the returned weights (to get values between 0 and 1).
+            use_hessian_based_scores (bool): Whether to use Hessian-based scores for weighted average distance metric computation.
+            norm_scores (bool): Whether to normalize the returned scores for the weighted distance metric (to get values between 0 and 1).
             refine_mp_solution (bool): Whether to try to improve the final mixed-precision configuration using a greedy algorithm that searches layers to increase their bit-width, or not.
             metric_normalization_threshold (float): A threshold for checking the mixed precision distance metric values, In case of values larger than this threshold, the metric will be scaled to prevent numerical issues.
 
@@ -64,8 +64,8 @@ class MixedPrecisionQuantizationConfigV2:
                                                         "thus, it should be between 0 to 1"
         self.num_interest_points_factor = num_interest_points_factor
 
-        self.use_grad_based_weights = use_grad_based_weights
-        self.norm_weights = norm_weights
+        self.use_hessian_based_scores = use_hessian_based_scores
+        self.norm_scores = norm_scores
 
         self.metric_normalization_threshold = metric_normalization_threshold
 

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -76,7 +76,7 @@ class SensitivityEvaluation:
         self.fw_impl = fw_impl
         self.set_layer_to_bitwidth = set_layer_to_bitwidth
         self.disable_activation_for_metric = disable_activation_for_metric
-        if self.quant_config.use_grad_based_weights:
+        if self.quant_config.use_hessian_based_scores:
             if not isinstance(hessian_info_service, HessianInfoService):
                 Logger.error(f"When using hessian based approximations for sensitivity evaluation, "
                              f" an HessianInfoService object must be provided but is {hessian_info_service}")
@@ -125,7 +125,7 @@ class SensitivityEvaluation:
         # Computing Hessian-based scores for weighted average distance metric computation (only if requested),
         # and assigning distance_weighting method accordingly.
         self.interest_points_hessians = None
-        if self.quant_config.use_grad_based_weights  is True:
+        if self.quant_config.use_hessian_based_scores is True:
             self.interest_points_hessians = self._compute_hessian_based_scores()
             self.quant_config.distance_weighting_method = lambda d: self.interest_points_hessians
 
@@ -263,9 +263,9 @@ class SensitivityEvaluation:
                 # Append the single approximation value to the list for the current image
                 approx_by_image_per_interest_point.append(compare_point_to_trace_hessian_approximations[target_node][image_idx][0])
 
-            if self.quant_config.norm_weights:
+            if self.quant_config.norm_scores:
                 approx_by_image_per_interest_point = \
-                    hessian_utils.normalize_weights(hessian_approximations=approx_by_image_per_interest_point)
+                    hessian_utils.normalize_scores(hessian_approximations=approx_by_image_per_interest_point)
 
             # Append the approximations for the current image to the main list
             approx_by_image.append(approx_by_image_per_interest_point)

--- a/model_compression_toolkit/core/keras/hessian/activation_trace_hessian_calculator_keras.py
+++ b/model_compression_toolkit/core/keras/hessian/activation_trace_hessian_calculator_keras.py
@@ -20,7 +20,7 @@ from tensorflow.python.keras.engine.base_layer import Layer
 from tqdm import tqdm
 import numpy as np
 
-from model_compression_toolkit.constants import MIN_JACOBIANS_ITER, JACOBIANS_COMP_TOLERANCE, EPS, \
+from model_compression_toolkit.constants import MIN_HESSIAN_ITER, HESSIAN_COMP_TOLERANCE, EPS, \
     HESSIAN_NUM_ITERATIONS
 from model_compression_toolkit.core.common.graph.edge import EDGE_SINK_INDEX
 from model_compression_toolkit.core.common import Graph, BaseNode
@@ -79,7 +79,7 @@ class ActivationTraceHessianCalculatorKeras(TraceHessianCalculatorKeras):
                 trace_approx_by_node = []
                 # Loop through each interest point activation tensor
                 for ipt in tqdm(interest_points_tensors):  # Per Interest point activation tensor
-                    interest_point_scores = [] # List to store scores for each interest point
+                    interest_point_scores = []  # List to store scores for each interest point
                     for j in range(self.num_iterations_for_approximation):  # Approximation iterations
                         # Getting a random vector with normal distribution
                         v = tf.random.normal(shape=output.shape)
@@ -106,7 +106,7 @@ class ActivationTraceHessianCalculatorKeras(TraceHessianCalculatorKeras):
 
                             # If the change to the mean approximation is insignificant (to all outputs)
                             # we stop the calculation.
-                            if j > MIN_JACOBIANS_ITER:
+                            if j > MIN_HESSIAN_ITER:
                                 new_mean_per_output = []
                                 delta_per_output = []
                                 # Compute new means and deltas for each output index
@@ -118,7 +118,7 @@ class ActivationTraceHessianCalculatorKeras(TraceHessianCalculatorKeras):
                                     delta_per_output.append(delta)
 
                                 # Check if all outputs have converged
-                                is_converged = all([np.abs(delta) / (np.abs(new_mean) + 1e-6) < JACOBIANS_COMP_TOLERANCE for delta, new_mean in zip(delta_per_output, new_mean_per_output)])
+                                is_converged = all([np.abs(delta) / (np.abs(new_mean) + 1e-6) < HESSIAN_COMP_TOLERANCE for delta, new_mean in zip(delta_per_output, new_mean_per_output)])
                                 if is_converged:
                                     interest_point_scores.append(score_approx_per_output)
                                     break

--- a/model_compression_toolkit/core/keras/hessian/weights_trace_hessian_calculator_keras.py
+++ b/model_compression_toolkit/core/keras/hessian/weights_trace_hessian_calculator_keras.py
@@ -17,7 +17,7 @@ import numpy as np
 import tensorflow as tf
 from typing import List
 
-from model_compression_toolkit.constants import HESSIAN_NUM_ITERATIONS, MIN_JACOBIANS_ITER, JACOBIANS_COMP_TOLERANCE, HESSIAN_EPS
+from model_compression_toolkit.constants import HESSIAN_NUM_ITERATIONS, MIN_HESSIAN_ITER, HESSIAN_COMP_TOLERANCE, HESSIAN_EPS
 from model_compression_toolkit.core.common import Graph
 from model_compression_toolkit.core.common.hessian import TraceHessianRequest, HessianInfoGranularity
 from model_compression_toolkit.core.keras.back2framework.float_model_builder import FloatKerasModelBuilder
@@ -120,11 +120,11 @@ class WeightsTraceHessianCalculatorKeras(TraceHessianCalculatorKeras):
 
                     # If the change to the mean approximation is insignificant (to all outputs)
                     # we stop the calculation.
-                    if j > MIN_JACOBIANS_ITER:
+                    if j > MIN_HESSIAN_ITER:
                         # Compute new means and deltas
                         new_mean = tf.reduce_mean(tf.stack(approximation_per_iteration + approx), axis=0)
                         delta = new_mean - tf.reduce_mean(tf.stack(approximation_per_iteration), axis=0)
-                        is_converged = np.all(np.abs(delta) / (np.abs(new_mean) + HESSIAN_EPS) < JACOBIANS_COMP_TOLERANCE)
+                        is_converged = np.all(np.abs(delta) / (np.abs(new_mean) + HESSIAN_EPS) < HESSIAN_COMP_TOLERANCE)
                         if is_converged:
                             approximation_per_iteration.append(approx)
                             break

--- a/model_compression_toolkit/core/pytorch/hessian/weights_trace_hessian_calculator_pytorch.py
+++ b/model_compression_toolkit/core/pytorch/hessian/weights_trace_hessian_calculator_pytorch.py
@@ -24,7 +24,7 @@ from model_compression_toolkit.core.pytorch.hessian.trace_hessian_calculator_pyt
 from model_compression_toolkit.logger import Logger
 from model_compression_toolkit.core.pytorch.back2framework.float_model_builder import FloatPyTorchModelBuilder
 from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
-from model_compression_toolkit.constants import HESSIAN_NUM_ITERATIONS, MIN_JACOBIANS_ITER, JACOBIANS_COMP_TOLERANCE, HESSIAN_EPS
+from model_compression_toolkit.constants import HESSIAN_NUM_ITERATIONS, MIN_HESSIAN_ITER, HESSIAN_COMP_TOLERANCE, HESSIAN_EPS
 
 
 class WeightsTraceHessianCalculatorPytorch(TraceHessianCalculatorPytorch):
@@ -112,10 +112,10 @@ class WeightsTraceHessianCalculatorPytorch(TraceHessianCalculatorPytorch):
             if len(shape_channel_axis) > 0:
                 approx = torch.sum(approx, dim=shape_channel_axis)
 
-            if j > MIN_JACOBIANS_ITER:
+            if j > MIN_HESSIAN_ITER:
                 new_mean = (torch.sum(torch.stack(approximation_per_iteration), dim=0) + approx)/(j+1)
                 delta = new_mean - torch.mean(torch.stack(approximation_per_iteration), dim=0)
-                converged_tensor = torch.abs(delta) / (torch.abs(new_mean) + HESSIAN_EPS) < JACOBIANS_COMP_TOLERANCE
+                converged_tensor = torch.abs(delta) / (torch.abs(new_mean) + HESSIAN_EPS) < HESSIAN_COMP_TOLERANCE
                 if torch.all(converged_tensor):
                     break
 

--- a/model_compression_toolkit/gptq/__init__.py
+++ b/model_compression_toolkit/gptq/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig, RoundingType, GradientPTQConfigV2, GPTQHessianWeightsConfig
+from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig, RoundingType, GradientPTQConfigV2, GPTQHessianScoresConfig
 from model_compression_toolkit.gptq.keras.quantization_facade import keras_gradient_post_training_quantization_experimental
 from model_compression_toolkit.gptq.keras.quantization_facade import get_keras_gptq_config
 from model_compression_toolkit.gptq.pytorch.quantization_facade import pytorch_gradient_post_training_quantization_experimental

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -29,14 +29,14 @@ class RoundingType(Enum):
     SoftQuantizer = 1
 
 
-class GPTQHessianWeightsConfig:
+class GPTQHessianScoresConfig:
     """
-    Configuration to use for computing the Hessian-based weights for GPTQ loss metric.
+    Configuration to use for computing the Hessian-based scores for GPTQ loss metric.
     """
 
     def __init__(self,
                  hessians_num_samples: int = 16,
-                 norm_weights: bool = True,
+                 norm_scores: bool = True,
                  log_norm: bool = True,
                  scale_log_norm: bool = False,
                  hessians_n_iter: int = 50): #TODO: remove
@@ -45,15 +45,15 @@ class GPTQHessianWeightsConfig:
         Initialize a GPTQHessianWeightsConfig.
 
         Args:
-            hessians_num_samples (int): Number of samples to use for computing the Hessian-based weights.
-            norm_weights (bool): Whether to normalize the returned weights (to get values between 0 and 1).
-            log_norm (bool): Whether to use log normalization to the GPTQ Hessian-based weights.
-            scale_log_norm (bool): Whether to scale the final vector of the Hessian weights.
-            hessians_n_iter (int): Number of random iterations to run Hessian approximation for GPTQ weights.
+            hessians_num_samples (int): Number of samples to use for computing the Hessian-based scores.
+            norm_scores (bool): Whether to normalize the returned scores of the weighted loss function (to get values between 0 and 1).
+            log_norm (bool): Whether to use log normalization for the GPTQ Hessian-based scores.
+            scale_log_norm (bool): Whether to scale the final vector of the Hessian-based scores.
+            hessians_n_iter (int): Number of random iterations to run Hessian approximation for GPTQ Hessian-based scores.
         """
 
         self.hessians_num_samples = hessians_num_samples
-        self.norm_weights = norm_weights
+        self.norm_scores = norm_scores
         self.log_norm = log_norm
         self.scale_log_norm = scale_log_norm
         self.hessians_n_iter = hessians_n_iter
@@ -75,7 +75,7 @@ class GradientPTQConfig:
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
                  regularization_factor: float = REG_DEFAULT,
-                 hessian_weights_config: GPTQHessianWeightsConfig = GPTQHessianWeightsConfig(),
+                 hessian_weights_config: GPTQHessianScoresConfig = GPTQHessianScoresConfig(),
                  gptq_quantizer_params_override: Dict[str, Any] = None):
         """
         Initialize a GradientPTQConfig.
@@ -94,7 +94,7 @@ class GradientPTQConfig:
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizer for bias.
             regularization_factor (float): A floating point number that defines the regularization factor.
-            hessian_weights_config (GPTQHessianWeightsConfig): A configuration that include all necessary arguments to run a computation of Hessian weights for the GPTQ loss.
+            hessian_weights_config (GPTQHessianScoresConfig): A configuration that include all necessary arguments to run a computation of Hessian scores for the GPTQ loss.
             gptq_quantizer_params_override (dict): A dictionary of parameters to override in GPTQ quantizer instantiation. Defaults to None (no parameters).
 
         """
@@ -131,7 +131,7 @@ class GradientPTQConfigV2(GradientPTQConfig):
                  optimizer_quantization_parameter: Any = None,
                  optimizer_bias: Any = None,
                  regularization_factor: float = REG_DEFAULT,
-                 hessian_weights_config: GPTQHessianWeightsConfig = GPTQHessianWeightsConfig(),
+                 hessian_weights_config: GPTQHessianScoresConfig = GPTQHessianScoresConfig(),
                  gptq_quantizer_params_override: Dict[str, Any] = None):
         """
         Initialize a GradientPTQConfigV2.
@@ -150,7 +150,7 @@ class GradientPTQConfigV2(GradientPTQConfig):
             optimizer_quantization_parameter (Any): Optimizer to override the rest optimizer  for quantizer parameters.
             optimizer_bias (Any): Optimizer to override the rest optimizerfor bias.
             regularization_factor (float): A floating point number that defines the regularization factor.
-            hessian_weights_config (GPTQHessianWeightsConfig): A configuration that include all necessary arguments to run a computation of Hessian weights for the GPTQ loss.
+            hessian_weights_config (GPTQHessianScoresConfig): A configuration that include all necessary arguments to run a computation of Hessian scores for the GPTQ loss.
             gptq_quantizer_params_override (dict): A dictionary of parameters to override in GPTQ quantizer instantiation. Defaults to None (no parameters).
 
         """

--- a/model_compression_toolkit/gptq/common/gptq_training.py
+++ b/model_compression_toolkit/gptq/common/gptq_training.py
@@ -204,8 +204,8 @@ class GPTQTrainer(ABC):
         trace_hessian_approx_by_image = []
         for image_idx in range(self.gptq_config.hessian_weights_config.hessians_num_samples):
             approx_by_interest_point = self._get_approximations_by_interest_point(approximations, image_idx)
-            if self.gptq_config.hessian_weights_config.norm_weights:
-                approx_by_interest_point = hessian_utils.normalize_weights(approx_by_interest_point)
+            if self.gptq_config.hessian_weights_config.norm_scores:
+                approx_by_interest_point = hessian_utils.normalize_scores(approx_by_interest_point)
             trace_hessian_approx_by_image.append(approx_by_interest_point)
         return trace_hessian_approx_by_image
 

--- a/tests/keras_tests/custom_layers_tests/test_sony_ssd_postprocess_layer.py
+++ b/tests/keras_tests/custom_layers_tests/test_sony_ssd_postprocess_layer.py
@@ -49,7 +49,7 @@ class TestSonySsdPostProcessLayer(unittest.TestCase):
 
         core_config = mct.core.CoreConfig(
             mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(
-                use_grad_based_weights=False))
+                use_hessian_based_scores=False))
         q_model, _ = mct.ptq.keras_post_training_quantization_experimental(model,
                                                                            get_rep_dataset(2, (1, 8, 8, 3)),
                                                                            core_config=core_config,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq/gptq_test.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 import model_compression_toolkit as mct
 from model_compression_toolkit.core import DefaultDict
 from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig, RoundingType, GradientPTQConfigV2, \
-    GPTQHessianWeightsConfig
+    GPTQHessianScoresConfig
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.core.common.user_info import UserInformation
 from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEARNING_STR, MAX_LSB_STR
@@ -81,18 +81,18 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
 
     def get_quantization_config(self):
         return mct.core.QuantizationConfig(activation_error_method=mct.core.QuantizationErrorMethod.NOCLIPPING,
-                                      weights_error_method=mct.core.QuantizationErrorMethod.NOCLIPPING,
-                                      relu_bound_to_power_of_2=True,
-                                      weights_bias_correction=False,
-                                      weights_per_channel_threshold=self.per_channel)
+                                           weights_error_method=mct.core.QuantizationErrorMethod.NOCLIPPING,
+                                           relu_bound_to_power_of_2=True,
+                                           weights_bias_correction=False,
+                                           weights_per_channel_threshold=self.per_channel)
 
     def get_gptq_config(self):
         return GradientPTQConfig(5, optimizer=tf.keras.optimizers.Adam(
             learning_rate=0.0001), optimizer_rest=tf.keras.optimizers.Adam(
             learning_rate=0.0001), loss=multiple_tensors_mse_loss, train_bias=True, rounding_type=self.rounding_type,
                                  use_hessian_based_weights=self.hessian_weights,
-                                 hessian_weights_config=GPTQHessianWeightsConfig(log_norm=self.log_norm_weights,
-                                                                                 scale_log_norm=self.scaled_log_norm),
+                                 hessian_weights_config=GPTQHessianScoresConfig(log_norm=self.log_norm_weights,
+                                                                                scale_log_norm=self.scaled_log_norm),
                                  gptq_quantizer_params_override=self.override_params)
 
     def create_networks(self):
@@ -208,10 +208,10 @@ class GradientPTQWeightedLossTest(GradientPTQBaseTest):
             learning_rate=0.0001), optimizer_rest=tf.keras.optimizers.Adam(
             learning_rate=0.0001), loss=multiple_tensors_mse_loss, train_bias=True, rounding_type=self.rounding_type,
                                  use_hessian_based_weights=True,
-                                 hessian_weights_config=GPTQHessianWeightsConfig(hessians_num_samples=16,
-                                                                                 norm_weights=False,
-                                                                                 log_norm=self.log_norm_weights,
-                                                                                 scale_log_norm=self.scaled_log_norm),
+                                 hessian_weights_config=GPTQHessianScoresConfig(hessians_num_samples=16,
+                                                                                norm_scores=False,
+                                                                                log_norm=self.log_norm_weights,
+                                                                                scale_log_norm=self.scaled_log_norm),
                                  gptq_quantizer_params_override=self.override_params)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
@@ -227,7 +227,7 @@ class MixedPercisionCombinedNMSTest(MixedPercisionBaseTest):
 
     def get_mixed_precision_v2_config(self):
         return mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=1,
-                                                           use_grad_based_weights=False)
+                                                           use_hessian_based_scores=False)
 
     def get_kpi(self):
         # kpi is for 4 bits on average
@@ -418,7 +418,7 @@ class MixedPercisionSearchLastLayerDistanceTest(MixedPercisionBaseTest):
     def get_mixed_precision_v2_config(self):
         return mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=1,
                                                            distance_weighting_method=get_last_layer_weights,
-                                                           use_grad_based_weights=False)
+                                                           use_hessian_based_scores=False)
 
     def get_kpi(self):
         # kpi is infinity -> should give best model - 8bits

--- a/tests/keras_tests/function_tests/test_get_gptq_config.py
+++ b/tests/keras_tests/function_tests/test_get_gptq_config.py
@@ -22,7 +22,7 @@ from model_compression_toolkit.core import QuantizationConfig, QuantizationError
 import tensorflow as tf
 
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
-from model_compression_toolkit.gptq.common.gptq_config import GPTQHessianWeightsConfig
+from model_compression_toolkit.gptq.common.gptq_config import GPTQHessianScoresConfig
 from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEARNING_STR, MAX_LSB_STR
 from model_compression_toolkit.gptq.keras.gptq_loss import multiple_tensors_mse_loss
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_keras_tpc
@@ -67,11 +67,11 @@ class TestGetGPTQConfig(unittest.TestCase):
                                      weights_bias_correction=False)  # disable bias correction when working with GPTQ
         self.cc = CoreConfig(quantization_config=self.qc)
 
-        test_hessian_weights_config = GPTQHessianWeightsConfig(hessians_num_samples=2,
-                                                               norm_weights=False,
-                                                               log_norm=True,
-                                                               scale_log_norm=True,
-                                                               hessians_n_iter=20)
+        test_hessian_weights_config = GPTQHessianScoresConfig(hessians_num_samples=2,
+                                                              norm_scores=False,
+                                                              log_norm=True,
+                                                              scale_log_norm=True,
+                                                              hessians_n_iter=20)
 
         self.gptqv2_configurations = [GradientPTQConfigV2(1, optimizer=tf.keras.optimizers.RMSprop(),
                                                           optimizer_rest=tf.keras.optimizers.RMSprop(),

--- a/tests/keras_tests/function_tests/test_sensitivity_eval_non_suppoerted_output.py
+++ b/tests/keras_tests/function_tests/test_sensitivity_eval_non_suppoerted_output.py
@@ -60,7 +60,7 @@ class TestSensitivityEvalWithNonSupportedOutputNodes(unittest.TestCase):
                                                        fw_impl=keras_impl)
 
         se = keras_impl.get_sensitivity_evaluator(graph,
-                                                  MixedPrecisionQuantizationConfigV2(use_grad_based_weights=True),
+                                                  MixedPrecisionQuantizationConfigV2(use_hessian_based_scores=True),
                                                   representative_dataset,
                                                   DEFAULT_KERAS_INFO,
                                                   hessian_info_service=hessian_info_service)

--- a/tests/keras_tests/non_parallel_tests/test_keras_tp_model.py
+++ b/tests/keras_tests/non_parallel_tests/test_keras_tp_model.py
@@ -247,7 +247,7 @@ class TestGetKerasTPC(unittest.TestCase):
 
         core_config = mct.core.CoreConfig(
             mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=1,
-                                                                               use_grad_based_weights=False))
+                                                                               use_hessian_based_scores=False))
         quantized_model, _ = mct.ptq.keras_post_training_quantization_experimental(model,
                                                                                    rep_data,
                                                                                    core_config=core_config,

--- a/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
@@ -284,7 +284,7 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
                                              mixed_precision_config=MixedPrecisionQuantizationConfigV2(compute_mse,
                                                                                                        get_average_weights,
                                                                                                        num_of_images=1,
-                                                                                                       use_grad_based_weights=False))
+                                                                                                       use_hessian_based_scores=False))
 
         self.run_search_bitwidth_config_test(core_config_avg_weights)
 
@@ -292,7 +292,7 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
                                             mixed_precision_config=MixedPrecisionQuantizationConfigV2(compute_mse,
                                                                                                       get_last_layer_weights,
                                                                                                       num_of_images=1,
-                                                                                                      use_grad_based_weights=False))
+                                                                                                      use_hessian_based_scores=False))
 
         self.run_search_bitwidth_config_test(core_config_last_layer)
 

--- a/tests/keras_tests/non_parallel_tests/test_tensorboard_writer.py
+++ b/tests/keras_tests/non_parallel_tests/test_tensorboard_writer.py
@@ -107,7 +107,7 @@ class TestFileLogger(unittest.TestCase):
 
         # Hessian service assumes core should be initialized. This test does not do it, so we disable the use of hessians in MP
         cfg = copy.deepcopy(DEFAULT_MIXEDPRECISION_CONFIG)
-        cfg.use_grad_based_weights=False
+        cfg.use_hessian_based_scores = False
 
         # compare max tensor size with plotted max tensor size
         tg = prepare_graph_set_bit_widths(in_model=model,
@@ -140,7 +140,7 @@ class TestFileLogger(unittest.TestCase):
             yield [np.random.randn(1, 8, 8, 3)]
 
         mp_qc = mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=1,
-                                                            use_grad_based_weights=False)
+                                                            use_hessian_based_scores=False)
         core_config = mct.core.CoreConfig(mixed_precision_config=mp_qc)
         quantized_model, _ = mct.ptq.keras_post_training_quantization_experimental(self.model,
                                                                                rep_data,

--- a/tests/pytorch_tests/function_tests/test_sensitivity_eval_non_supported_output.py
+++ b/tests/pytorch_tests/function_tests/test_sensitivity_eval_non_supported_output.py
@@ -66,7 +66,7 @@ class TestSensitivityEvalWithNonSupportedOutputBase(BasePytorchTest):
                                                    representative_dataset=self.representative_data_gen)
 
         se = pytorch_impl.get_sensitivity_evaluator(graph,
-                                                    MixedPrecisionQuantizationConfigV2(use_grad_based_weights=True),
+                                                    MixedPrecisionQuantizationConfigV2(use_hessian_based_scores=True),
                                                     self.representative_data_gen,
                                                     DEFAULT_PYTORCH_INFO,
                                                     hessian_info_service=hessian_info_service)

--- a/tests/pytorch_tests/model_tests/feature_models/gptq_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/gptq_test.py
@@ -22,7 +22,7 @@ from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEA
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 import model_compression_toolkit as mct
 from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig, GradientPTQConfigV2, RoundingType, \
-    GPTQHessianWeightsConfig
+    GPTQHessianScoresConfig
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
 from model_compression_toolkit.gptq.pytorch.gptq_loss import multiple_tensors_mse_loss
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
@@ -121,8 +121,8 @@ class GPTQAccuracyTest(GPTQBaseTest):
                                  loss=multiple_tensors_mse_loss, train_bias=True, rounding_type=self.rounding_type,
                                  use_hessian_based_weights=self.hessian_weights,
                                  optimizer_bias=torch.optim.Adam([torch.Tensor([])], lr=0.4),
-                                 hessian_weights_config=GPTQHessianWeightsConfig(log_norm=self.log_norm_weights,
-                                                                                 scale_log_norm=self.scaled_log_norm),
+                                 hessian_weights_config=GPTQHessianScoresConfig(log_norm=self.log_norm_weights,
+                                                                                scale_log_norm=self.scaled_log_norm),
                                  gptq_quantizer_params_override=self.override_params)
 
     def get_gptq_configv2(self):
@@ -131,8 +131,8 @@ class GPTQAccuracyTest(GPTQBaseTest):
                                    loss=multiple_tensors_mse_loss, train_bias=True, rounding_type=self.rounding_type,
                                    use_hessian_based_weights=self.hessian_weights,
                                    optimizer_bias=torch.optim.Adam([torch.Tensor([])], lr=0.4),
-                                   hessian_weights_config=GPTQHessianWeightsConfig(log_norm=self.log_norm_weights,
-                                                                                   scale_log_norm=self.scaled_log_norm),
+                                   hessian_weights_config=GPTQHessianScoresConfig(log_norm=self.log_norm_weights,
+                                                                                  scale_log_norm=self.scaled_log_norm),
                                    gptq_quantizer_params_override=self.override_params)
 
     def gptq_compare(self, ptq_model, gptq_model, input_x=None):

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_weights_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_weights_test.py
@@ -219,8 +219,8 @@ class MixedPercisionSearchLastLayerDistance(MixedPercisionBaseTest):
 
     def get_mixed_precision_v2_config(self):
         return mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=1,
-                                                      use_grad_based_weights=False,
-                                                      distance_weighting_method=get_last_layer_weights)
+                                                           use_hessian_based_scores=False,
+                                                           distance_weighting_method=get_last_layer_weights)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
         self.compare_results(quantization_info, quantized_models, float_model, 1)

--- a/tutorials/notebooks/example_keras_mobilenet_gptq_mixed_precision.py
+++ b/tutorials/notebooks/example_keras_mobilenet_gptq_mixed_precision.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
 
     # Create a mixed-precision quantization configuration.
     mixed_precision_config = mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
-                                                                    use_grad_based_weights=args.enable_mixed_precision_gradients_weighting)
+                                                                         use_hessian_based_scores=args.enable_mixed_precision_gradients_weighting)
 
     # Create a core quantization configuration, set the mixed-precision configuration,
     # and set the number of calibration iterations.

--- a/tutorials/notebooks/example_keras_mobilenet_mixed_precision.py
+++ b/tutorials/notebooks/example_keras_mobilenet_mixed_precision.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
     # and quantize the model according to this configuration.
     # The candidates bit-width for quantization should be defined in the target platform model:
     configuration = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
-                                                                                                           use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
+                                                                                                           use_hessian_based_scores=args.enable_mixed_precision_gradients_weighting))
 
     # Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.
     # Here, for example, we use the default platform that is attached to a Tensorflow layers representation.

--- a/tutorials/notebooks/example_keras_mobilenet_mixed_precision_lut.py
+++ b/tutorials/notebooks/example_keras_mobilenet_mixed_precision_lut.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
     # and quantize the model according to this configuration.
     # The candidates bit-width for quantization should be defined in the target platform model:
     configuration = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
-                                                                                                           use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
+                                                                                                           use_hessian_based_scores=args.enable_mixed_precision_gradients_weighting))
 
     # Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.
     # In this example, we use a pre-defined platform that allows us to set a non-uniform (LUT) quantizer

--- a/tutorials/notebooks/example_pytorch_mobilenet_mixed_precision.py
+++ b/tutorials/notebooks/example_pytorch_mobilenet_mixed_precision.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     # and quantize the model according to this configuration.
     # The candidates bit-width for quantization should be defined in the target platform model:
     configuration = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
-                                                                                                           use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
+                                                                                                           use_hessian_based_scores=args.enable_mixed_precision_gradients_weighting))
 
     # Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.
     # Here, for example, we use the default platform that is attached to a Pytorch layers representation.

--- a/tutorials/notebooks/example_pytorch_mobilenet_mixed_precision_lut.py
+++ b/tutorials/notebooks/example_pytorch_mobilenet_mixed_precision_lut.py
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     # and quantize the model according to this configuration.
     # The candidates bit-width for quantization should be defined in the target platform model:
     configuration = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(num_of_images=args.mixed_precision_num_of_images,
-                                                                                                           use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
+                                                                                                           use_hessian_based_scores=args.enable_mixed_precision_gradients_weighting))
 
     # Get a TargetPlatformCapabilities object that models the hardware for the quantized model inference.
     # In this example, we use a pre-defined platform that allows us to set a non-uniform (LUT) quantizer

--- a/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.py
+++ b/tutorials/notebooks/example_pytorch_mobilenetv2_cifar100_mixed_precision.py
@@ -224,7 +224,7 @@ if __name__ == '__main__':
     # The candidates bit-width for quantization should be defined in the target platform model:
     configuration = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfigV2(
         num_of_images=args.mixed_precision_num_of_images,
-        use_grad_based_weights=args.enable_mixed_precision_gradients_weighting))
+        use_hessian_based_scores=args.enable_mixed_precision_gradients_weighting))
 
     # Get KPI information to constraint your model's memory size.
     # Retrieve a KPI object with helpful information of each KPI metric,


### PR DESCRIPTION
## Pull Request Description:
Modified names of Hessian-related variables and methods.
Removed any reference to "jacobians", "gradient-based" and "weights" in the scope of Hessian computation for mixed precision and gptq.
Replaced with uniform referencing as "**Hessian**-based **scores**", to prevent mixup with model's weights.
No functionality was affected in this changeset.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).