### PR TITLE
Remove tflite export part from QAT tutorial

### DIFF
--- a/tutorials/notebooks/example_keras_qat.py
+++ b/tutorials/notebooks/example_keras_qat.py
@@ -216,16 +216,8 @@ if __name__ == "__main__":
     print(f"Quantized model test accuracy: {score[1]:02.4f}")
 
 
-    # Export quantized model to TFLite and Keras.
+    # Export quantized model to Keras.
     # For more details please see: https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/exporter/README.md
-    _, tflite_file_path = tempfile.mkstemp('.tflite') # Path of exported model
-    mct.exporter.keras_export_model(model=quantized_model,
-                                    save_model_path=tflite_file_path,
-                                    serialization_format=mct.exporter.KerasExportSerializationFormat.TFLITE,
-                                    quantization_format=mct.exporter.QuantizationFormat.FAKELY_QUANT)
-    print(f"Quantized model was exporting to TFLite here: {tflite_file_path}")
-
-    # Export quantized model to Keras
     _, keras_file_path = tempfile.mkstemp('.h5') # Path of exported model
     mct.exporter.keras_export_model(model=quantized_model,
                                     save_model_path=keras_file_path)


### PR DESCRIPTION
## Pull Request Description:
Exporting non 8bits activation quantization in tflite is unsupported.
Thus, it's removed from qat tutorial.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).