### PR TITLE
Populate `__version__` for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build nightly
         run: |
           version=$(python -c 'import model_compression_toolkit; print(model_compression_toolkit.__version__)')
-          now=$(date +'%Y%m%d-%H%M%S')
+          now=$(date +'%Y%m%d.%H%M%S')
           echo "nightly_version=$version.$now" >> $GITHUB_ENV
           sed -i "s/attr: model_compression_toolkit.__version__/$version.$now/g" setup.cfg
           sed -i "s/name='model_compression_toolkit'/name='mct-nightly'/g" setup.py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
           version=$(python -c 'import model_compression_toolkit; print(model_compression_toolkit.__version__)')
           now=$(date +'%Y%m%d.%H%M%S')
           echo "nightly_version=$version.$now" >> $GITHUB_ENV
-          sed -i "s/attr: model_compression_toolkit.__version__/$version.$now/g" setup.cfg
+          sed -i "s/__version__ =.*/__version__ = \"$version.$now\"/g" model_compression_toolkit/__init__.py
           sed -i "s/name='model_compression_toolkit'/name='mct-nightly'/g" setup.py
           python setup.py sdist bdist_wheel
       - name: Publish nightly


### PR DESCRIPTION
## Pull Request Description:

Closes #998. 

This changeset modifies the nightly build workflow to set `model_compression_toolkit.__version__` in-source, making the full nightly version identifier available at runtime. This also resolves the curious post-release identifiers published to PyPI, which I assume were unintentional behavior (please correct me if I'm wrong).