### PR TITLE
Fix support const as input to linear layers in pytorch

### DIFF
--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -239,7 +239,9 @@ class BaseNode:
         for pos, weight in sorted((pos, weight) for pos, weight in self.weights.items()
                                   if isinstance(pos, int)):
             assert pos <= len(input_tensors), 'Positional weight index mismatch'
-            input_tensors.insert(pos, weight)
+            # Insert only positional weights that are not subject to quantization.
+            if not self.is_weights_quantization_enabled(pos):
+                input_tensors.insert(pos, weight)
 
         return input_tensors
 

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -238,8 +238,10 @@ class BaseNode:
         """
         for pos, weight in sorted((pos, weight) for pos, weight in self.weights.items()
                                   if isinstance(pos, int)):
-            assert pos <= len(input_tensors), 'Positional weight index mismatch'
-            # Insert only positional weights that are not subject to quantization.
+            if pos > len(input_tensors):
+                Logger.critical("The positional weight index cannot exceed the number of input tensors to the node.")  # pragma: no cover
+            # Insert only positional weights that are not subject to quantization. If the positional weight is
+            # subject to quantization, the quantization wrapper inserts the positional weight into the node.
             if not self.is_weights_quantization_enabled(pos):
                 input_tensors.insert(pos, weight)
 

--- a/model_compression_toolkit/core/pytorch/back2framework/pytorch_model_builder.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/pytorch_model_builder.py
@@ -67,8 +67,7 @@ def _build_input_tensors_list(node: BaseNode,
             _input_tensors = node_to_output_tensors_dict[ie.source_node]
             input_tensors.append(_input_tensors)
         input_tensors = [tensor for tensor_list in input_tensors for tensor in tensor_list]  # flat list of lists
-        if not is_op_quantize_wrapper:
-            input_tensors = node.insert_positional_weights_to_input_list(input_tensors)
+        input_tensors = node.insert_positional_weights_to_input_list(input_tensors)
         # convert inputs from positional weights (numpy arrays) to tensors. Must handle each element in the
         # list separately, because in FX the tensors are FX objects and fail to_torch_tensor
         input_tensors = [to_torch_tensor(t, numpy_type=t.dtype) if isinstance(t, np.ndarray) else t

--- a/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
@@ -56,7 +56,7 @@ class ConstRepresentationTest(BasePytorchFeatureNetworkTest):
     def get_tpc(self):
         tp = generate_test_tp_model({'weights_n_bits': 32,
                                      'activation_n_bits': 32,
-                                     'enable_weights_quantization': False,
+                                     'enable_weights_quantization': True,
                                      'enable_activation_quantization': False})
         return generate_pytorch_tpc(name="linear_collapsing_test", tp_model=tp)
 
@@ -104,7 +104,6 @@ class ConstRepresentationMultiInputTest(ConstRepresentationTest):
         return ConstRepresentationMultiInputNet()
 
 
-
 class ConstRepresentationLinearLayerNet(nn.Module):
     def __init__(self, layer, const):
         super().__init__()
@@ -124,6 +123,7 @@ class ConstRepresentationLinearLayerTest(ConstRepresentationTest):
 
     def create_networks(self):
         return ConstRepresentationLinearLayerNet(self.func, self.const)
+
 
 class ConstRepresentationGetIndexNet(nn.Module):
     def __init__(self, layer, const, indices):

--- a/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
@@ -47,16 +47,17 @@ class ConstRepresentationReverseOrderNet(nn.Module):
 
 class ConstRepresentationTest(BasePytorchFeatureNetworkTest):
 
-    def __init__(self, unit_test, func, const, input_reverse_order=False):
+    def __init__(self, unit_test, func, const, input_reverse_order=False, enable_weights_quantization=False):
         super().__init__(unit_test=unit_test, input_shape=(16, 32, 32))
         self.func = func
         self.const = const
         self.input_reverse_order = input_reverse_order
+        self.enable_weights_quantization = enable_weights_quantization
 
     def get_tpc(self):
         tp = generate_test_tp_model({'weights_n_bits': 32,
                                      'activation_n_bits': 32,
-                                     'enable_weights_quantization': True,
+                                     'enable_weights_quantization': self.enable_weights_quantization,
                                      'enable_activation_quantization': False})
         return generate_pytorch_tpc(name="linear_collapsing_test", tp_model=tp)
 
@@ -97,8 +98,9 @@ class ConstRepresentationMultiInputNet(nn.Module):
 
 class ConstRepresentationMultiInputTest(ConstRepresentationTest):
 
-    def __init__(self, unit_test):
-        super().__init__(unit_test=unit_test, func=None, const=None, input_reverse_order=False)
+    def __init__(self, unit_test, enable_weights_quantization):
+        super().__init__(unit_test=unit_test, func=None, const=None, input_reverse_order=False,
+                         enable_weights_quantization=enable_weights_quantization)
 
     def create_networks(self):
         return ConstRepresentationMultiInputNet()
@@ -118,8 +120,9 @@ class ConstRepresentationLinearLayerNet(nn.Module):
 
 class ConstRepresentationLinearLayerTest(ConstRepresentationTest):
 
-    def __init__(self, unit_test, func, const):
-        super().__init__(unit_test=unit_test, func=func, const=const, input_reverse_order=False)
+    def __init__(self, unit_test, func, const, enable_weights_quantization):
+        super().__init__(unit_test=unit_test, func=func, const=const, input_reverse_order=False,
+                         enable_weights_quantization=enable_weights_quantization)
 
     def create_networks(self):
         return ConstRepresentationLinearLayerNet(self.func, self.const)
@@ -139,8 +142,9 @@ class ConstRepresentationGetIndexNet(nn.Module):
 
 class ConstRepresentationGetIndexTest(ConstRepresentationTest):
 
-    def __init__(self, unit_test, func, const, indices):
-        super().__init__(unit_test=unit_test, func=func, const=const, input_reverse_order=False)
+    def __init__(self, unit_test, func, const, indices, enable_weights_quantization):
+        super().__init__(unit_test=unit_test, func=func, const=const, input_reverse_order=False,
+                         enable_weights_quantization=enable_weights_quantization)
         self.func = func
         self.const = const
         self.indices = indices

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -261,6 +261,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
         c = (np.ones((1, 16, 32, 32)) + np.random.random((1, 16, 32, 32))).astype(np.float32)
         ConstRepresentationLinearLayerTest(self, func=nn.Linear(32, 32), const=c).run_test()
         ConstRepresentationLinearLayerTest(self, func=nn.Conv2d(16, 16, 1), const=c).run_test()
+        ConstRepresentationLinearLayerTest(self, func=nn.ConvTranspose2d(16, 16, 1), const=c).run_test()
 
     def test_permute_substitution(self):
         """


### PR DESCRIPTION
## Pull Request Description:
The issue is that positional weights are only inserted as inputs to the node if the positional weights of the node are being quantized, and in any case where the node weights are not being quantized.
The PR addresses the scenario where the node weights are being quantized and the positional weights are not quantized.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).