### PR TITLE
Fix interest points list in MP to exclude outputs

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -474,10 +474,8 @@ def get_mp_interest_points(graph: Graph,
 
     interest_points_nodes = bound_num_interest_points(ip_nodes, num_ip_factor)
 
-    # We add output layers of the model to interest points
-    # in order to consider the model's output in the distance metric computation (and also to make sure
-    # all configurable layers are included in the configured mp model for metric computation purposes)
-    output_nodes = get_output_nodes_for_metric(graph)
+    # We exclude output nodes from the set of interest points since they are used separately in the sensitivity evaluation.
+    output_nodes = [n.node for n in graph.get_outputs()]
 
     interest_points = [n for n in interest_points_nodes if n not in output_nodes]
 


### PR DESCRIPTION
## Pull Request Description:
This is a complementary fix for a missing piece from commit #850 .
Remove the output nodes from the list of interest points for MP metric.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).