### PR TITLE
fix LSQ weights quantizer keras for dw-conv

### DIFF
--- a/model_compression_toolkit/qat/keras/quantizer/lsq/symmetric_lsq.py
+++ b/model_compression_toolkit/qat/keras/quantizer/lsq/symmetric_lsq.py
@@ -87,17 +87,6 @@ class LSQWeightQATQuantizer(BaseKerasQATTrainableQuantizer):
         self.threshold_shape = self.threshold_values.shape
         self.per_channel = self.quantization_config.weights_per_channel_threshold
         self.channel_axis = self.quantization_config.weights_channels_axis
-
-        if self.per_channel and self.channel_axis not in [-1, len(self.threshold_shape) - 1]:
-            # Tensorflow's fake_quant_with_min_max_vars_per_channel only works on last axis, so
-            # need to move the quantization axis to the last axis
-            self.perm_vec = list(np.arange(len(self.threshold_shape)))
-            self.perm_vec[self.channel_axis] = len(self.threshold_shape) - 1
-            self.perm_vec[len(self.threshold_shape) - 1] = self.channel_axis
-        else:
-            self.perm_vec = None
-
-
         self.threshold_values = np.reshape(np.asarray(self.threshold_values), [-1]) if self.per_channel else float(self.threshold_values)
         self.num_bits = self.quantization_config.weights_n_bits
         n_pos_bits = self.num_bits - int(C.WEIGHTS_SIGNED)
@@ -142,17 +131,9 @@ class LSQWeightQATQuantizer(BaseKerasQATTrainableQuantizer):
             The quantized tensor.
         """
 
-        thresholds = self.get_quantizer_variable(THRESHOLD_TENSOR)
-        if self.per_channel:
-            if self.perm_vec:
-                inputs = tf.transpose(inputs, perm=self.perm_vec)
-            q_tensor = symmetric_lsq_quantizer(inputs, thresholds, self.num_bits, C.WEIGHTS_SIGNED, self.min_int,
-                                               self.max_int, self.scale_factor)
-            if self.perm_vec:
-                q_tensor = tf.transpose(q_tensor, perm=self.perm_vec)
-        else:
-            q_tensor = symmetric_lsq_quantizer(inputs, thresholds, self.num_bits, C.WEIGHTS_SIGNED, self.min_int,
-                                               self.max_int, self.scale_factor)
+        thresholds = tf.reshape(self.get_quantizer_variable(THRESHOLD_TENSOR), self.threshold_shape)
+        q_tensor = symmetric_lsq_quantizer(inputs, thresholds, self.num_bits, C.WEIGHTS_SIGNED, self.min_int,
+                                           self.max_int, self.scale_factor)
         return q_tensor
 
     def convert2inferable(self) -> Union[WeightsPOTInferableQuantizer, WeightsSymmetricInferableQuantizer]:

--- a/model_compression_toolkit/qat/keras/quantizer/lsq/uniform_lsq.py
+++ b/model_compression_toolkit/qat/keras/quantizer/lsq/uniform_lsq.py
@@ -93,14 +93,6 @@ class LSQUniformWeightQATQuantizer(BaseKerasQATTrainableQuantizer):
         self.max_int = 2**self.num_bits - 1
         self.scale_factor = 1.0 / np.sqrt(self.max_int * self.max_values.size)
 
-        if self.per_channel and self.channel_axis not in [-1, len(self.min_max_shape) - 1]:
-            # Tensorflow's fake_quant_with_min_max_vars_per_channel only works on last axis, so
-            # need to move the quantization axis to the last axis
-            self.perm_vec = list(np.arange(len(self.min_max_shape)))
-            self.perm_vec[self.channel_axis] = len(self.min_max_shape) - 1
-            self.perm_vec[len(self.min_max_shape) - 1] = self.channel_axis
-        else:
-            self.perm_vec = None
 
     def initialize_quantization(self,
                                 tensor_shape: TensorShape,
@@ -144,17 +136,9 @@ class LSQUniformWeightQATQuantizer(BaseKerasQATTrainableQuantizer):
             The quantized tensor.
         """
 
-        min_range = self.get_quantizer_variable(FQ_MIN)
-        max_range = self.get_quantizer_variable(FQ_MAX)
-        if self.per_channel:
-            if self.perm_vec:
-                inputs = tf.transpose(inputs, perm=self.perm_vec)
-            q_tensor = uniform_lsq_quantizer(inputs, min_range, max_range, self.num_bits, self.min_int, self.max_int, self.scale_factor)
-            if self.perm_vec:
-                q_tensor = tf.transpose(q_tensor, perm=self.perm_vec)
-        else:
-            q_tensor = uniform_lsq_quantizer(inputs, min_range, max_range, self.num_bits, self.min_int, self.max_int, self.scale_factor)
-
+        min_range = tf.reshape(self.get_quantizer_variable(FQ_MIN), self.min_max_shape)
+        max_range = tf.reshape(self.get_quantizer_variable(FQ_MAX), self.min_max_shape)
+        q_tensor = uniform_lsq_quantizer(inputs, min_range, max_range, self.num_bits, self.min_int, self.max_int, self.scale_factor)
         return q_tensor
 
     def convert2inferable(self) -> BaseKerasInferableQuantizer:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
@@ -275,7 +275,7 @@ class QATWrappersTest(BaseKerasFeatureNetworkTest):
                                  and self.weights_quantization_method in _q.quantization_method
                                  and _q.identifier == QuantizerID.INFERABLE]
                             self.unit_test.assertTrue(len(q) == 1)
-                            self.unit_test.assertTrue(isinstance(layer.weights_quantizers[KERNEL], q[0]))
+                            self.unit_test.assertTrue(isinstance(layer.weights_quantizers[name], q[0]))
                         else:
                             self.unit_test.assertTrue(isinstance(quantizer, BaseKerasTrainableQuantizer))
                             q = [_q for _q in all_trainable_quantizers if _q.identifier == self.training_method
@@ -283,7 +283,7 @@ class QATWrappersTest(BaseKerasFeatureNetworkTest):
                                  and self.weights_quantization_method in _q.quantization_method
                                  and type(_q.identifier) == TrainingMethod]
                             self.unit_test.assertTrue(len(q) == 1)
-                            self.unit_test.assertTrue(isinstance(layer.weights_quantizers[KERNEL], q[0]))
+                            self.unit_test.assertTrue(isinstance(layer.weights_quantizers[name], q[0]))
 
 
 class QATWrappersMixedPrecisionCfgTest(MixedPrecisionActivationBaseTest):

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -707,6 +707,10 @@ class FeatureNetworkTest(unittest.TestCase):
                         weights_quantization_method=QuantizationMethod.UNIFORM,
                         activation_quantization_method=QuantizationMethod.UNIFORM,
                         training_method=TrainingMethod.LSQ).run_test()
+        QATWrappersTest(self, layers.DepthwiseConv2D(3, 4, activation='relu'),
+                        weights_quantization_method=QuantizationMethod.UNIFORM,
+                        activation_quantization_method=QuantizationMethod.UNIFORM,
+                        training_method=TrainingMethod.LSQ).run_test()
         QATWrappersTest(self, layers.Dense(3, activation='relu'),
                         weights_quantization_method=QuantizationMethod.POWER_OF_TWO,
                         activation_quantization_method=QuantizationMethod.POWER_OF_TWO,

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -699,7 +699,7 @@ class FeatureNetworkTest(unittest.TestCase):
                         weights_quantization_method=QuantizationMethod.SYMMETRIC,
                         activation_quantization_method=QuantizationMethod.SYMMETRIC).run_test()
         QATWrappersTest(self, layers.Conv2DTranspose(3, 4, activation='relu')).run_test()
-        QATWrappersTest(self, layers.Conv2D(3, 4, activation='relu'),
+        QATWrappersTest(self, layers.DepthwiseConv2D(3, 4, activation='relu'),
                         weights_quantization_method=QuantizationMethod.SYMMETRIC,
                         activation_quantization_method=QuantizationMethod.SYMMETRIC,
                         training_method=TrainingMethod.LSQ).run_test()
@@ -711,8 +711,6 @@ class FeatureNetworkTest(unittest.TestCase):
                         weights_quantization_method=QuantizationMethod.POWER_OF_TWO,
                         activation_quantization_method=QuantizationMethod.POWER_OF_TWO,
                         training_method=TrainingMethod.LSQ).run_test()
-        # DW-Conv2D are tested under the tests below because an extra check is needed to verify the
-        # quantization per channel of its kernel TODO: should be part of the quantizers tests
         QuantizationAwareTrainingQuantizersTest(self).run_test()
         QuantizationAwareTrainingQuantizerHolderTest(self).run_test()
         QATWrappersMixedPrecisionCfgTest(self).run_test()


### PR DESCRIPTION
## Pull Request Description:
Add reshape to channel axis for LSQ QAT keras quantizers. This is needed for Conv-DW where we need to adapt the axis.  

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).