### PR TITLE
Change default onnx opset to 17

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -26,7 +26,10 @@ from mct_quantizers import pytorch_quantizers
 # ONNX opset version 16 is supported from PyTorch 1.12
 if version.parse(torch.__version__) < version.parse("1.12"):
     OPSET_VERSION = 15
+elif version.parse(torch.__version__) == version.parse("1.12"):
+    OPSET_VERSION = 16
 else:
+    # ONNX opset version 17 is supported from PyTorch 1.13
     OPSET_VERSION = 17
 
 

--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -27,7 +27,7 @@ from mct_quantizers import pytorch_quantizers
 if version.parse(torch.__version__) < version.parse("1.12"):
     OPSET_VERSION = 15
 else:
-    OPSET_VERSION = 16
+    OPSET_VERSION = 17
 
 
 class FakelyQuantONNXPyTorchExporter(BasePyTorchExporter):

--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -26,7 +26,7 @@ from mct_quantizers import pytorch_quantizers
 # ONNX opset version 16 is supported from PyTorch 1.12
 if version.parse(torch.__version__) < version.parse("1.12"):
     OPSET_VERSION = 15
-elif version.parse(torch.__version__) == version.parse("1.12"):
+elif version.parse("1.12.0") <= version.parse(torch.__version__) < version.parse("1.13.0"):
     OPSET_VERSION = 16
 else:
     # ONNX opset version 17 is supported from PyTorch 1.13


### PR DESCRIPTION
## Pull Request Description:
Change ONNX default opset when exporting Pytorch models. Changed from opset 16 to opset 17.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).