### PR TITLE
Add Op2d->add_const collapse substitution

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -236,6 +236,14 @@ class FrameworkImplementation(ABC):
                              f'framework\'s get_linear_collapsing_substitution method.')  # pragma: no cover
 
     @abstractmethod
+    def get_op2d_add_const_collapsing_substitution(self) -> common.BaseSubstitution:
+        """
+        Returns: conv2d add const collapsing substitution
+        """
+        raise NotImplemented(f'{self.__class__.__name__} have to implement the '
+                             f'framework\'s get_op2d_add_const_collapsing_substitution method.')  # pragma: no cover
+
+    @abstractmethod
     def get_substitutions_statistics_correction(self, quant_config: QuantizationConfig) -> \
             List[common.BaseSubstitution]:
         """

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -79,7 +79,8 @@ class BaseNode:
     def type(self):
         """
         A function to get the node's layer_class op for convenient comparison
-        :return: the node's layer_class
+        Returns:
+            the node's layer_class
         """
         return self.layer_class
 
@@ -129,6 +130,14 @@ class BaseNode:
 
         """
         return f'{self.type.__name__}:{self.name}'
+
+    def is_reused(self) -> bool:
+        """
+        Check whether the node is reused or not
+        Returns:
+            True if node is reused, else False
+        """
+        return self.reuse or self.reuse_group is not None
 
     def get_weights_by_keys(self, name: str) -> np.ndarray:
         """

--- a/model_compression_toolkit/core/common/substitutions/batchnorm_folding.py
+++ b/model_compression_toolkit/core/common/substitutions/batchnorm_folding.py
@@ -93,7 +93,7 @@ class BatchNormalizationFolding(common.BaseSubstitution):
 
         # If the linear operator is part of a reused group (it is the "base" node, or a reused node),
         # we should skip the substitution.
-        if conv_node.reuse or conv_node.reuse_group is not None:
+        if conv_node.is_reused():
             return graph
 
         bn_node = edge_nodes[1]
@@ -230,7 +230,7 @@ class BatchNormalizationForwardFolding(common.BaseSubstitution):
 
         # If the linear operator is part of a reused group (it is the "base" node, or a reused node),
         # we should skip the substitution.
-        if conv_node.reuse or conv_node.reuse_group is not None or bn_node.reuse or bn_node.reuse_group is not None:
+        if conv_node.is_reused() or bn_node.is_reused():
             return graph
 
         if len(graph.get_next_nodes(bn_node)) > 1 or len(graph.get_prev_nodes(conv_node)) > 1:

--- a/model_compression_toolkit/core/common/substitutions/batchnorm_reconstruction.py
+++ b/model_compression_toolkit/core/common/substitutions/batchnorm_reconstruction.py
@@ -79,7 +79,7 @@ class BatchNormalizationReconstruction(common.BaseSubstitution):
 
         # If the linear operator is part of a reused group (it is the "base" node, or a reused node),
         # we should skip the substitution.
-        if source_node.reuse or source_node.reuse_group is not None:
+        if source_node.is_reused():
             for qc in source_node.candidates_quantization_cfg:
                 qc.weights_quantization_cfg.weights_second_moment_correction = False
             return graph

--- a/model_compression_toolkit/core/common/substitutions/batchnorm_refusing.py
+++ b/model_compression_toolkit/core/common/substitutions/batchnorm_refusing.py
@@ -102,7 +102,7 @@ class BatchNormalizationRefusing(common.BaseSubstitution):
 
         # If the linear operator is part of a reused group (it is the "base" node, or a reused node),
         # we should skip the substitution.
-        if source_node.reuse or source_node.reuse_group is not None:
+        if source_node.is_reused():
             Logger.exception("If the linear operator is part of a reused group we should skip the the BN folding "
                              "substitution and SMC feature")  # pragma: no cover
 

--- a/model_compression_toolkit/core/common/substitutions/linear_collapsing_substitution.py
+++ b/model_compression_toolkit/core/common/substitutions/linear_collapsing_substitution.py
@@ -30,6 +30,9 @@ def linear_collapsing_substitute(graph: common.Graph,
     Returns:
         Transformed graph after applying all linear collapsing substitutions.
     """
+    # TODO: remove this if after adding Op2d-add_const collapse substitution in PyTorch
+    if linear_collapsing_substitution is None:
+        return graph
     matched_nodes = graph.filter(linear_collapsing_substitution.matcher_instance)
     matched_nodes_list = []
     match_indicator = True

--- a/model_compression_toolkit/core/common/substitutions/residual_collapsing.py
+++ b/model_compression_toolkit/core/common/substitutions/residual_collapsing.py
@@ -63,9 +63,7 @@ class ResidualCollapsing(common.BaseSubstitution):
 
         # If the linear operator is part of a reused group (it is the "base" node, or a reused node),
         # we should skip the substitution.
-        if first_node.reuse or first_node.reuse_group is not None:
-            return graph
-        if second_node.reuse or second_node.reuse_group is not None:
+        if first_node.is_reused() or second_node.is_reused():
             return graph
 
         # Check if convolution and residual satisfy the collapsing conditions, otherwise skip substitution

--- a/model_compression_toolkit/core/graph_prep_runner.py
+++ b/model_compression_toolkit/core/graph_prep_runner.py
@@ -129,6 +129,7 @@ def get_finalized_graph(initial_graph: Graph,
     transformed_graph = substitute(graph, fw_impl.get_substitutions_pre_statistics_collection(quant_config))
     if quant_config.linear_collapsing:
         transformed_graph = linear_collapsing_substitute(transformed_graph, fw_impl.get_linear_collapsing_substitution())
+        transformed_graph = linear_collapsing_substitute(transformed_graph, fw_impl.get_op2d_add_const_collapsing_substitution())
     if quant_config.residual_collapsing:
         transformed_graph = substitute(transformed_graph, fw_impl.get_residual_collapsing_substitution())
 

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/linear_collapsing.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/linear_collapsing.py
@@ -164,7 +164,7 @@ def op2d_add_const_collapsing_fn(op2d_node: BaseNode,
     elif 'y' in add_node.op_call_kwargs:
         const = add_node.op_call_kwargs['y']
     else:
-        Logger.error(f'Unable to read constant from add node: {add_node.name}')
+        Logger.error(f'Unable to read constant from add node: {add_node.name}')  # pragma: no cover
 
     # convert constant to numpy array
     if isinstance(const, tf.Tensor):
@@ -172,7 +172,7 @@ def op2d_add_const_collapsing_fn(op2d_node: BaseNode,
     elif isinstance(const, list):
         const = np.array(const)
     else:
-        Logger.error(f'Unable to convert constant to numpy array: {add_node.name}')
+        Logger.error(f'Unable to convert constant to numpy array: {add_node.name}')  # pragma: no cover
 
     # return new bias
     if bias is None:

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -75,7 +75,7 @@ from model_compression_toolkit.core.keras.graph_substitutions.substitutions.batc
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.batchnorm_refusing import \
     keras_batchnorm_refusing
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.linear_collapsing import \
-    keras_linear_collapsing
+    keras_linear_collapsing, keras_op2d_add_const_collapsing
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.residual_collapsing import \
     keras_residual_collapsing
 from model_compression_toolkit.core.keras.graph_substitutions.substitutions.input_scaling import InputScaling, \
@@ -310,6 +310,12 @@ class KerasImplementation(FrameworkImplementation):
         Returns: linear collapsing substitution
         """
         return keras_linear_collapsing()
+
+    def get_op2d_add_const_collapsing_substitution(self) -> common.BaseSubstitution:
+        """
+        Returns: Op2d add-const collapsing substitution
+        """
+        return keras_op2d_add_const_collapsing()
 
     def get_substitutions_post_statistics_collection(self, quant_config: QuantizationConfig) \
             -> List[common.BaseSubstitution]:

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -289,6 +289,12 @@ class PytorchImplementation(FrameworkImplementation):
         """
         return pytorch_linear_collapsing()
 
+    def get_op2d_add_const_collapsing_substitution(self) -> common.BaseSubstitution:
+        """
+        Returns: None, as Op2d add-const substitution is not supported in torch yet
+        """
+        return None
+
     def get_substitutions_post_statistics_collection(self,
                                                      quant_config: QuantizationConfig) -> List[common.BaseSubstitution]:
         """

--- a/tests/keras_tests/feature_networks_tests/feature_networks/linear_collapsing_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/linear_collapsing_test.py
@@ -134,8 +134,6 @@ class Op2DAddConstCollapsingTest(BaseConv2DCollapsingTest):
         super().__init__(unit_test)
 
     def create_networks(self):
-        # TODO: check add with two inputs, not const
-        # TODO: add dense+add_const
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
         # ########
         # Cond2D #
@@ -153,9 +151,10 @@ class Op2DAddConstCollapsingTest(BaseConv2DCollapsingTest):
         x = layers.ReLU()(x)
 
         # Collapse + operator to Conv2D without bias
+        # TODO: replace add with + (currently using tf.math.add because below TF 2.14 creates TFOpLambda which fails ths node matcher)
         x = layers.Conv2D(filters=9, kernel_size=(5, 5), strides=(1, 1), padding='same',
                           use_bias=False)(x)
-        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
 
         # #################
         # DepthwiseConv2D #
@@ -173,9 +172,10 @@ class Op2DAddConstCollapsingTest(BaseConv2DCollapsingTest):
         x = layers.ReLU()(x)
 
         # Collapse + operator to DepthwiseConv2D without bias
+        # TODO: replace add with + (currently using tf.math.add because below TF 2.14 creates TFOpLambda which fails ths node matcher)
         x = layers.DepthwiseConv2D(kernel_size=(5, 5), strides=(1, 1), padding='same',
                                    use_bias=False)(x)
-        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
 
         # #################
         # Conv2DTranspose #
@@ -193,9 +193,10 @@ class Op2DAddConstCollapsingTest(BaseConv2DCollapsingTest):
         x = layers.ReLU()(x)
 
         # Collapse + operator to Conv2DTranspose without bias
+        # TODO: replace add with + (currently using tf.math.add because below TF 2.14 creates TFOpLambda which fails ths node matcher)
         x = layers.Conv2DTranspose(filters=9, kernel_size=(5, 5), strides=(1, 1), padding='same',
                                    use_bias=False)(x)
-        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
 
         # #######
         # Dense #
@@ -212,8 +213,9 @@ class Op2DAddConstCollapsingTest(BaseConv2DCollapsingTest):
         x = layers.ReLU()(x)
 
         # Collapse + operator to Conv2DTranspose without bias
+        # TODO: replace add with + (currently using tf.math.add because below TF 2.14 creates TFOpLambda which fails ths node matcher)
         x = layers.Dense(9, use_bias=False)(x)
-        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
 
         # Don't collapse
         x2 = layers.Dense(9, use_bias=True, bias_initializer='glorot_uniform')(x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/linear_collapsing_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/linear_collapsing_test.py
@@ -16,7 +16,6 @@
 from abc import ABC
 import model_compression_toolkit as mct
 import tensorflow as tf
-from tensorflow.keras.layers import Conv2D
 
 from model_compression_toolkit.trainable_infrastructure import KerasTrainableQuantizationWrapper
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
@@ -51,7 +50,7 @@ class BaseConv2DCollapsingTest(BaseKerasFeatureNetworkTest, ABC):
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)
         self.unit_test.assertTrue(y.shape == y_hat.shape, msg=f'out shape is not as expected!')
-        self.unit_test.assertTrue(len([l for l in quantized_model.layers if isinstance(l, KerasTrainableQuantizationWrapper) and isinstance(l.layer, Conv2D)]) < len([l for l in float_model.layers if isinstance(l, Conv2D)]), msg=f'fail number of layers should decrease!')
+        self.unit_test.assertTrue(len([l for l in quantized_model.layers if isinstance(l, KerasTrainableQuantizationWrapper) and isinstance(l.layer, layers.Conv2D)]) < len([l for l in float_model.layers if isinstance(l, layers.Conv2D)]), msg=f'fail number of layers should decrease!')
         cs = cosine_similarity(y, y_hat)
         self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')
 
@@ -69,7 +68,7 @@ class TwoConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         super().compare(quantized_model, float_model, input_x, quantization_info)
         for layer in quantized_model.layers:
-            if type(layer) == Conv2D:
+            if type(layer) == layers.Conv2D:
                 self.unit_test.assertTrue(len(layer.weights) == 2, msg=f'fail Bias should appear in weights!!')
 
 class ThreeConv2DCollapsingTest(BaseConv2DCollapsingTest):
@@ -86,7 +85,7 @@ class ThreeConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         super().compare(quantized_model, float_model, input_x, quantization_info)
         for layer in quantized_model.layers:
-            if type(layer) == Conv2D:
+            if type(layer) == layers.Conv2D:
                 self.unit_test.assertTrue(len(layer.weights) == 1,msg=f'fail Bias should not appear in weights!!')
 
 
@@ -105,8 +104,9 @@ class FourConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         super().compare(quantized_model, float_model, input_x, quantization_info)
         for layer in quantized_model.layers:
-            if type(layer) == Conv2D:
+            if type(layer) == layers.Conv2D:
                 self.unit_test.assertTrue(len(layer.weights) == 2,msg=f'fail Bias should appear in weights!!')
+
 
 class SixConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def __init__(self, unit_test):
@@ -125,5 +125,105 @@ class SixConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         super().compare(quantized_model, float_model, input_x, quantization_info)
         for layer in quantized_model.layers:
-            if type(layer) == Conv2D:
+            if type(layer) == layers.Conv2D:
                 self.unit_test.assertTrue(len(layer.weights) == 2,msg=f'fail Bias should appear in weights!!')
+
+
+class Op2DAddConstCollapsingTest(BaseConv2DCollapsingTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+
+    def create_networks(self):
+        # TODO: check add with two inputs, not const
+        # TODO: add dense+add_const
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        # ########
+        # Cond2D #
+        # ########
+        # Collapse Conv2D with bias
+        x = layers.Conv2D(filters=7, kernel_size=(5, 5), strides=(1, 1), padding='same',
+                          use_bias=True, bias_initializer='glorot_uniform')(inputs)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
+        x = layers.ReLU()(x)
+
+        # Collapse Conv2D without bias, const first argument of tf.math.add
+        x = layers.Conv2D(filters=5, kernel_size=(5, 5), strides=(1, 1), padding='same',
+                          use_bias=False)(x)
+        x = tf.math.add(tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype), x)
+        x = layers.ReLU()(x)
+
+        # Collapse + operator to Conv2D without bias
+        x = layers.Conv2D(filters=9, kernel_size=(5, 5), strides=(1, 1), padding='same',
+                          use_bias=False)(x)
+        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+
+        # #################
+        # DepthwiseConv2D #
+        # #################
+        # Collapse DepthwiseConv2D with bias
+        x = layers.DepthwiseConv2D(kernel_size=(5, 5), strides=(1, 1), padding='same',
+                                   use_bias=True, bias_initializer='glorot_uniform')(x)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
+        x = layers.ReLU()(x)
+
+        # Collapse DepthwiseConv2D without bias, const first argument of tf.math.add
+        x = layers.DepthwiseConv2D(kernel_size=(5, 5), strides=(1, 1), padding='same',
+                                   use_bias=False)(x)
+        x = tf.math.add(tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype), x)
+        x = layers.ReLU()(x)
+
+        # Collapse + operator to DepthwiseConv2D without bias
+        x = layers.DepthwiseConv2D(kernel_size=(5, 5), strides=(1, 1), padding='same',
+                                   use_bias=False)(x)
+        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+
+        # #################
+        # Conv2DTranspose #
+        # #################
+        # Collapse Conv2DTranspose with bias
+        x = layers.Conv2DTranspose(filters=9, kernel_size=(5, 5), strides=(1, 1), padding='same',
+                                   use_bias=True, bias_initializer='glorot_uniform')(x)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
+        x = layers.ReLU()(x)
+
+        # Collapse Conv2DTranspose without bias, const first argument of tf.math.add
+        x = layers.Conv2DTranspose(filters=9, kernel_size=(5, 5), strides=(1, 1), padding='same',
+                                   use_bias=False)(x)
+        x = tf.math.add(tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype), x)
+        x = layers.ReLU()(x)
+
+        # Collapse + operator to Conv2DTranspose without bias
+        x = layers.Conv2DTranspose(filters=9, kernel_size=(5, 5), strides=(1, 1), padding='same',
+                                   use_bias=False)(x)
+        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+
+        # #######
+        # Dense #
+        # #######
+        x = layers.Reshape((-1,))(x)
+        # Collapse Dense with bias
+        x = layers.Dense(9, use_bias=True, bias_initializer='glorot_uniform')(x)
+        x = tf.math.add(x, tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype))
+        x = layers.ReLU()(x)
+
+        # Collapse Dense without bias, const first argument of tf.math.add
+        x = layers.Dense(9, use_bias=False)(x)
+        x = tf.math.add(tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype), x)
+        x = layers.ReLU()(x)
+
+        # Collapse + operator to Conv2DTranspose without bias
+        x = layers.Dense(9, use_bias=False)(x)
+        x = x + tf.constant(np.random.normal(size=x.shape[-1]), dtype=x.dtype)
+
+        # Don't collapse
+        x2 = layers.Dense(9, use_bias=True, bias_initializer='glorot_uniform')(x)
+        x = tf.math.add(x2, x)
+        y = layers.ReLU()(x)
+
+        return tf.keras.models.Model(inputs=inputs, outputs=y)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        super().compare(quantized_model, float_model, input_x, quantization_info)
+        for layer in quantized_model.layers:
+            if type(layer) in [layers.Conv2D, layers.DepthwiseConv2D, layers.Conv2DTranspose, layers.Dense]:
+                self.unit_test.assertTrue(len(layer.weights) == 2, msg=f'fail Bias should appear in weights!!')

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -45,7 +45,7 @@ from tests.keras_tests.feature_networks_tests.feature_networks.gptq.gptq_test im
 from tests.keras_tests.feature_networks_tests.feature_networks.input_scaling_test import InputScalingDenseTest, \
     InputScalingConvTest, InputScalingDWTest, InputScalingZeroPadTest
 from tests.keras_tests.feature_networks_tests.feature_networks.linear_collapsing_test import TwoConv2DCollapsingTest, \
-    ThreeConv2DCollapsingTest, FourConv2DCollapsingTest, SixConv2DCollapsingTest
+    ThreeConv2DCollapsingTest, FourConv2DCollapsingTest, SixConv2DCollapsingTest, Op2DAddConstCollapsingTest
 from tests.keras_tests.feature_networks_tests.feature_networks.lut_quantizer import LUTWeightsQuantizerTest, \
     LUTActivationQuantizerTest
 from tests.keras_tests.feature_networks_tests.feature_networks.mixed_precision_bops_test import \
@@ -531,6 +531,7 @@ class FeatureNetworkTest(unittest.TestCase):
         ThreeConv2DCollapsingTest(self).run_test()
         FourConv2DCollapsingTest(self).run_test()
         SixConv2DCollapsingTest(self).run_test()
+        Op2DAddConstCollapsingTest(self).run_test()
 
     def test_second_moment(self):
         DepthwiseConv2DSecondMomentTest(self).run_test()


### PR DESCRIPTION
## Pull Request Description:
Add a substitution for collapsing Op2d->add-const into the Op2d node
Op2d: Conv2D, DW-Conv2D, Conv2DTranspose or Dense

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).