### PR TITLE
Add verbose flag to FakelyQuantKerasExporter to avoid confusion in tflite export

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -46,18 +46,21 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
     def __init__(self,
                  model: keras.models.Model,
                  is_layer_exportable_fn: Callable,
-                 save_model_path: str):
+                 save_model_path: str,
+                 verbose: bool = True):
         """
 
         Args:
             model: Model to export.
             is_layer_exportable_fn: Callable to check whether a layer can be exported or not.
             save_model_path: Path to save the exported model.
+            verbose: Whether to log information about the export process or not.
         """
 
         super().__init__(model,
                          is_layer_exportable_fn,
                          save_model_path)
+        self._verbose = verbose
 
     def export(self) -> Dict[str, type]:
         """
@@ -138,7 +141,8 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
         if self.exported_model is None:
             Logger.critical(f'Exporter can not save model as it is not exported')  # pragma: no cover
 
-        Logger.info(f'Exporting FQ Keras model to: {self.save_model_path}')
+        if self._verbose:
+            Logger.info(f'Exporting FQ Keras model to: {self.save_model_path}')
 
         keras.models.save_model(self.exported_model, self.save_model_path)
 

--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_tflite_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_tflite_exporter.py
@@ -59,9 +59,10 @@ class FakelyQuantTFLiteExporter(FakelyQuantKerasExporter):
         # Use Keras exporter to quantize model's weights before converting it to TFLite.
         # Since exporter saves the model, we use a tmp path for saving, and then we delete it automatically.
         with tempfile.NamedTemporaryFile(suffix=TMP_KERAS_EXPORT_FORMAT) as tmp_file:
-            custom_objects = FakelyQuantKerasExporter(self.model,
-                                                      self.is_layer_exportable_fn,
-                                                      tmp_file.name).export()
+            FakelyQuantKerasExporter(self.model,
+                                     self.is_layer_exportable_fn,
+                                     tmp_file.name,
+                                     verbose=False).export()
 
             model = keras_load_quantized_model(tmp_file.name)
 


### PR DESCRIPTION
## Pull Request Description:
Add a verbose flag to FakelyQuantKerasExporter to avoid confusion in tflite export (since tflite fake quant export uses
an intermediate temp file that FakelyQuantKerasExporter produces).


## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).