### PR TITLE
Remove constant multiplication factor from activation Hessian computation

### DIFF
--- a/model_compression_toolkit/core/keras/hessian/activation_trace_hessian_calculator_keras.py
+++ b/model_compression_toolkit/core/keras/hessian/activation_trace_hessian_calculator_keras.py
@@ -129,7 +129,7 @@ class ActivationTraceHessianCalculatorKeras(TraceHessianCalculatorKeras):
                     # Compute the final approximation for each output index
                     num_node_outputs = len(interest_point_scores[0])
                     for output_idx in range(num_node_outputs):
-                        final_approx_per_output.append(2 * tf.reduce_mean([x[output_idx] for x in interest_point_scores]) / output.shape[-1])
+                        final_approx_per_output.append(tf.reduce_mean([x[output_idx] for x in interest_point_scores]))
 
                     # final_approx_per_output is a list of all approximations (one per output), thus we average them to
                     # get the final score of a node.

--- a/model_compression_toolkit/core/pytorch/hessian/activation_trace_hessian_calculator_pytorch.py
+++ b/model_compression_toolkit/core/pytorch/hessian/activation_trace_hessian_calculator_pytorch.py
@@ -110,8 +110,8 @@ class ActivationTraceHessianCalculatorPytorch(TraceHessianCalculatorPytorch):
                             break
 
                     trace_hv.append(hessian_trace_approx)
-                ipts_hessian_trace_approx.append(2 * torch.mean(torch.stack(trace_hv)) / output.shape[
-                    -1])  # Get averaged Hessian trace approximation
+
+                ipts_hessian_trace_approx.append(torch.mean(torch.stack(trace_hv)))  # Get averaged Hessian trace approximation
 
             # If a node has multiple outputs, it means that multiple approximations were computed
             # (one per output since granularity is per-tensor). In this case we average the approximations.


### PR DESCRIPTION
## Pull Request Description:
This is an unnecessary factor that remained from previous versions of the Hessian approximation method.
It doesn't affect the results of most common networks.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).