### PR TITLE
Fix PyTorch fakely_quant_onnx_pytorch_exporter

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -103,7 +103,7 @@ class FakelyQuantONNXPyTorchExporter(BasePyTorchExporter):
         with custom quantizers.
         """
 
-        for n, m in self.model.named_children():
+        for n, m in self.model.named_modules():
             if isinstance(m, PytorchActivationQuantizationHolder):
                 assert isinstance(m.activation_holder_quantizer, pytorch_quantizers.BasePyTorchInferableQuantizer)
                 m.activation_holder_quantizer.enable_custom_impl()


### PR DESCRIPTION
Adjust PyTorch's fakely_quant_onnx_pytorch_exporter to support exporting with custom quantizers for inner modules in the model instead of just for its children.

## Pull Request Description:


## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).