### PR TITLE
Move MP traget_kpi from facade to MixedPrecisionQuantizationConfig

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_quantization_config.py
@@ -15,6 +15,7 @@
 
 from typing import List, Callable
 
+from model_compression_toolkit.core.common.mixed_precision.kpi_tools.kpi import KPI
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import get_average_weights
 from model_compression_toolkit.core.common.similarity_analyzer import compute_mse
 
@@ -22,6 +23,7 @@ from model_compression_toolkit.core.common.similarity_analyzer import compute_ms
 class MixedPrecisionQuantizationConfig:
 
     def __init__(self,
+                 target_kpi: KPI = None,
                  compute_distance_fn: Callable = None,
                  distance_weighting_method: Callable = get_average_weights,
                  num_of_images: int = 32,
@@ -35,6 +37,7 @@ class MixedPrecisionQuantizationConfig:
         Class with mixed precision parameters to quantize the input model.
 
         Args:
+            target_kpi (KPI): KPI to constraint the search of the mixed-precision configuration for the model.
             compute_distance_fn (Callable): Function to compute a distance between two tensors.
             distance_weighting_method (Callable): Function to use when weighting the distances among different layers when computing the sensitivity metric.
             num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
@@ -47,6 +50,7 @@ class MixedPrecisionQuantizationConfig:
 
         """
 
+        self.target_kpi = target_kpi
         self.compute_distance_fn = compute_distance_fn
         self.distance_weighting_method = distance_weighting_method
         self.num_of_images = num_of_images

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -47,7 +47,6 @@ search_methods = {
 def search_bit_width(graph_to_search_cfg: Graph,
                      fw_info: FrameworkInfo,
                      fw_impl: FrameworkImplementation,
-                     target_kpi: KPI,
                      mp_config: MixedPrecisionQuantizationConfig,
                      representative_data_gen: Callable,
                      search_method: BitWidthSearchMethod = BitWidthSearchMethod.INTEGER_PROGRAMMING,
@@ -64,7 +63,6 @@ def search_bit_width(graph_to_search_cfg: Graph,
         graph_to_search_cfg: Graph to search a MP configuration for.
         fw_info: FrameworkInfo object about the specific framework (e.g., attributes of different layers' weights to quantize).
         fw_impl: FrameworkImplementation object with specific framework methods implementation.
-        target_kpi: Target KPI to bound our feasible solution space s.t the configuration does not violate it.
         mp_config: Mixed-precision quantization configuration.
         representative_data_gen: Dataset to use for retrieving images for the models inputs.
         search_method: BitWidthSearchMethod to define which searching method to use.
@@ -76,6 +74,7 @@ def search_bit_width(graph_to_search_cfg: Graph,
         bit-width index on the node).
 
     """
+    target_kpi = mp_config.target_kpi
 
     # target_kpi have to be passed. If it was not passed, the facade is not supposed to get here by now.
     if target_kpi is None:

--- a/model_compression_toolkit/gptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/gptq/pytorch/quantization_facade.py
@@ -94,7 +94,6 @@ if FOUND_TORCH:
 
     def pytorch_gradient_post_training_quantization(model: Module,
                                                     representative_data_gen: Callable,
-                                                    target_kpi: KPI = None,
                                                     core_config: CoreConfig = CoreConfig(),
                                                     gptq_config: GradientPTQConfig = None,
                                                     gptq_representative_data_gen: Callable = None,
@@ -118,7 +117,6 @@ if FOUND_TORCH:
         Args:
             model (Module): Pytorch model to quantize.
             representative_data_gen (Callable): Dataset used for calibration.
-            target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
             core_config (CoreConfig): Configuration object containing parameters of how the model should be quantized, including mixed precision parameters.
             gptq_config (GradientPTQConfig): Configuration for using gptq (e.g. optimizer).
             gptq_representative_data_gen (Callable): Dataset used for GPTQ training. If None defaults to representative_data_gen
@@ -176,7 +174,6 @@ if FOUND_TORCH:
                                                                      fw_info=DEFAULT_PYTORCH_INFO,
                                                                      fw_impl=fw_impl,
                                                                      tpc=target_platform_capabilities,
-                                                                     target_kpi=target_kpi,
                                                                      tb_w=tb_w)
 
         # ---------------------- #

--- a/model_compression_toolkit/ptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/ptq/keras/quantization_facade.py
@@ -42,7 +42,6 @@ if FOUND_TF:
 
     def keras_post_training_quantization(in_model: Model,
                                          representative_data_gen: Callable,
-                                         target_kpi: KPI = None,
                                          core_config: CoreConfig = CoreConfig(),
                                          target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_KERAS_TPC):
         """
@@ -61,7 +60,6 @@ if FOUND_TF:
          Args:
              in_model (Model): Keras model to quantize.
              representative_data_gen (Callable): Dataset used for calibration.
-             target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
              core_config (CoreConfig): Configuration object containing parameters of how the model should be quantized, including mixed precision parameters.
              target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the Keras model according to.
 
@@ -137,7 +135,6 @@ if FOUND_TF:
                                                fw_info=fw_info,
                                                fw_impl=fw_impl,
                                                tpc=target_platform_capabilities,
-                                               target_kpi=target_kpi,
                                                tb_w=tb_w)
 
         tg = ptq_runner(tg, representative_data_gen, core_config, fw_info, fw_impl, tb_w)

--- a/model_compression_toolkit/ptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/ptq/pytorch/quantization_facade.py
@@ -41,7 +41,6 @@ if FOUND_TORCH:
 
     def pytorch_post_training_quantization(in_module: Module,
                                            representative_data_gen: Callable,
-                                           target_kpi: KPI = None,
                                            core_config: CoreConfig = CoreConfig(),
                                            target_platform_capabilities: TargetPlatformCapabilities = DEFAULT_PYTORCH_TPC):
         """
@@ -60,7 +59,6 @@ if FOUND_TORCH:
         Args:
             in_module (Module): Pytorch module to quantize.
             representative_data_gen (Callable): Dataset used for calibration.
-            target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
             core_config (CoreConfig): Configuration object containing parameters of how the model should be quantized, including mixed precision parameters.
             target_platform_capabilities (TargetPlatformCapabilities): TargetPlatformCapabilities to optimize the PyTorch model according to.
 
@@ -109,7 +107,6 @@ if FOUND_TORCH:
                                                fw_info=DEFAULT_PYTORCH_INFO,
                                                fw_impl=fw_impl,
                                                tpc=target_platform_capabilities,
-                                               target_kpi=target_kpi,
                                                tb_w=tb_w)
 
         tg = ptq_runner(tg, representative_data_gen, core_config, DEFAULT_PYTORCH_INFO, fw_impl, tb_w)

--- a/model_compression_toolkit/qat/keras/quantization_facade.py
+++ b/model_compression_toolkit/qat/keras/quantization_facade.py
@@ -87,7 +87,6 @@ if FOUND_TF:
 
     def keras_quantization_aware_training_init_experimental(in_model: Model,
                                                             representative_data_gen: Callable,
-                                                            target_kpi: KPI = None,
                                                             core_config: CoreConfig = CoreConfig(),
                                                             qat_config: QATConfig = QATConfig(),
                                                             fw_info: FrameworkInfo = DEFAULT_KERAS_INFO,
@@ -110,7 +109,6 @@ if FOUND_TF:
          Args:
              in_model (Model): Keras model to quantize.
              representative_data_gen (Callable): Dataset used for initial calibration.
-             target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
              core_config (CoreConfig): Configuration object containing parameters of how the model should be quantized, including mixed precision parameters.
              qat_config (QATConfig): QAT configuration
              fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.).  `Default Keras info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/core/keras/default_framework_info.py>`_
@@ -195,7 +193,6 @@ if FOUND_TF:
                                                fw_info=fw_info,
                                                fw_impl=fw_impl,
                                                tpc=target_platform_capabilities,
-                                               target_kpi=target_kpi,
                                                tb_w=tb_w)
 
         tg = ptq_runner(tg, representative_data_gen, core_config, fw_info, fw_impl, tb_w)

--- a/model_compression_toolkit/qat/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/qat/pytorch/quantization_facade.py
@@ -75,7 +75,6 @@ if FOUND_TORCH:
 
     def pytorch_quantization_aware_training_init_experimental(in_model: Module,
                                                               representative_data_gen: Callable,
-                                                              target_kpi: KPI = None,
                                                               core_config: CoreConfig = CoreConfig(),
                                                               qat_config: QATConfig = QATConfig(),
                                                               fw_info: FrameworkInfo = DEFAULT_PYTORCH_INFO,
@@ -98,7 +97,6 @@ if FOUND_TORCH:
          Args:
              in_model (Model): Pytorch model to quantize.
              representative_data_gen (Callable): Dataset used for initial calibration.
-             target_kpi (KPI): KPI object to limit the search of the mixed-precision configuration as desired.
              core_config (CoreConfig): Configuration object containing parameters of how the model should be quantized, including mixed precision parameters.
              qat_config (QATConfig): QAT configuration
              fw_info (FrameworkInfo): Information needed for quantization about the specific framework (e.g., kernel channels indices, groups of layers by how they should be quantized, etc.).  `Default Pytorch info <https://github.com/sony/model_optimization/blob/main/model_compression_toolkit/core/pytorch/default_framework_info.py>`_
@@ -162,7 +160,6 @@ if FOUND_TORCH:
                                                fw_info=DEFAULT_PYTORCH_INFO,
                                                fw_impl=fw_impl,
                                                tpc=target_platform_capabilities,
-                                               target_kpi=target_kpi,
                                                tb_w=tb_w)
 
         tg = ptq_runner(tg, representative_data_gen, core_config, fw_info, fw_impl, tb_w)

--- a/tests/common_tests/base_feature_test.py
+++ b/tests/common_tests/base_feature_test.py
@@ -43,7 +43,6 @@ class BaseFeatureNetworkTest(BaseTest):
             core_config = self.get_core_config()
             ptq_model, quantization_info = self.get_ptq_facade()(model_float,
                                                                  self.representative_data_gen_experimental,
-                                                                 target_kpi=self.get_kpi(),
                                                                  core_config=core_config,
                                                                  target_platform_capabilities=self.get_tpc()
                                                                  )

--- a/tests/common_tests/base_test.py
+++ b/tests/common_tests/base_test.py
@@ -35,13 +35,13 @@ class BaseTest:
 
     def get_core_config(self):
         return CoreConfig(quantization_config=self.get_quantization_config(),
-                          mixed_precision_config=self.get_mixed_precision_v2_config(),
+                          mixed_precision_config=self.get_mixed_precision_config(),
                           debug_config=self.get_debug_config())
 
     def get_quantization_config(self):
         return QuantizationConfig()
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return None
 
     def get_debug_config(self):

--- a/tests/common_tests/helpers/prep_graph_for_func_test.py
+++ b/tests/common_tests/helpers/prep_graph_for_func_test.py
@@ -140,7 +140,6 @@ def prepare_graph_set_bit_widths(in_model,
             bit_widths_config = search_bit_width(tg,
                                                  fw_info,
                                                  fw_impl,
-                                                 target_kpi,
                                                  core_config.mixed_precision_config,
                                                  _representative_data_gen)
         else:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/gptq/gptq_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/gptq/gptq_test.py
@@ -114,7 +114,6 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
         ptq_model, quantization_info = mct.ptq.keras_post_training_quantization(
             model_float,
             representative_data_gen,
-            target_kpi=self.get_kpi(),
             core_config=core_config,
             target_platform_capabilities=tpc
         )
@@ -122,7 +121,6 @@ class GradientPTQBaseTest(BaseKerasFeatureNetworkTest):
             model_float,
             representative_data_gen,
             gptq_config=self.get_gptq_config(),
-            target_kpi=self.get_kpi(),
             core_config=core_config,
             target_platform_capabilities=tpc
         )

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_bops_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_bops_test.py
@@ -46,8 +46,9 @@ class BaseMixedPrecisionBopsTest(BaseKerasFeatureNetworkTest):
                                                 mp_bitwidth_candidates_list=self.mixed_precision_candidates_list,
                                                 name="mp_bopts_test")
 
-    def get_mixed_precision_v2_config(self):
-        return MixedPrecisionQuantizationConfig(num_of_images=1)
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                target_kpi=self.get_kpi())
 
     def get_input_shapes(self):
         return [[self.val_batch_size, 16, 16, 3]]

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
@@ -65,7 +65,8 @@ class MixedPrecisionActivationBaseTest(BaseKerasFeatureNetworkTest):
                                            activation_channel_equalization=False)
 
     def get_mixed_precision_v2_config(self):
-        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1)
+        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                         target_kpi=self.get_kpi())
 
     def get_input_shapes(self):
         return [[self.val_batch_size, 16, 16, 3]]
@@ -423,7 +424,8 @@ class MixedPrecisionActivationMultipleInputsTest(MixedPrecisionActivationBaseTes
                                            input_scaling=False, activation_channel_equalization=False)
 
     def get_mixed_precision_v2_config(self):
-        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=self.num_of_inputs)
+        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=self.num_of_inputs,
+                                                         target_kpi=self.get_kpi())
 
     def create_networks(self):
         inputs_1 = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_qc_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_qc_test.py
@@ -133,14 +133,13 @@ def prepare_graph_for_second_network_editor(in_model, representative_data_gen, c
     ######################################
     # Finalize bit widths
     ######################################
-    if target_kpi is not None:
-        assert core_config.mixed_precision_enable
+    if core_config.mixed_precision_enable:
+        assert target_kpi is not None
         if core_config.mixed_precision_config.configuration_overwrite is None:
 
             bit_widths_config = search_bit_width(tg_with_bias,
                                                  fw_info,
                                                  fw_impl,
-                                                 target_kpi,
                                                  core_config.mixed_precision_config,
                                                  representative_data_gen)
         else:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
@@ -295,11 +295,13 @@ class QATWrappersMixedPrecisionCfgTest(MixedPrecisionActivationBaseTest):
 
     def run_test(self, **kwargs):
         model_float = self.create_networks()
-        config = mct.core.CoreConfig(mixed_precision_config=MixedPrecisionQuantizationConfig())
+        config = mct.core.CoreConfig(
+            mixed_precision_config=MixedPrecisionQuantizationConfig(target_kpi=
+                                                                    mct.core.KPI(weights_memory=self.kpi_weights,
+                                                                                 activation_memory=self.kpi_activation)))
         qat_ready_model, quantization_info, custom_objects = mct.qat.keras_quantization_aware_training_init_experimental(
             model_float,
             self.representative_data_gen_experimental,
-            mct.core.KPI(weights_memory=self.kpi_weights, activation_memory=self.kpi_activation),
             core_config=config,
             fw_info=self.get_fw_info(),
             target_platform_capabilities=self.get_tpc())

--- a/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/reused_layer_mixed_precision_test.py
@@ -51,8 +51,8 @@ class ReusedLayerMixedPrecisionTest(BaseKerasFeatureNetworkTest):
                                            relu_bound_to_power_of_2=True, weights_bias_correction=True,
                                            input_scaling=True, activation_channel_equalization=True)
 
-    def get_mixed_precision_v2_config(self):
-        return MixedPrecisionQuantizationConfig()
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig(target_kpi=self.get_kpi())
 
     def create_networks(self):
         layer = layers.Conv2D(3, 4)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
@@ -44,7 +44,7 @@ class MixedPercisionBaseTest(BaseKerasFeatureNetworkTest):
                                            relu_bound_to_power_of_2=True, weights_bias_correction=True,
                                            input_scaling=True, activation_channel_equalization=True)
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
                                                          target_kpi=self.get_kpi())
 
@@ -81,7 +81,7 @@ class MixedPercisionManuallyConfiguredTest(MixedPercisionBaseTest):
                                            relu_bound_to_power_of_2=True, weights_bias_correction=True,
                                            input_scaling=True, activation_channel_equalization=True)
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(target_kpi=self.get_kpi())
 
     def get_kpi(self):
@@ -225,7 +225,7 @@ class MixedPercisionCombinedNMSTest(MixedPercisionBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
                                                          target_kpi=self.get_kpi(),
                                                          use_hessian_based_scores=False)
@@ -367,7 +367,7 @@ class MixedPercisionDepthwiseTest(MixedPercisionBaseTest):
                                            relu_bound_to_power_of_2=False, weights_bias_correction=False,
                                            input_scaling=False, activation_channel_equalization=False)
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(target_kpi=self.get_kpi())
 
 
@@ -383,7 +383,7 @@ class MixedPrecisionActivationDisabled(MixedPercisionBaseTest):
                                            input_scaling=False,
                                            activation_channel_equalization=False)
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
                                                          target_kpi=self.get_kpi())
 
@@ -416,7 +416,7 @@ class MixedPercisionSearchLastLayerDistanceTest(MixedPercisionBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test, val_batch_size=2)
 
-    def get_mixed_precision_v2_config(self):
+    def get_mixed_precision_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
                                                          target_kpi=self.get_kpi(),
                                                          distance_weighting_method=get_last_layer_weights,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
@@ -45,7 +45,8 @@ class MixedPercisionBaseTest(BaseKerasFeatureNetworkTest):
                                            input_scaling=True, activation_channel_equalization=True)
 
     def get_mixed_precision_v2_config(self):
-        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1)
+        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                         target_kpi=self.get_kpi())
 
     def get_input_shapes(self):
         return [[self.val_batch_size, 16, 16, 3]]
@@ -81,7 +82,7 @@ class MixedPercisionManuallyConfiguredTest(MixedPercisionBaseTest):
                                            input_scaling=True, activation_channel_equalization=True)
 
     def get_mixed_precision_v2_config(self):
-        return mct.core.MixedPrecisionQuantizationConfig()
+        return mct.core.MixedPrecisionQuantizationConfig(target_kpi=self.get_kpi())
 
     def get_kpi(self):
         # Return some KPI (it does not really matter the value here as search_methods is not done,
@@ -226,6 +227,7 @@ class MixedPercisionCombinedNMSTest(MixedPercisionBaseTest):
 
     def get_mixed_precision_v2_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                         target_kpi=self.get_kpi(),
                                                          use_hessian_based_scores=False)
 
     def get_kpi(self):
@@ -366,7 +368,7 @@ class MixedPercisionDepthwiseTest(MixedPercisionBaseTest):
                                            input_scaling=False, activation_channel_equalization=False)
 
     def get_mixed_precision_v2_config(self):
-        return mct.core.MixedPrecisionQuantizationConfig()
+        return mct.core.MixedPrecisionQuantizationConfig(target_kpi=self.get_kpi())
 
 
 class MixedPrecisionActivationDisabled(MixedPercisionBaseTest):
@@ -382,7 +384,8 @@ class MixedPrecisionActivationDisabled(MixedPercisionBaseTest):
                                            activation_channel_equalization=False)
 
     def get_mixed_precision_v2_config(self):
-        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1)
+        return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                         target_kpi=self.get_kpi())
 
     def get_tpc(self):
         base_config, _, default_config = get_op_quantization_configs()
@@ -415,6 +418,7 @@ class MixedPercisionSearchLastLayerDistanceTest(MixedPercisionBaseTest):
 
     def get_mixed_precision_v2_config(self):
         return mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                         target_kpi=self.get_kpi(),
                                                          distance_weighting_method=get_last_layer_weights,
                                                          use_hessian_based_scores=False)
 

--- a/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
@@ -254,7 +254,6 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
         cfg = search_bit_width(graph_to_search_cfg=graph,
                                fw_info=DEFAULT_KERAS_INFO,
                                fw_impl=keras_impl,
-                               target_kpi=KPI(np.inf),
                                mp_config=core_config.mixed_precision_config,
                                representative_data_gen=representative_data_gen,
                                search_method=BitWidthSearchMethod.INTEGER_PROGRAMMING)
@@ -263,23 +262,23 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
             cfg = search_bit_width(graph_to_search_cfg=graph,
                                    fw_info=DEFAULT_KERAS_INFO,
                                    fw_impl=keras_impl,
-                                   target_kpi=KPI(np.inf),
                                    mp_config=core_config.mixed_precision_config,
                                    representative_data_gen=representative_data_gen,
                                    search_method=None)
 
+        core_config.mixed_precision_config.target_kpi = None
         with self.assertRaises(Exception):
             cfg = search_bit_width(graph_to_search_cfg=graph,
                                    fw_info=DEFAULT_KERAS_INFO,
                                    fw_impl=keras_impl,
-                                   target_kpi=None,
                                    mp_config=core_config.mixed_precision_config,
                                    representative_data_gen=representative_data_gen,
                                    search_method=BitWidthSearchMethod.INTEGER_PROGRAMMING)
 
     def test_mixed_precision_search_facade(self):
         core_config_avg_weights = CoreConfig(quantization_config=DEFAULTCONFIG,
-                                             mixed_precision_config=MixedPrecisionQuantizationConfig(compute_mse,
+                                             mixed_precision_config=MixedPrecisionQuantizationConfig(KPI(np.inf),
+                                                                                                     compute_mse,
                                                                                                      get_average_weights,
                                                                                                      num_of_images=1,
                                                                                                      use_hessian_based_scores=False))
@@ -287,7 +286,8 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
         self.run_search_bitwidth_config_test(core_config_avg_weights)
 
         core_config_last_layer = CoreConfig(quantization_config=DEFAULTCONFIG,
-                                            mixed_precision_config=MixedPrecisionQuantizationConfig(compute_mse,
+                                            mixed_precision_config=MixedPrecisionQuantizationConfig(KPI(np.inf),
+                                                                                                    compute_mse,
                                                                                                     get_last_layer_weights,
                                                                                                     num_of_images=1,
                                                                                                     use_hessian_based_scores=False))

--- a/tests/pytorch_tests/function_tests/test_pytorch_tp_model.py
+++ b/tests/pytorch_tests/function_tests/test_pytorch_tp_model.py
@@ -23,7 +23,7 @@ from torch.nn.functional import hardtanh
 from torchvision.models import mobilenet_v2
 
 import model_compression_toolkit as mct
-from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig
+from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.defaultdict import DefaultDict
 from model_compression_toolkit.constants import PYTORCH
 from model_compression_toolkit.core.common import BaseNode

--- a/tests/pytorch_tests/function_tests/test_pytorch_tp_model.py
+++ b/tests/pytorch_tests/function_tests/test_pytorch_tp_model.py
@@ -29,7 +29,8 @@ from model_compression_toolkit.core.common import BaseNode
 from model_compression_toolkit.target_platform_capabilities.target_platform import TargetPlatformCapabilities
 from model_compression_toolkit.target_platform_capabilities.target_platform.targetplatform2framework import LayerFilterParams
 from model_compression_toolkit.target_platform_capabilities.target_platform.targetplatform2framework.attribute_filter import Greater, Smaller, Eq
-from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import DEFAULT_MIXEDPRECISION_CONFIG
+from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
+    DEFAULT_MIXEDPRECISION_CONFIG, MixedPrecisionQuantizationConfig
 from model_compression_toolkit.target_platform_capabilities.constants import DEFAULT_TP_MODEL, IMX500_TP_MODEL, \
     TFLITE_TP_MODEL, QNNPACK_TP_MODEL, KERNEL_ATTR, WEIGHTS_N_BITS, PYTORCH_KERNEL, BIAS_ATTR, BIAS
 from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
@@ -240,13 +241,12 @@ class TestGetPytorchTPC(unittest.TestCase):
                                                                         rep_data,
                                                                         target_platform_capabilities=tpc)
 
-        mp_qc = copy.deepcopy(DEFAULT_MIXEDPRECISION_CONFIG)
+        mp_qc = MixedPrecisionQuantizationConfig(target_kpi=mct.core.KPI(np.inf))
         mp_qc.num_of_images = 1
         core_config = mct.core.CoreConfig(quantization_config=mct.core.QuantizationConfig(),
                                           mixed_precision_config=mp_qc)
         quantized_model, _ = mct.ptq.pytorch_post_training_quantization(model,
                                                                         rep_data,
-                                                                        target_kpi=mct.core.KPI(np.inf),
                                                                         target_platform_capabilities=tpc,
                                                                         core_config=core_config)
 

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -49,7 +49,8 @@ class MixedPercisionActivationBaseTest(BasePytorchTest):
         qc = mct.core.QuantizationConfig(mct.core.QuantizationErrorMethod.MSE, mct.core.QuantizationErrorMethod.MSE,
                                          relu_bound_to_power_of_2=False, weights_bias_correction=True,
                                          input_scaling=False, activation_channel_equalization=False)
-        mpc = mct.core.MixedPrecisionQuantizationConfig(num_of_images=1)
+        mpc = mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                        target_kpi=self.get_kpi())
 
         return {"mixed_precision_activation_model": mct.core.CoreConfig(quantization_config=qc, mixed_precision_config=mpc)}
 
@@ -126,8 +127,9 @@ class MixedPercisionActivationMultipleInputs(MixedPercisionActivationBaseTest):
     def get_kpi(self):
         return KPI(np.inf, np.inf)
 
-    def get_mixed_precision_v2_config(self):
-        return MixedPrecisionQuantizationConfig(num_of_images=4)
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig(num_of_images=4,
+                                                target_kpi=self.get_kpi())
 
     def create_feature_network(self, input_shape):
         return MixedPrecisionMultipleInputsNet(input_shape)


### PR DESCRIPTION
## Pull Request Description:

This change solves two problems:
-
- Usability: now it's clear that in order to enable mixed precision quantization, the user should provide a mixed precision configuration inside the core config (we still check that the target KPI is not None, but this is not part of "mixed_precision_enabled" condition).
- 
- API clarity: target_kpi is not a part of PQT, GPTQ of QAT facades, and it was unreasonable to include it there, since it is only relevant for mixed precision (running target_kpi remains a part of running facade arguments).

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).