### PR TITLE
Use context manager to avoid permission error on Windows

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_tflite_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_tflite_exporter.py
@@ -57,14 +57,13 @@ class FakelyQuantTFLiteExporter(FakelyQuantKerasExporter):
 
         """
         # Use Keras exporter to quantize model's weights before converting it to TFLite.
-        # Since exporter saves the model, we use a tmp path for saving, and then we delete it.
-        _, tmp_file = tempfile.mkstemp(TMP_KERAS_EXPORT_FORMAT)
-        custom_objects = FakelyQuantKerasExporter(self.model,
-                                                  self.is_layer_exportable_fn,
-                                                  tmp_file).export()
+        # Since exporter saves the model, we use a tmp path for saving, and then we delete it automatically.
+        with tempfile.NamedTemporaryFile(suffix=TMP_KERAS_EXPORT_FORMAT) as tmp_file:
+            custom_objects = FakelyQuantKerasExporter(self.model,
+                                                      self.is_layer_exportable_fn,
+                                                      tmp_file.name).export()
 
-        model = keras_load_quantized_model(tmp_file)
-        os.remove(tmp_file)
+            model = keras_load_quantized_model(tmp_file.name)
 
         self.exported_model = tf.lite.TFLiteConverter.from_keras_model(model).convert()
         Logger.info(f'Exporting FQ tflite model to: {self.save_model_path}')


### PR DESCRIPTION
## Pull Request Description:

The Model Compression Toolkit appears to have a bug on Windows caused by trying to remove a file that is still open. Linux allows for deleting a file that is still open, but Windows is much more particular about this operation and in general trying to remove a file that is still open somewhere will result in a `PermissionError`. Here's a standalone reproduction of the fundamental problem:

```
PS C:\Users\James> py -3.9
Python 3.9.9 (tags/v3.9.9:ccb0e6a, Nov 15 2021, 18:08:50) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import os, tempfile
>>> handle, tmpfile = tempfile.mkstemp()
>>> os.remove(tmpfile)  # File handle is still open, Windows will refuse to remove the file
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\James\\AppData\\Local\\Temp\\tmp8m6l666s'  
>>> os.close(handle)
>>> os.remove(tmpfile)  # If the file is first closed, it can be safely removed
```

I can confirm that changing the affected code inside of MCT to `os.close()` the handle before calling `os.remove()` does resolve the problem, but I have written this PR to use [`tempfile.NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) as a context manager, which handles close/removal of the file automatically, and will also clean up the file if an error occurs during export.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [N/A] I have added/updated the release note draft (if necessary).
- [N/A] I have updated the documentation to reflect my changes (if necessary).
- [N/A] All function and files are well documented. 
- [N/A] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [N/A] I have added new unittest (if necessary).