### PR TITLE
Fix None bias in separable conv decomposition

### DIFF
--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/separableconv_decomposition.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/separableconv_decomposition.py
@@ -75,8 +75,10 @@ class SeparableConvDecomposition(common.BaseSubstitution):
         pw_bias = separable_node.get_weights_by_keys(BIAS)
 
         dw_weights_dict = {DEPTHWISE_KERNEL: dw_kernel}
-        pw_weights_dict = {KERNEL: pw_kernel,
-                           BIAS: pw_bias}
+        pw_weights_dict = {KERNEL: pw_kernel}
+
+        if pw_bias is not None:
+            pw_weights_dict[BIAS] = pw_bias
 
         # Split separable node attributes into relevant attributes for each of the new nodes.
         # List of dw attributes that should take from separable as they are.


### PR DESCRIPTION
## Pull Request Description:
Fix issue where we created a None bias to a decomposed separable conv node.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).