### PR TITLE
Add constant weight representation in Keras & PyTorch

### DIFF
--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -52,6 +52,8 @@ class BaseNode:
             input_shape: Input tensor shape of the node.
             output_shape: Input tensor shape of the node.
             weights: Dictionary from a variable name to the weights with that name in the layer the node represents.
+                     Constant inputs to a node are also saved in the weights (AKA positional weights) dictionary and
+                     their key is their position (an integer) in the node's call_args.
             layer_class: Class path of the layer this node represents.
             reuse: Whether this node was duplicated and represents a reused layer.
             reuse_group: Name of group of nodes from the same reused layer.
@@ -177,7 +179,7 @@ class BaseNode:
     def get_weights_list(self):
         """
 
-        Returns: A list of all weights the node holds.
+        Returns: A list of all non-positional weights the node holds.
 
         """
         return [self.weights[k] for k in self.weights.keys()
@@ -185,15 +187,17 @@ class BaseNode:
 
     def insert_positional_weights_to_input_list(self, input_tensors: List) -> List:
         """
-        Insert node's positional weights to input tensors list.
+        Insert node's positional weights to input tensors list. The positional weights are inserted
+        in the node's list of inputs according to their keys in the weights dictionary.
 
         Args:
             input_tensors: activation input tensors to node.
         Returns:
-            input tensors list with positional weights
+            Activation input tensors list with positional weights
         """
         for pos, weight in sorted((pos, weight) for pos, weight in self.weights.items()
                                   if isinstance(pos, int)):
+            assert pos <= len(input_tensors), 'Positional weight index mismatch'
             input_tensors.insert(pos, weight)
 
         return input_tensors

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -180,7 +180,23 @@ class BaseNode:
         Returns: A list of all weights the node holds.
 
         """
-        return [self.weights[k] for k in self.weights.keys() if self.weights[k] is not None]
+        return [self.weights[k] for k in self.weights.keys()
+                if self.weights[k] is not None and not isinstance(k, int)]
+
+    def insert_positional_weights_to_input_list(self, input_tensors: List) -> List:
+        """
+        Insert node's positional weights to input tensors list.
+
+        Args:
+            input_tensors: activation input tensors to node.
+        Returns:
+            input tensors list with positional weights
+        """
+        for pos, weight in sorted((pos, weight) for pos, weight in self.weights.items()
+                                  if isinstance(pos, int)):
+            input_tensors.insert(pos, weight)
+
+        return input_tensors
 
     def get_num_parameters(self, fw_info) -> Tuple[int,int]:
         """

--- a/model_compression_toolkit/core/common/graph/functional_node.py
+++ b/model_compression_toolkit/core/common/graph/functional_node.py
@@ -16,7 +16,7 @@ class FunctionalNode(BaseNode):
                  output_shape: Tuple[Any],
                  weights: Dict[str, np.ndarray],
                  layer_class: type,
-                 op_call_args: List[Any] = None,
+                 op_call_args: Tuple[Any] = None,
                  op_call_kwargs: Dict[str, Any] = None,
                  reuse: bool = False,
                  reuse_group: str = None,

--- a/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
@@ -270,6 +270,7 @@ class KerasModelBuilder(BaseModelBuilder):
                                                                            out_tensors_of_n_float)
         else:
             input_tensors = [tensor for tensor_list in input_tensors for tensor in tensor_list]  # flat list of lists
+            input_tensors = n.insert_positional_weights_to_input_list(input_tensors)
             # Build a functional node using its args
             if isinstance(n, FunctionalNode):
                 if n.inputs_as_list:  # If the first argument should be a list of tensors:

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/linear_collapsing.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/linear_collapsing.py
@@ -158,21 +158,10 @@ def op2d_add_const_collapsing_fn(op2d_node: BaseNode,
     """
     bias = op2d_node.get_weights_by_keys(bias_str)
 
-    # read constant from add node
-    if len(add_node.op_call_args) > 0:
-        const = add_node.op_call_args[0]
-    elif 'y' in add_node.op_call_kwargs:
-        const = add_node.op_call_kwargs['y']
-    else:
+    # read constant from add node (either 1st or 2nd positional weight)
+    const = add_node.weights.get(0, add_node.weights.get(1))
+    if const is None:
         Logger.error(f'Unable to read constant from add node: {add_node.name}')  # pragma: no cover
-
-    # convert constant to numpy array
-    if isinstance(const, tf.Tensor):
-        const = const.numpy()
-    elif isinstance(const, list):
-        const = np.array(const)
-    else:
-        Logger.error(f'Unable to convert constant to numpy array: {add_node.name}')  # pragma: no cover
 
     # return new bias
     if bias is None:

--- a/model_compression_toolkit/core/keras/tf_tensor_numpy.py
+++ b/model_compression_toolkit/core/keras/tf_tensor_numpy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Union, List, Tuple
 import tensorflow as tf
 import numpy as np
 
@@ -37,11 +38,14 @@ def to_tf_tensor(tensor):
         raise Exception(f'Conversion of type {type(tensor)} to {type(tf.Tensor)} is not supported')
 
 
-def tf_tensor_to_numpy(tensor: tf.Tensor) -> np.ndarray:
+def tf_tensor_to_numpy(tensor: Union[List, Tuple, np.ndarray, tf.Tensor],
+                       is_single_tensor=False) -> np.ndarray:
     """
     Convert a TF tensor to a Numpy array.
     Args:
         tensor: TF tensor.
+        is_single_tensor: whether input is a value to be converted to a single tensor.
+                          if False, recurse the lists and tuples
 
     Returns:
         Numpy array converted from the input tensor.
@@ -49,9 +53,15 @@ def tf_tensor_to_numpy(tensor: tf.Tensor) -> np.ndarray:
     if isinstance(tensor, np.ndarray):
         return tensor
     elif isinstance(tensor, list):
-        return [tf_tensor_to_numpy(t) for t in tensor]
+        if is_single_tensor:
+            return np.array(tensor)
+        else:
+            return [tf_tensor_to_numpy(t) for t in tensor]
     elif isinstance(tensor, tuple):
-        return (tf_tensor_to_numpy(t) for t in tensor)
+        if is_single_tensor:
+            return np.array(tensor)
+        else:
+            return (tf_tensor_to_numpy(t) for t in tensor)
     elif isinstance(tensor, tf.Tensor):
         return tensor.numpy()
     else:

--- a/model_compression_toolkit/core/pytorch/back2framework/pytorch_model_builder.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/pytorch_model_builder.py
@@ -64,8 +64,7 @@ def _build_input_tensors_list(node: BaseNode,
         input_tensors = [tensor for tensor_list in input_tensors for tensor in tensor_list]  # flat list of lists
         input_tensors = node.insert_positional_weights_to_input_list(input_tensors)
         # convert inputs from positional weights (numpy arrays) to tensors
-        input_tensors = [to_torch_tensor(t) if isinstance(t, np.ndarray) else t
-                         for t in input_tensors]
+        input_tensors = to_torch_tensor(input_tensors)
     return input_tensors
 
 

--- a/model_compression_toolkit/core/pytorch/back2framework/pytorch_model_builder.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/pytorch_model_builder.py
@@ -63,8 +63,10 @@ def _build_input_tensors_list(node: BaseNode,
             input_tensors.append(_input_tensors)
         input_tensors = [tensor for tensor_list in input_tensors for tensor in tensor_list]  # flat list of lists
         input_tensors = node.insert_positional_weights_to_input_list(input_tensors)
-        # convert inputs from positional weights (numpy arrays) to tensors
-        input_tensors = to_torch_tensor(input_tensors)
+        # convert inputs from positional weights (numpy arrays) to tensors. Must handle each element in the
+        # list separately, because in FX the tensors are FX objects and fail to_torch_tensor
+        input_tensors = [to_torch_tensor(t) if isinstance(t, np.ndarray) else t
+                         for t in input_tensors]
     return input_tensors
 
 

--- a/model_compression_toolkit/core/pytorch/constants.py
+++ b/model_compression_toolkit/core/pytorch/constants.py
@@ -17,8 +17,6 @@
 # # Layer type constants:
 PLACEHOLDER = 'placeholder'
 OUTPUT = 'output'
-CONSTANT = 'constant'
-BUFFER = 'buffer'
 
 # # Module operation type
 CALL_FUNCTION = 'call_function'

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/const_holder_conv.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/const_holder_conv.py
@@ -14,90 +14,71 @@
 # ==============================================================================
 from torch.nn import Conv2d, ConvTranspose2d
 from torch.nn.functional import conv2d, conv_transpose2d
-from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher, EdgeMatcher
+from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher
+from model_compression_toolkit.logger import Logger
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common.graph.base_graph import Graph
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
-from model_compression_toolkit.core.pytorch.reader.graph_builders import ConstantHolder
-from model_compression_toolkit.core.pytorch.constants import IN_CHANNELS, OUT_CHANNELS, KERNEL_SIZE, KERNEL, BIAS, CONSTANT
+from model_compression_toolkit.core.pytorch.constants import IN_CHANNELS, OUT_CHANNELS, KERNEL_SIZE, KERNEL, BIAS
 from model_compression_toolkit.core.common import FrameworkInfo
 
-class ConstantHolderConv(common.BaseSubstitution):
-    """
-    Find "ConstantHolder" followed by conv layer to substitute a new single layer with weights if needed
-    """
 
+class FunctionalConvSubstitution(common.BaseSubstitution):
+    """
+    Substitute functional convolutions with Layers
+    """
     def __init__(self, fw_info: FrameworkInfo):
         """
-        Matches: 'ConstantHolder' followed by conv layer
+        Matches a functional conv node
         """
-        first_node = NodeOperationMatcher(ConstantHolder)
-        second_node = NodeOperationMatcher(conv2d) | NodeOperationMatcher(conv_transpose2d)
+        func_node = NodeOperationMatcher(conv2d) | NodeOperationMatcher(conv_transpose2d)
         self.fw_info = fw_info
-        super().__init__(matcher_instance=EdgeMatcher(first_node, second_node))
+        super().__init__(matcher_instance=func_node)
 
     def substitute(self,
                    graph: Graph,
-                   nodes: BaseNode) -> Graph:
+                   func_node: BaseNode) -> Graph:
         """
-        Substitute ConstantHolder and conv/linear layer with single layer
+        Substitute functional and conv/linear layer with torch layer
         Args:
             graph: Graph we apply the substitution on.
-            nodes: nodes that match the pattern in the substitution init.
+            func_node: node that match the pattern in the substitution init.
 
         Returns:
             Graph after applying the substitution.
         """
-        first_node = nodes[0] # constant holder node
-        second_node = nodes[1] # convolution node
-
-        # Check if there is a connection
-        if graph.get_edge_data(first_node,second_node) is None:
-            return graph # skip substitution
-
         # Set new layer
-        if second_node.type == conv2d:
-            NewLayer = Conv2d
-        elif second_node.type == conv_transpose2d:
-            NewLayer = ConvTranspose2d
+        if func_node.type == conv2d:
+            new_layer = Conv2d
+        elif func_node.type == conv_transpose2d:
+            new_layer = ConvTranspose2d
         else:
-            return graph # skip substitution
+            Logger.error('mismatch in substitution filter')  # pragma: no cover
 
-        out_channel_index, in_channel_index = self.fw_info.kernel_channels_mapping.get(NewLayer)
-
-        # Check if there is a bias node
-        bias_node = None
-        prev_nodes = graph.get_prev_nodes(second_node)
-        prev_nodes = list(filter(lambda prev_node: prev_node.type == ConstantHolder, prev_nodes))
-        if len(prev_nodes) == 2:
-            bias_node = prev_nodes[1]
+        out_channel_index, in_channel_index = self.fw_info.kernel_channels_mapping.get(new_layer)
 
         # Create new node of layer convolution
-        weights = first_node.get_weights_by_keys(CONSTANT)
-        framework_attr = second_node.framework_attr
-        framework_attr.update({OUT_CHANNELS: weights.shape[out_channel_index]})
-        framework_attr.update({IN_CHANNELS: weights.shape[in_channel_index]})
-        framework_attr.update({KERNEL_SIZE: weights.shape[2:]})
+        if 1 not in func_node.weights:
+            Logger.error('missing weight input')  # pragma: no cover
+        weight = func_node.weights[1]
+        bias = func_node.weights.get(2)
+        framework_attr = func_node.framework_attr
+        framework_attr.update({OUT_CHANNELS: weight.shape[out_channel_index]})
+        framework_attr.update({IN_CHANNELS: weight.shape[in_channel_index]})
+        framework_attr.update({KERNEL_SIZE: weight.shape[2:]})
 
-        new_node = BaseNode(name=second_node.name,
+        new_node = BaseNode(name=func_node.name,
                             framework_attr=framework_attr,
-                            input_shape=second_node.input_shape,
-                            output_shape=second_node.output_shape,
-                            weights={KERNEL: weights} if bias_node is None else {KERNEL: weights, BIAS: bias_node.get_weights_by_keys(CONSTANT)},
-                            layer_class=NewLayer,
-                            has_activation=second_node.has_activation)
+                            input_shape=func_node.input_shape,
+                            output_shape=func_node.output_shape,
+                            weights={KERNEL: weight} if bias is None else {KERNEL: weight, BIAS: bias},
+                            layer_class=new_layer,
+                            has_activation=func_node.has_activation)
         graph.add_node(new_node)
-        if bias_node is not None:
-            graph.remove_edge(bias_node, second_node)
-            if len(graph.get_next_nodes(bias_node)) == 0:
-                graph.remove_node(bias_node)
-        graph.remove_edge(first_node, second_node)
-        if len(graph.get_next_nodes(first_node)) == 0:
-            graph.remove_node(first_node)
-        graph.reconnect_out_edges(current_node=second_node, new_node=new_node)
-        graph.reconnect_in_edges(current_node=second_node, new_node=new_node)
-        graph.replace_output_node(current_node=second_node, new_node=new_node)
-        graph.remove_node(second_node)
+        graph.reconnect_out_edges(current_node=func_node, new_node=new_node)
+        graph.reconnect_in_edges(current_node=func_node, new_node=new_node)
+        graph.replace_output_node(current_node=func_node, new_node=new_node)
+        graph.remove_node(func_node)
 
         return graph
 

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/functional_batch_norm.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/functional_batch_norm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Dict
 import numpy as np
 from torch import nn
 import torch.nn.functional as F
@@ -36,14 +37,14 @@ class FunctionalBatchNorm(common.BaseSubstitution):
         super().__init__(matcher_instance=bn_node)
 
     @staticmethod
-    def get_attributes_from_weights(node: BaseNode) -> dict:
+    def get_attributes_from_weights(node: BaseNode) -> Dict:
         """
         convert functional batch_norm positional weights to BatchNorm2d weights
         Args:
             node: functional batch_norm node.
 
         Returns:
-            weights dictionary for BatchNorm2d.
+            Weights dictionary for BatchNorm2d.
         """
         if 1 not in node.weights and 2 not in node.weights:
             Logger.error(f'Missing {MOVING_MEAN} and {MOVING_VARIANCE} in functional batch_norm inputs')

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/functional_layer_norm.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/functional_layer_norm.py
@@ -46,7 +46,7 @@ class FunctionalLayerNorm(common.BaseSubstitution):
             normalized_shape: nn.LayerNorm "normalized_shape" argument
 
         Returns:
-            weights dictionary for LayerNorm.
+            Weights dictionary for LayerNorm.
         """
 
         # Define default weight and bias

--- a/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/functional_layer_norm.py
+++ b/model_compression_toolkit/core/pytorch/graph_substitutions/substitutions/functional_layer_norm.py
@@ -16,7 +16,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 import numpy as np
-from typing import Tuple, List
+from typing import Dict, Tuple, List
 
 from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher
 from model_compression_toolkit.core import common
@@ -37,36 +37,37 @@ class FunctionalLayerNorm(common.BaseSubstitution):
         ln_node = NodeOperationMatcher(F.layer_norm)
         super().__init__(matcher_instance=ln_node)
 
-    def get_attributes_from_inputs(self, graph: Graph, node: BaseNode, normalized_shape: [Tuple, List, int]) -> dict:
+    @staticmethod
+    def get_attributes_from_weights(node: BaseNode, normalized_shape: [Tuple, List, int]) -> Dict:
         """
         Parse layer_norm(input, normalized_shape, weight=None, bias=None)
         Args:
-            graph: Graph we apply the substitution on.
             node: Node that match the pattern in the substitution init.
             normalized_shape: nn.LayerNorm "normalized_shape" argument
 
         Returns:
-            Graph after applying the substitution.
+            weights dictionary for LayerNorm.
         """
 
-        # Get input nodes (sorted)
-        input_nodes = graph.get_prev_nodes(node, sink_index_sorted=True)
-
         # Define default weight and bias
-        w0 = np.ones(normalized_shape) # Default value in case weight is not given
-        b0 = np.zeros(normalized_shape) # Default value in case bias is not given
+        weights_dict = {GAMMA: np.ones(normalized_shape), # Default value in case weight is not given
+                        BETA: np.zeros(normalized_shape) # Default value in case bias is not given
+                        }
 
         # Check if weight and/or bias were not given.
         has_weight = WEIGHT not in node.framework_attr
         has_bias = BIAS not in node.framework_attr
 
-        weight_input_ind = 1 if has_weight else 0
-        bias_input_ind = weight_input_ind + 1
+        if 1 in node.weights:
+            if has_weight:
+                weights_dict[GAMMA] = node.weights[1]
+            else:
+                weights_dict[BETA] = node.weights[1]
+        if 2 in node.weights:
+            assert has_bias
+            weights_dict[BETA] = node.weights[2]
 
-        return {
-            GAMMA: list(input_nodes[weight_input_ind].weights.values())[0] if has_weight else w0,
-            BETA: list(input_nodes[bias_input_ind].weights.values())[0] if has_bias else b0
-        }
+        return weights_dict
 
     def substitute(self,
                    graph: Graph,
@@ -82,7 +83,7 @@ class FunctionalLayerNorm(common.BaseSubstitution):
         """
         normalized_shape = node.input_shape[0][-1]
 
-        ln_node_weights = self.get_attributes_from_inputs(graph, node, normalized_shape)
+        ln_node_weights = self.get_attributes_from_weights(node, normalized_shape)
 
         new_layernorm = BaseNode(name=node.name + '_into_LayerNorm',
                                  framework_attr={NORMALIZED_SHAPE: normalized_shape,
@@ -93,17 +94,5 @@ class FunctionalLayerNorm(common.BaseSubstitution):
                                  weights=ln_node_weights,
                                  layer_class=nn.LayerNorm)
 
-        num_nodes_before_substitution = len(graph.nodes)
-        num_edges_before_substitution = len(graph.edges)
-
-        layer_norm_consts = graph.get_prev_nodes(node)[1:]
-        for const in layer_norm_consts:
-            graph.remove_edge(const, node)
-            graph.remove_node(const)
-
         graph.replace_node(node, new_layernorm)
-
-        assert num_nodes_before_substitution - len(graph.nodes) == len(layer_norm_consts)
-        assert num_edges_before_substitution - len(graph.edges) == len(layer_norm_consts)
-
         return graph

--- a/model_compression_toolkit/core/pytorch/pytorch_implementation.py
+++ b/model_compression_toolkit/core/pytorch/pytorch_implementation.py
@@ -59,7 +59,7 @@ from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.mu
 from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.permute_call_method import \
     PermuteCallMethod
 from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.const_holder_conv import \
-    ConstantHolderConv
+    FunctionalConvSubstitution
 from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.relu_bound_to_power_of_2 import \
     ReLUBoundToPowerOfTwo
 from model_compression_toolkit.core.pytorch.graph_substitutions.substitutions.reshape_with_static_shapes import \
@@ -247,7 +247,7 @@ class PytorchImplementation(FrameworkImplementation):
         return [ReshapeWithStaticShapes(),
                 MultiHeadAttentionDecomposition(),
                 PermuteCallMethod(),
-                ConstantHolderConv(fw_info),
+                FunctionalConvSubstitution(fw_info),
                 FunctionalBatchNorm(),
                 FunctionalLayerNorm()]
 

--- a/model_compression_toolkit/core/pytorch/reader/node_holders.py
+++ b/model_compression_toolkit/core/pytorch/reader/node_holders.py
@@ -16,7 +16,7 @@
 
 import torch
 
-from model_compression_toolkit.core.pytorch.constants import PLACEHOLDER, CONSTANT, BUFFER
+from model_compression_toolkit.core.pytorch.constants import PLACEHOLDER
 
 
 class DummyPlaceHolder(torch.nn.Module):
@@ -29,36 +29,3 @@ class DummyPlaceHolder(torch.nn.Module):
 
     def forward(self, x):
         return x
-
-
-class ConstantHolder(torch.nn.Module):
-    """
-    Class for saving constant values or parameters in graph inference.
-    """
-
-    def __init__(self, const_size):
-        super(ConstantHolder, self).__init__()
-        setattr(self, CONSTANT, torch.nn.Parameter(torch.empty(const_size)))
-
-    def __name__(self):
-        return CONSTANT
-
-    def forward(self):
-        return getattr(self, CONSTANT)
-
-
-class BufferHolder(torch.nn.Module):
-    """
-    Class for saving buffers in graph inference.
-    """
-
-    def __init__(self, name):
-        super(BufferHolder, self).__init__()
-        setattr(self, BUFFER, name)
-
-    def __name__(self):
-        return BUFFER
-
-    def forward(self):
-        return self.get_buffer(getattr(self, BUFFER))
-

--- a/model_compression_toolkit/ptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/ptq/pytorch/quantization_facade.py
@@ -96,12 +96,12 @@ if FOUND_TORCH:
         if core_config.mixed_precision_enable:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfigV2):
                 Logger.error("Given quantization config to mixed-precision facade is not of type "
-                                    "MixedPrecisionQuantizationConfigV2. Please use "
-                                    "pytorch_post_training_quantization API, or pass a valid mixed precision "
-                                    "configuration.")  # pragma: no cover
+                             "MixedPrecisionQuantizationConfigV2. Please use "
+                             "pytorch_post_training_quantization API, or pass a valid mixed precision "
+                             "configuration.")  # pragma: no cover
 
             Logger.info("Using experimental mixed-precision quantization. "
-                               "If you encounter an issue please file a bug.")
+                        "If you encounter an issue please file a bug.")
 
         tb_w = init_tensorboard_writer(DEFAULT_PYTORCH_INFO)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/const_representation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/const_representation_test.py
@@ -1,0 +1,111 @@
+# Copyright 2024 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import tensorflow as tf
+import numpy as np
+
+import model_compression_toolkit as mct
+from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
+from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_keras_tpc
+from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
+from tests.common_tests.helpers.tensors_compare import cosine_similarity
+
+keras = tf.keras
+layers = keras.layers
+tp = mct.target_platform
+
+
+class ConstRepresentationTest(BaseKerasFeatureNetworkTest):
+
+    def __init__(self, unit_test, layer, const, is_list_input=False,
+                 as_layer=False, input_reverse_order=False, use_kwrags=False,
+                 input_shape=(32, 32, 16)):
+        super(ConstRepresentationTest, self).__init__(unit_test=unit_test, input_shape=input_shape,
+                                                      experimental_exporter=True)
+        self.layer = layer
+        self.const = const
+        self.is_list_input = is_list_input
+        self.as_layer = as_layer
+        self.input_reverse_order = input_reverse_order
+        self.use_kwrags = use_kwrags
+
+    def generate_inputs(self):
+        # need positive inputs so won't divide with zero or take root of negative number
+        return [1+np.random.random((in_shape)) for in_shape in self.get_input_shapes()]
+
+    def get_tpc(self):
+        tp = generate_test_tp_model({'weights_n_bits': 16,
+                                     'activation_n_bits': 16,
+                                     'enable_weights_quantization': False,
+                                     'enable_activation_quantization': False})
+        return generate_keras_tpc(name="bn_folding_test", tp_model=tp)
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = inputs
+        if self.is_list_input:
+            if self.input_reverse_order:
+                x = self.layer([self.const, x])
+            else:
+                x = self.layer([x, self.const])
+        else:
+            if self.input_reverse_order:
+                if self.use_kwrags:
+                    x = self.layer(x=self.const, y=x)
+                else:
+                    x = self.layer(self.const, x)
+            else:
+                if self.use_kwrags:
+                    x = self.layer(x=x, y=self.const)
+                else:
+                    x = self.layer(x, self.const)
+        return tf.keras.models.Model(inputs=inputs, outputs=x)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        y = float_model.predict(input_x)
+        y_hat = quantized_model.predict(input_x)
+        self.unit_test.assertTrue(y.shape == y_hat.shape, msg=f'out shape is not as expected!')
+        cs = cosine_similarity(y, y_hat)
+        self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')
+
+
+class ConstRepresentationMultiInputTest(BaseKerasFeatureNetworkTest):
+
+    def __init__(self, unit_test, input_shape=(32, 32, 16)):
+        super(ConstRepresentationMultiInputTest, self).__init__(unit_test=unit_test, input_shape=input_shape,
+                                                                experimental_exporter=True)
+
+    def get_tpc(self):
+        tp = generate_test_tp_model({'weights_n_bits': 16,
+                                     'activation_n_bits': 16,
+                                     'enable_weights_quantization': False,
+                                     'enable_activation_quantization': False})
+        return generate_keras_tpc(name="bn_folding_test", tp_model=tp)
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = layers.Concatenate()([inputs, np.random.random((1, 32, 32, 3)), inputs, np.random.random((1, 32, 32, 3))])
+        x1 = layers.Add()([np.random.random((1, x.shape[-1])), x, np.random.random((1, x.shape[-1]))])
+        x2 = layers.Multiply()([x, np.random.random((1, x.shape[-1])), x, np.random.random((1, x.shape[-1]))])
+        x3 = tf.add_n([x1, np.random.random(x.shape.as_list()).astype(np.float32), x2])
+        x = tf.concat([x1, x2, np.random.random(x3.shape.as_list()).astype(np.float32), x3], 1)
+        return tf.keras.models.Model(inputs=inputs, outputs=x)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        y = float_model.predict(input_x)
+        y_hat = quantized_model.predict(input_x)
+        self.unit_test.assertTrue(y.shape == y_hat.shape, msg=f'out shape is not as expected!')
+        cs = cosine_similarity(y, y_hat)
+        self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+import numpy as np
 import tensorflow as tf
 from tensorflow.keras.layers import PReLU, ELU
 
@@ -125,6 +126,8 @@ from tests.keras_tests.feature_networks_tests.feature_networks.weights_mixed_pre
     MixedPercisionSearchTotalKPINonConfNodesTest, MixedPercisionSearchPartWeightsLayersTest, MixedPercisionCombinedNMSTest
 from tests.keras_tests.feature_networks_tests.feature_networks.old_api_test import OldApiTest
 from tests.keras_tests.feature_networks_tests.feature_networks.matmul_substitution_test import MatmulToDenseSubstitutionTest
+from tests.keras_tests.feature_networks_tests.feature_networks.const_representation_test import ConstRepresentationTest, \
+    ConstRepresentationMultiInputTest
 from model_compression_toolkit.qat.common.qat_config import TrainingMethod
 
 layers = tf.keras.layers
@@ -536,6 +539,23 @@ class FeatureNetworkTest(unittest.TestCase):
         FourConv2DCollapsingTest(self).run_test()
         SixConv2DCollapsingTest(self).run_test()
         Op2DAddConstCollapsingTest(self).run_test()
+
+    def test_const_representation(self):
+        c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32)
+        for func in [tf.add, tf.multiply, tf.subtract, tf.divide, tf.truediv, tf.pow]:
+            ConstRepresentationTest(self, func, c, as_layer=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwrags=True).run_test()
+            ConstRepresentationTest(self, func, c, as_layer=True, use_kwrags=True).run_test()
+
+        c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32).reshape((1, -1))
+        for func in [layers.Add(), layers.Multiply(), layers.Subtract()]:
+            ConstRepresentationTest(self, func, c, as_layer=True, is_list_input=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True, is_list_input=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwrags=True, is_list_input=True).run_test()
+            ConstRepresentationTest(self, func, c, as_layer=True, use_kwrags=True, is_list_input=True).run_test()
+
+        ConstRepresentationMultiInputTest(self).run_test()
 
     def test_second_moment(self):
         DepthwiseConv2DSecondMomentTest(self).run_test()

--- a/tests/keras_tests/function_tests/test_unsupported_custom_layer.py
+++ b/tests/keras_tests/function_tests/test_unsupported_custom_layer.py
@@ -43,9 +43,12 @@ class TestUnsupportedCustomLayer(unittest.TestCase):
                          f'\'test_unsupported_custom_layer.CustomIdentity\'>. Please add the custom layer to TPC ' \
                          f'or file a feature request or an issue if you believe this is an issue.'
 
+        def rep_dataset():
+            yield [np.random.randn(1, 3, 3, 3)]
+
         with self.assertRaises(Exception) as e:
             mct.ptq.keras_post_training_quantization_experimental(model,
-                                                                  lambda _: [np.random.randn(1, 3, 3, 3)])
+                                                                  rep_dataset)
         # Remove class object path to compare with expected error message
         err_msg = str(e.exception)
         err_msg = err_msg[:err_msg.find('<class ')+8] + err_msg[err_msg.find('test_unsupported_custom_layer'):]

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -34,7 +34,7 @@ from model_compression_toolkit.ptq import pytorch_post_training_quantization_exp
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
 from model_compression_toolkit.core.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
-from model_compression_toolkit.core.pytorch.reader.node_holders import DummyPlaceHolder, ConstantHolder
+from model_compression_toolkit.core.pytorch.reader.node_holders import DummyPlaceHolder
 from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy, to_torch_tensor
 from tests.common_tests.base_layer_test import BaseLayerTest, LayerTestMode
 from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
@@ -45,7 +45,7 @@ from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_m
 PYTORCH_LAYER_TEST_OPS = {
     "kernel_ops": [Conv2d, Linear, ConvTranspose2d],
 
-    "no_quantization": [Dropout, Flatten, ConstantHolder, dropout, flatten, split, operator.getitem, reshape,
+    "no_quantization": [Dropout, Flatten, dropout, flatten, split, operator.getitem, reshape,
                         unsqueeze],
 
     "activation": [DummyPlaceHolder,
@@ -137,11 +137,11 @@ class BasePytorchLayerTest(BaseLayerTest):
         if self.current_mode == LayerTestMode.FLOAT:
             # Disable all features that are enabled by default:
             tp = generate_test_tp_model({'enable_weights_quantization': False,
-                                          'enable_activation_quantization': False})
+                                         'enable_activation_quantization': False})
             return generate_pytorch_tpc(name="base_layer_test", tp_model=tp)
         elif self.current_mode == LayerTestMode.QUANTIZED_8_BITS:
             tp = generate_test_tp_model({'weights_n_bits': 8,
-                                          'activation_n_bits': 8})
+                                         'activation_n_bits': 8})
             return generate_pytorch_tpc(name="8bit_layer_test", tp_model=tp)
         else:
             raise NotImplemented

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -33,7 +33,7 @@ The base test class for the feature networks
 class BasePytorchTest(BaseFeatureNetworkTest):
     def __init__(self,
                  unit_test,
-                 float_reconstruction_error=1e-7,
+                 float_reconstruction_error=1e-6,
                  convert_to_fx=True,
                  experimental_exporter=True,
                  val_batch_size=1):

--- a/tests/pytorch_tests/model_tests/feature_models/bn_function_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/bn_function_test.py
@@ -18,7 +18,7 @@ from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 from model_compression_toolkit.core.pytorch.pytorch_device_config import get_working_device
 
 """
-This tests check the batch_norm function and demonstrates the usage of BufferHolder node.
+This tests check the batch_norm function.
 """
 
 
@@ -39,7 +39,7 @@ class BNFNet(torch.nn.Module):
 
 class BNFNetTest(BasePytorchTest):
     """
-    This tests check the batch_norm function and demonstrates the usage of BufferHolder node.
+    This test check the batch_norm function.
     """
 
     def __init__(self, unit_test):

--- a/tests/pytorch_tests/model_tests/feature_models/bn_function_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/bn_function_test.py
@@ -18,7 +18,7 @@ from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 from model_compression_toolkit.core.pytorch.pytorch_device_config import get_working_device
 
 """
-This tests check the batch_norm function.
+This test checks the batch_norm function.
 """
 
 

--- a/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import torch
+import torch.nn as nn
+import numpy as np
+import model_compression_toolkit as mct
+from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
+from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
+from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
+from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from tests.common_tests.helpers.tensors_compare import cosine_similarity
+
+tp = mct.target_platform
+
+
+class ConstRepresentationNet(nn.Module):
+    def __init__(self, layer, const):
+        super().__init__()
+        self.layer = layer
+        self.const = to_torch_tensor(const)
+
+    def forward(self, x):
+        return self.layer(x, self.const)
+
+
+class ConstRepresentationReverseOrderNet(nn.Module):
+    def __init__(self, layer, const):
+        super().__init__()
+        self.layer = layer
+        self.const = to_torch_tensor(const)
+
+    def forward(self, x):
+        return self.layer(self.const, x)
+
+
+class ConstRepresentationTest(BasePytorchFeatureNetworkTest):
+
+    def __init__(self, unit_test, func, const, input_reverse_order=False):
+        super().__init__(unit_test=unit_test, input_shape=(16, 32, 32))
+        self.func = func
+        self.const = const
+        self.input_reverse_order = input_reverse_order
+
+    def get_tpc(self):
+        tp = generate_test_tp_model({'weights_n_bits': 32,
+                                     'activation_n_bits': 32,
+                                     'enable_weights_quantization': False,
+                                     'enable_activation_quantization': False})
+        return generate_pytorch_tpc(name="linear_collapsing_test", tp_model=tp)
+
+    def get_quantization_config(self):
+        return mct.core.QuantizationConfig(mct.core.QuantizationErrorMethod.NOCLIPPING,
+                                      mct.core.QuantizationErrorMethod.NOCLIPPING,
+                                      False, False, True)
+
+    def create_networks(self):
+        if self.input_reverse_order:
+            return ConstRepresentationReverseOrderNet(self.func, self.const)
+        else:
+            return ConstRepresentationNet(self.func, self.const)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        in_torch_tensor = to_torch_tensor(input_x[0])
+        set_model(float_model)
+        y = float_model(in_torch_tensor)
+        y_hat = quantized_model(in_torch_tensor)
+        self.unit_test.assertTrue(y.shape == y_hat.shape, msg=f'out shape is not as expected!')
+        cs = cosine_similarity(torch_tensor_to_numpy(y), torch_tensor_to_numpy(y_hat))
+        self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')
+
+
+class ConstRepresentationMultiInputNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const1 = to_torch_tensor(np.random.random((32,)))
+        self.const2 = to_torch_tensor(np.random.random((32,)))
+        self.const3 = to_torch_tensor(np.random.random((1, 5, 32, 32)))
+
+    def forward(self, x):
+        x1 = sum([self.const1, x, self.const2])  # not really a 3-input add operation, but just in case torch will support it
+        x = torch.cat([x1, self.const3, x], dim=1)
+        return x
+
+
+class ConstRepresentationMultiInputTest(ConstRepresentationTest):
+
+    def __init__(self, unit_test):
+        super().__init__(unit_test=unit_test, func=None, const=None, input_reverse_order=False)
+
+    def create_networks(self):
+        return ConstRepresentationMultiInputNet()

--- a/tests/pytorch_tests/model_tests/feature_models/layer_norm_net_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/layer_norm_net_test.py
@@ -48,7 +48,6 @@ class LayerNormNet(torch.nn.Module):
         return x
 
 
-
 class LayerNormNetTest(BasePytorchTest):
     """
     This tests check the addition and subtraction operations.

--- a/tests/pytorch_tests/model_tests/feature_models/layer_norm_net_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/layer_norm_net_test.py
@@ -16,9 +16,11 @@ import torch
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 
 """
-This tests check the addition and subtraction operations. 
+This test checks the addition and subtraction operations. 
 Both with different layers and with constants.
 """
+
+
 class LayerNormNet(torch.nn.Module):
     def __init__(self, has_weight=None, has_bias=None):
         super(LayerNormNet, self).__init__()
@@ -50,7 +52,7 @@ class LayerNormNet(torch.nn.Module):
 
 class LayerNormNetTest(BasePytorchTest):
     """
-    This tests check the addition and subtraction operations.
+    This test checks the addition and subtraction operations.
     Both with different layers and with constants.
     """
     def __init__(self, unit_test, has_weight=None, has_bias=None):

--- a/tests/pytorch_tests/model_tests/feature_models/linear_collapsing_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/linear_collapsing_test.py
@@ -28,7 +28,7 @@ tp = mct.target_platform
 class BaseConv2DCollapsingTest(BasePytorchFeatureNetworkTest, ABC):
 
     def __init__(self, unit_test):
-        super().__init__(unit_test=unit_test, input_shape=(16,32,32))
+        super().__init__(unit_test=unit_test, input_shape=(16, 32, 32))
 
     def get_tpc(self):
         tp = generate_test_tp_model({'weights_n_bits': 32,
@@ -53,6 +53,7 @@ class BaseConv2DCollapsingTest(BasePytorchFeatureNetworkTest, ABC):
         cs = cosine_similarity(torch_tensor_to_numpy(y), torch_tensor_to_numpy(y_hat))
         self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')
 
+
 class TwoConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
@@ -70,6 +71,7 @@ class TwoConv2DCollapsingTest(BaseConv2DCollapsingTest):
 
     def create_networks(self):
         return self.Conv2DCollapsingNet()
+
 
 class ThreeConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def __init__(self, unit_test):
@@ -92,6 +94,7 @@ class ThreeConv2DCollapsingTest(BaseConv2DCollapsingTest):
 
     def create_networks(self):
         return self.Conv2DCollapsingNet()
+
 
 class FourConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def __init__(self, unit_test):
@@ -116,6 +119,7 @@ class FourConv2DCollapsingTest(BaseConv2DCollapsingTest):
 
     def create_networks(self):
         return self.Conv2DCollapsingNet()
+
 
 class SixConv2DCollapsingTest(BaseConv2DCollapsingTest):
     def __init__(self, unit_test):

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -15,6 +15,7 @@
 import unittest
 from functools import partial
 
+import numpy as np
 import torch
 from torch import nn
 import model_compression_toolkit as mct
@@ -82,6 +83,8 @@ from tests.pytorch_tests.model_tests.feature_models.gptq_test import GPTQAccurac
 from tests.pytorch_tests.model_tests.feature_models.uniform_activation_test import \
     UniformActivationTest
 from tests.pytorch_tests.model_tests.feature_models.old_api_test import OldApiTest
+from tests.pytorch_tests.model_tests.feature_models.const_representation_test import ConstRepresentationTest, \
+    ConstRepresentationMultiInputTest
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 
 
@@ -149,7 +152,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
         This test checks the BatchNorm folding feature.
         """
         for functional in [True, False]:
-            BNFoldingNetTest(self, nn.Conv2d(3, 2, kernel_size=1), functional).run_test()
+            BNFoldingNetTest(self, nn.Conv2d(3, 2, kernel_size=1), functional, has_weight=False).run_test()
             BNFoldingNetTest(self, nn.Conv2d(3, 3, kernel_size=3, groups=3), functional).run_test()  # DW-Conv test
             BNFoldingNetTest(self, nn.ConvTranspose2d(3, 2, kernel_size=(2, 1)), functional).run_test()
             BNFoldingNetTest(self, nn.Conv2d(3, 2, kernel_size=2), functional, fold_applied=False).run_test()
@@ -191,7 +194,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
 
     def test_bn_function(self):
         """
-        This tests check the batch_norm function and demonstrates the usage of BufferHolder node.
+        This test check the batch_norm function.
         """
         BNFNetTest(self).run_test()
 
@@ -217,6 +220,14 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         ResidualCollapsingTest1(self).run_test()
         ResidualCollapsingTest2(self).run_test()
+
+    def test_const_representation(self):
+        c = (np.ones((32,)) + np.random.random((32,))).astype(np.float32)
+        for func in [torch.add, torch.sub, torch.mul, torch.div]:
+            ConstRepresentationTest(self, func, c).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True).run_test()
+
+        ConstRepresentationMultiInputTest(self).run_test()
 
     def test_permute_substitution(self):
         """

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -194,13 +194,13 @@ class FeatureModelsTestRunner(unittest.TestCase):
 
     def test_bn_function(self):
         """
-        This test check the batch_norm function.
+        This test checks the batch_norm function.
         """
         BNFNetTest(self).run_test()
 
     def test_broken_net(self):
         """
-        This tests checks that the "broken" node (node without output) is being
+        This test checks that the "broken" node (node without output) is being
         removed from the graph during quantization.
         """
         BrokenNetTest(self).run_test()


### PR DESCRIPTION
## Pull Request Description:
This PR refactors the way MCT handles constants. Instead of keeping them in the framework_attr, the constants are saved as weights in the internal graph nodes. The constants are referred to as "positional weights" whos keys are integers corresponding to the position of the constants in the call_args\call_kwargs. The constants are restored in the model builder.
This PR is the first step towards fully quantizing all constants in a model

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).