### PR TITLE
Set default distance function for softmax node in MP to be MSE if axis is not specified

### DIFF
--- a/model_compression_toolkit/core/common/framework_implementation.py
+++ b/model_compression_toolkit/core/common/framework_implementation.py
@@ -375,7 +375,8 @@ class FrameworkImplementation(ABC):
 
     def get_node_distance_fn(self, layer_class: type,
                              framework_attrs: Dict[str, Any],
-                             compute_distance_fn: Callable = None) -> Callable:
+                             compute_distance_fn: Callable = None,
+                             axis: int = None) -> Callable:
         """
         A mapping between layers' types and a distance function for computing the distance between
         two tensors (for loss computation purposes). Returns a specific function if node of specific types is
@@ -385,6 +386,7 @@ class FrameworkImplementation(ABC):
             layer_class: Class path of a model's layer.
             framework_attrs: Framework attributes the layer had which the graph node holds.
             compute_distance_fn: An optional distance function to use globally for all nodes.
+            axis: The axis on which the operation is preformed (if specified).
 
         Returns: A distance function between two tensors.
         """

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -144,12 +144,14 @@ class SensitivityEvaluation:
         distance_fns_list = []
         batch_axis_list = []
         for n in points:
+
+            axis = n.framework_attr.get(AXIS) if not isinstance(n, FunctionalNode) else n.op_call_kwargs.get(AXIS)
             distance_fns_list.append(self.fw_impl.get_node_distance_fn(
                 layer_class=n.layer_class,
                 framework_attrs=n.framework_attr,
-                compute_distance_fn=self.quant_config.compute_distance_fn))
-            batch_axis_list.append(n.framework_attr.get(AXIS) if not isinstance(n, FunctionalNode)
-                                   else n.op_call_kwargs.get(AXIS))
+                compute_distance_fn=self.quant_config.compute_distance_fn,
+                axis=axis))
+            batch_axis_list.append(axis)
         return distance_fns_list, batch_axis_list
 
     def compute_metric(self,

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -411,7 +411,8 @@ class PytorchImplementation(FrameworkImplementation):
 
     def get_node_distance_fn(self, layer_class: type,
                              framework_attrs: Dict[str, Any],
-                             compute_distance_fn: Callable = None) -> Callable:
+                             compute_distance_fn: Callable = None,
+                             axis: int = None) -> Callable:
         """
         A mapping between layers' types and a distance function for computing the distance between
         two tensors (for loss computation purposes). Returns a specific function if node of specific types is
@@ -421,6 +422,7 @@ class PytorchImplementation(FrameworkImplementation):
             layer_class: Class path of a model's layer.
             framework_attrs: Framework attributes the layer had which the graph node holds.
             compute_distance_fn: An optional distance function to use globally for all nodes.
+            axis: The axis on which the operation is preformed (if specified).
 
         Returns: A distance function between two tensors.
         """
@@ -428,7 +430,7 @@ class PytorchImplementation(FrameworkImplementation):
         if compute_distance_fn is not None:
             return compute_distance_fn
 
-        elif layer_class in [Softmax, softmax]:
+        elif layer_class in [Softmax, softmax] and axis is not None:
             return compute_kl_divergence
         elif layer_class in [Sigmoid, sigmoid]:
             return compute_cs

--- a/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
+++ b/tests/keras_tests/function_tests/test_sensitivity_metric_interest_points.py
@@ -137,14 +137,15 @@ class TestSensitivityMetricInterestPoints(unittest.TestCase):
             t1 = softmax_node2layer[sn](np.random.rand(*[8, *softmax_node2layer[sn].input_shape[1:]])).numpy()
             t2 = softmax_node2layer[sn](np.random.rand(*[8, *softmax_node2layer[sn].input_shape[1:]])).numpy()
 
-            distance_fn = KerasImplementation().get_node_distance_fn(layer_class=sn.layer_class,
-                                                                     framework_attrs=sn.framework_attr)
-            self.assertEqual(distance_fn, compute_kl_divergence,
-                             f"Softmax node should use KL Divergence for distance computation.")
-
             axis = sn.framework_attr.get(AXIS)
             if axis is None:
                 axis = sn.op_call_kwargs.get(AXIS)
+
+            distance_fn = KerasImplementation().get_node_distance_fn(layer_class=sn.layer_class,
+                                                                     framework_attrs=sn.framework_attr,
+                                                                     axis=axis)
+            self.assertEqual(distance_fn, compute_kl_divergence,
+                             f"Softmax node should use KL Divergence for distance computation.")
 
             distance_per_softmax_axis = distance_fn(t1, t2, batch=True, axis=axis)
             distance_global = distance_fn(t1, t2, batch=True, axis=None)


### PR DESCRIPTION
If the axis is not retrievable for the softmax operation, we can't compute kl-divergence correctly, so we use mse distance by default in mixed precision distance computation.

## Pull Request Description:


## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).