### PR TITLE
Fix Python 3.9 Windows file permission error in Fakely TFlite exporter

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_tflite_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_tflite_exporter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 import os
+from pathlib import Path
 import tempfile
 from typing import Callable
 


### PR DESCRIPTION
## Pull Request Description:

The same issue as reported in #865. This time unfortunately, the file created by `NamedTemporaryFile` can not be opened by another function while the handle is held by the context manager. This is precisely what happens in the Keras exporting mechanism. This issue happens on Windows with Python 3.9 (all the way to 3.11). The requirements for single ownership of the file have been relaxed in newer Python 3.12+.

This PR reverts the changes of #865 while preserving context management benefits it tried to bring by using a `try` block with a `finally` clause to ensure file deletion. It also uses `pathlib.Path` to delete the file without complaints if it was previously removed.
 
## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).