### PR TITLE
Fix base_quantizer tests

### DIFF
--- a/tests/trainable_infrastructure_tests/keras/trainable_keras/test_keras_base_quantizer.py
+++ b/tests/trainable_infrastructure_tests/keras/trainable_keras/test_keras_base_quantizer.py
@@ -41,7 +41,7 @@ class TestKerasBaseWeightsQuantizer(BaseKerasTrainableInfrastructureTest):
         with self.unit_test.assertRaises(Exception) as e:
             ZeroWeightsQuantizer(self.get_weights_quantization_config())
         self.unit_test.assertEqual(f'Quantization method mismatch expected: [<QuantizationMethod.POWER_OF_TWO: 0>, '
-                                   f''f'<QuantizationMethod.SYMMETRIC: 3>] and got  QuantizationMethod.UNIFORM',
+                                   f''f'<QuantizationMethod.SYMMETRIC: 2>] and got  QuantizationMethod.UNIFORM',
                                    str(e.exception))
 
         with self.unit_test.assertRaises(Exception) as e:
@@ -73,7 +73,7 @@ class TestKerasBaseActivationsQuantizer(BaseKerasTrainableInfrastructureTest):
         with self.unit_test.assertRaises(Exception) as e:
             ZeroActivationsQuantizer(self.get_activation_quantization_config())
         self.unit_test.assertEqual(f'Quantization method mismatch expected: [<QuantizationMethod.POWER_OF_TWO: 0>, '
-                                   f'<QuantizationMethod.SYMMETRIC: 3>] and got  QuantizationMethod.UNIFORM',
+                                   f'<QuantizationMethod.SYMMETRIC: 2>] and got  QuantizationMethod.UNIFORM',
                                    str(e.exception))
 
         with self.unit_test.assertRaises(Exception) as e:

--- a/tests/trainable_infrastructure_tests/pytorch/trainable_pytorch/test_pytorch_base_quantizer.py
+++ b/tests/trainable_infrastructure_tests/pytorch/trainable_pytorch/test_pytorch_base_quantizer.py
@@ -39,7 +39,7 @@ class TestPytorchBaseWeightsQuantizer(BasePytorchInfrastructureTest):
 
         with self.unit_test.assertRaises(Exception) as e:
             ZeroWeightsQuantizer(self.get_weights_quantization_config())
-        self.unit_test.assertEqual(f'Quantization method mismatch expected: [<QuantizationMethod.POWER_OF_TWO: 0>, <QuantizationMethod.SYMMETRIC: 3>] and got  QuantizationMethod.UNIFORM', str(e.exception))
+        self.unit_test.assertEqual(f'Quantization method mismatch expected: [<QuantizationMethod.POWER_OF_TWO: 0>, <QuantizationMethod.SYMMETRIC: 2>] and got  QuantizationMethod.UNIFORM', str(e.exception))
 
         with self.unit_test.assertRaises(Exception) as e:
             ZeroWeightsQuantizer(self.get_activation_quantization_config())
@@ -66,7 +66,7 @@ class TestPytorchBaseActivationQuantizer(BasePytorchInfrastructureTest):
 
         with self.unit_test.assertRaises(Exception) as e:
             ZeroActivationsQuantizer(self.get_activation_quantization_config())
-        self.unit_test.assertEqual(f'Quantization method mismatch expected: [<QuantizationMethod.POWER_OF_TWO: 0>, <QuantizationMethod.SYMMETRIC: 3>] and got  QuantizationMethod.UNIFORM', str(e.exception))
+        self.unit_test.assertEqual(f'Quantization method mismatch expected: [<QuantizationMethod.POWER_OF_TWO: 0>, <QuantizationMethod.SYMMETRIC: 2>] and got  QuantizationMethod.UNIFORM', str(e.exception))
 
         with self.unit_test.assertRaises(Exception) as e:
             ZeroActivationsQuantizer(self.get_weights_quantization_config())


### PR DESCRIPTION
## Pull Request Description:
Fix base_quantizer tests after removing KMEANS QuantizationMethod from mctq.
Fix the expected error message since QuantizationMethod enum values were changed.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).