### PR TITLE
Fix Hessian batch sample method to use remaining samples correctly

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -392,7 +392,11 @@ class SensitivityEvaluation:
             mean_distance_per_layer = ipts_distances.mean(axis=1)
 
             # Use weights such that every layer's distance is weighted differently (possibly).
-            mean_ipts_distance = np.average(mean_distance_per_layer, weights=metrics_weights_fn(ipts_distances))
+            weight_scores = metrics_weights_fn(ipts_distances)
+            weight_scores = np.asarray(weight_scores) if isinstance(weight_scores, List) else weight_scores
+            weight_scores = weight_scores.flatten()
+
+            mean_ipts_distance = np.average(mean_distance_per_layer, weights=weight_scores)
 
         mean_output_distance = 0
         if len(out_pts_distances) > 0:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision/requires_mixed_precision_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision/requires_mixed_precision_test.py
@@ -24,13 +24,13 @@ from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tp
     get_op_quantization_configs
 from tests.keras_tests.feature_networks_tests.feature_networks.mixed_precision_tests import get_base_mp_nbits_candidates
 from tests.keras_tests.feature_networks_tests.feature_networks.weights_mixed_precision_tests import \
-    MixedPercisionBaseTest
+    MixedPrecisionBaseTest
 from tests.keras_tests.tpc_keras import get_tpc_with_activation_mp_keras, get_weights_only_mp_tpc_keras
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_op_qc, generate_test_attr_configs
 import model_compression_toolkit as mct
 
 
-class RequiresMixedPrecision(MixedPercisionBaseTest):
+class RequiresMixedPrecision(MixedPrecisionBaseTest):
     """
     A test to ensure that mixed precision is used instead of single precision
     when the memory allocated for resources is less than the memory required for all layers using single precision.

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -123,15 +123,16 @@ from tests.keras_tests.feature_networks_tests.feature_networks.symmetric_thresho
     SymmetricThresholdSelectionActivationTest, SymmetricThresholdSelectionBoundedActivationTest
 from tests.keras_tests.feature_networks_tests.feature_networks.test_depthwise_conv2d_replacement import \
     DwConv2dReplacementTest
-from tests.keras_tests.feature_networks_tests.feature_networks.test_kmeans_quantizer import KmeansQuantizerTest, \
-    KmeansQuantizerTestManyClasses, KmeansQuantizerNotPerChannelTest
+from tests.keras_tests.feature_networks_tests.feature_networks.test_kmeans_quantizer import \
+    KmeansQuantizerTestManyClasses
 from tests.keras_tests.feature_networks_tests.feature_networks.uniform_range_selection_activation_test import \
     UniformRangeSelectionActivationTest, UniformRangeSelectionBoundedActivationTest
 from tests.keras_tests.feature_networks_tests.feature_networks.weights_mixed_precision_tests import \
-    MixedPercisionSearchTest, MixedPercisionDepthwiseTest, \
-    MixedPercisionSearch4BitsAvgTest, MixedPercisionSearch2BitsAvgTest, MixedPrecisionActivationDisabled, \
-    MixedPercisionSearchLastLayerDistanceTest, MixedPercisionSearchActivationNonConfNodesTest, \
-    MixedPercisionSearchTotalMemoryNonConfNodesTest, MixedPercisionSearchPartWeightsLayersTest, MixedPercisionCombinedNMSTest
+    MixedPrecisionSearch4BitsAvgTest, MixedPrecisionSearch2BitsAvgTest, MixedPrecisionActivationDisabled, \
+    MixedPrecisionWithHessianScoresTest, MixedPrecisionSearchTest, \
+    MixedPrecisionSearchPartWeightsLayersTest, MixedPrecisionDepthwiseTest, MixedPrecisionSearchLastLayerDistanceTest, \
+    MixedPrecisionSearchActivationNonConfNodesTest, MixedPrecisionSearchTotalMemoryNonConfNodesTest, \
+    MixedPrecisionCombinedNMSTest
 from tests.keras_tests.feature_networks_tests.feature_networks.matmul_substitution_test import MatmulToDenseSubstitutionTest
 from tests.keras_tests.feature_networks_tests.feature_networks.metadata_test import MetadataTest
 from tests.keras_tests.feature_networks_tests.feature_networks.tpc_test import TpcTest
@@ -207,17 +208,18 @@ class FeatureNetworkTest(unittest.TestCase):
         ReusedSeparableTest(self).run_test()
 
     def test_mixed_precision_search_2bits_avg(self):
-        MixedPercisionSearch2BitsAvgTest(self).run_test()
+        MixedPrecisionSearch2BitsAvgTest(self).run_test()
 
     def test_mixed_precision_search_4bits_avg(self):
-        MixedPercisionSearch4BitsAvgTest(self).run_test()
+        MixedPrecisionSearch4BitsAvgTest(self).run_test()
 
     def test_mixed_precision_search_4bits_avg_nms(self):
-        MixedPercisionCombinedNMSTest(self).run_test()
+        MixedPrecisionCombinedNMSTest(self).run_test()
 
     def test_mixed_precision_search(self):
-        MixedPercisionSearchTest(self, distance_metric=MpDistanceWeighting.AVG).run_test()
-        MixedPercisionSearchTest(self, distance_metric=MpDistanceWeighting.LAST_LAYER).run_test()
+        MixedPrecisionSearchTest(self, distance_metric=MpDistanceWeighting.AVG).run_test()
+        MixedPrecisionSearchTest(self, distance_metric=MpDistanceWeighting.LAST_LAYER).run_test()
+        MixedPrecisionWithHessianScoresTest(self, distance_metric=MpDistanceWeighting.AVG).run_test()
 
     def test_requires_mixed_recision(self):
         RequiresMixedPrecisionWeights(self, weights_memory=True).run_test()
@@ -227,22 +229,22 @@ class FeatureNetworkTest(unittest.TestCase):
         RequiresMixedPrecision(self).run_test()
 
     def test_mixed_precision_for_part_weights_layers(self):
-        MixedPercisionSearchPartWeightsLayersTest(self).run_test()
+        MixedPrecisionSearchPartWeightsLayersTest(self).run_test()
 
     def test_mixed_precision_activation_disabled(self):
         MixedPrecisionActivationDisabled(self).run_test()
 
     def test_mixed_precision_dw(self):
-        MixedPercisionDepthwiseTest(self).run_test()
+        MixedPrecisionDepthwiseTest(self).run_test()
 
     def test_mixed_precision_search_with_last_layer_distance(self):
-        MixedPercisionSearchLastLayerDistanceTest(self).run_test()
+        MixedPrecisionSearchLastLayerDistanceTest(self).run_test()
 
     def test_mixed_precision_search_activation_non_conf_nodes(self):
-        MixedPercisionSearchActivationNonConfNodesTest(self).run_test()
+        MixedPrecisionSearchActivationNonConfNodesTest(self).run_test()
 
     def test_mixed_precision_search_total_non_conf_nodes(self):
-        MixedPercisionSearchTotalMemoryNonConfNodesTest(self).run_test()
+        MixedPrecisionSearchTotalMemoryNonConfNodesTest(self).run_test()
 
     def test_mixed_precision_activation_search(self):
         MixedPrecisionActivationSearchTest(self).run_test()

--- a/tests/pytorch_tests/model_tests/base_pytorch_test.py
+++ b/tests/pytorch_tests/model_tests/base_pytorch_test.py
@@ -35,9 +35,10 @@ class BasePytorchTest(BaseFeatureNetworkTest):
                  unit_test,
                  float_reconstruction_error=1e-6,
                  convert_to_fx=True,
-                 val_batch_size=1):
+                 val_batch_size=1,
+                 num_calibration_iter=1):
 
-        super().__init__(unit_test, val_batch_size=val_batch_size)
+        super().__init__(unit_test, val_batch_size=val_batch_size, num_calibration_iter=num_calibration_iter)
         self.float_reconstruction_error = float_reconstruction_error
         self.convert_to_fx = convert_to_fx
 

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -29,7 +29,7 @@ This test checks the Mixed Precision feature.
 """
 
 
-class MixedPercisionActivationBaseTest(BasePytorchTest):
+class MixedPrecisionActivationBaseTest(BasePytorchTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
 
@@ -65,7 +65,7 @@ class MixedPercisionActivationBaseTest(BasePytorchTest):
         self.unit_test.assertTrue(all(result_config == expected_config))
 
 
-class MixedPercisionActivationSearch8Bit(MixedPercisionActivationBaseTest):
+class MixedPrecisionActivationSearch8Bit(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
         self.expected_config = [1, 0, 0, 0]
@@ -77,7 +77,7 @@ class MixedPercisionActivationSearch8Bit(MixedPercisionActivationBaseTest):
         self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
-class MixedPercisionActivationSearch2Bit(MixedPercisionActivationBaseTest):
+class MixedPrecisionActivationSearch2Bit(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
         self.expected_config = [2, 8, 2, 2]
@@ -89,7 +89,7 @@ class MixedPercisionActivationSearch2Bit(MixedPercisionActivationBaseTest):
         self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
-class MixedPercisionActivationSearch4Bit(MixedPercisionActivationBaseTest):
+class MixedPrecisionActivationSearch4Bit(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
         self.expected_config = [1, 4, 1, 1]
@@ -101,7 +101,7 @@ class MixedPercisionActivationSearch4Bit(MixedPercisionActivationBaseTest):
         self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
-class MixedPercisionActivationSearch4BitFunctional(MixedPercisionActivationBaseTest):
+class MixedPrecisionActivationSearch4BitFunctional(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
         self.expected_config = [1, 4, 4, 1]
@@ -116,7 +116,7 @@ class MixedPercisionActivationSearch4BitFunctional(MixedPercisionActivationBaseT
         self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
 
 
-class MixedPercisionActivationMultipleInputs(MixedPercisionActivationBaseTest):
+class MixedPrecisionActivationMultipleInputs(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
         self.expected_config = [0 for _ in range(8)] + [1] # expected config for this test.

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -46,8 +46,8 @@ from tests.pytorch_tests.model_tests.feature_models.residual_collapsing_test imp
     ResidualCollapsingTest2
 from tests.pytorch_tests.model_tests.feature_models.dynamic_size_inputs_test import ReshapeNetTest
 from tests.pytorch_tests.model_tests.feature_models.mixed_precision_activation_test import \
-    MixedPercisionActivationSearch8Bit, MixedPercisionActivationSearch2Bit, MixedPercisionActivationSearch4Bit, \
-    MixedPercisionActivationSearch4BitFunctional, MixedPercisionActivationMultipleInputs
+    MixedPrecisionActivationSearch8Bit, MixedPrecisionActivationSearch2Bit, MixedPrecisionActivationSearch4Bit, \
+    MixedPrecisionActivationSearch4BitFunctional, MixedPrecisionActivationMultipleInputs
 from tests.pytorch_tests.model_tests.feature_models.relu_bound_test import ReLUBoundToPOTNetTest, \
     HardtanhBoundToPOTNetTest
 from tests.pytorch_tests.model_tests.feature_models.scalar_tensor_test import ScalarTensorTest
@@ -70,9 +70,9 @@ from tests.pytorch_tests.model_tests.feature_models.scale_equalization_test impo
 from tests.pytorch_tests.model_tests.feature_models.layer_name_test import ReuseNameNetTest
 from tests.pytorch_tests.model_tests.feature_models.lut_quantizer_test import LUTWeightsQuantizerTest, \
     LUTActivationQuantizerTest
-from tests.pytorch_tests.model_tests.feature_models.mixed_precision_weights_test import MixedPercisionSearch8Bit, \
-    MixedPercisionSearch2Bit, MixedPercisionSearch4Bit, MixedPercisionActivationDisabledTest, \
-    MixedPercisionSearchLastLayerDistance, MixedPercisionSearchPartWeightsLayers
+from tests.pytorch_tests.model_tests.feature_models.mixed_precision_weights_test import MixedPrecisionSearch4Bit, \
+    MixedPrecisionActivationDisabledTest, MixedPrecisionSearchLastLayerDistance, MixedPrecisionWithHessianScores, \
+    MixedPrecisionSearch8Bit, MixedPrecisionSearchPartWeightsLayers, MixedPrecisionSearch2Bit
 from tests.pytorch_tests.model_tests.feature_models.multiple_output_nodes_multiple_tensors_test import \
     MultipleOutputsMultipleTensorsNetTest
 from tests.pytorch_tests.model_tests.feature_models.multiple_outputs_node_test import MultipleOutputsNetTest
@@ -444,20 +444,26 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         This test checks the Mixed Precision search.
         """
-        MixedPercisionSearch8Bit(self, distance_metric=MpDistanceWeighting.AVG).run_test()
-        MixedPercisionSearch8Bit(self, distance_metric=MpDistanceWeighting.LAST_LAYER).run_test()
+        MixedPrecisionSearch8Bit(self, distance_metric=MpDistanceWeighting.AVG).run_test()
+        MixedPrecisionSearch8Bit(self, distance_metric=MpDistanceWeighting.LAST_LAYER).run_test()
+
+    def test_mixed_precision_with_hessian_weights(self):
+        """
+        This test checks the Mixed Precision search with Hessian-based scores.
+        """
+        MixedPrecisionWithHessianScores(self, distance_metric=MpDistanceWeighting.AVG).run_test()
 
     def test_mixed_precision_part_weights_layers(self):
         """
         This test checks the Mixed Precision search.
         """
-        MixedPercisionSearchPartWeightsLayers(self).run_test()
+        MixedPrecisionSearchPartWeightsLayers(self).run_test()
 
     def test_mixed_precision_2bit(self):
         """
         This test checks the Mixed Precision search.
         """
-        MixedPercisionSearch2Bit(self).run_test()
+        MixedPrecisionSearch2Bit(self).run_test()
 
     def test_reshape_net(self):
         """
@@ -471,49 +477,49 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         This test checks the Mixed Precision search.
         """
-        MixedPercisionSearch4Bit(self).run_test()
+        MixedPrecisionSearch4Bit(self).run_test()
 
     def test_mixed_precision_with_last_layer_distance(self):
         """
         This test checks the Mixed Precision search with last layer distance function.
         """
-        MixedPercisionSearchLastLayerDistance(self).run_test()
+        MixedPrecisionSearchLastLayerDistance(self).run_test()
 
     def test_mixed_precision_activation_disabled(self):
         """
         This test checks the Mixed Precision search.
         """
-        MixedPercisionActivationDisabledTest(self).run_test()
+        MixedPrecisionActivationDisabledTest(self).run_test()
 
     def test_mixed_precision_activation_8bit(self):
         """
         This test checks the activation Mixed Precision search.
         """
-        MixedPercisionActivationSearch8Bit(self).run_test()
+        MixedPrecisionActivationSearch8Bit(self).run_test()
 
     def test_mixed_precision_activation_2bit(self):
         """
         This test checks the activation Mixed Precision search.
         """
-        MixedPercisionActivationSearch2Bit(self).run_test()
+        MixedPrecisionActivationSearch2Bit(self).run_test()
 
     def test_mixed_precision_activation_4bit(self):
         """
         This test checks the activation Mixed Precision search.
         """
-        MixedPercisionActivationSearch4Bit(self).run_test()
+        MixedPrecisionActivationSearch4Bit(self).run_test()
 
     def test_mixed_precision_activation_4bit_functional(self):
         """
         This test checks the activation Mixed Precision search with functional node.
         """
-        MixedPercisionActivationSearch4BitFunctional(self).run_test()
+        MixedPrecisionActivationSearch4BitFunctional(self).run_test()
 
     def test_mixed_precision_multiple_inputs(self):
         """
         This test checks the activation Mixed Precision search with multiple inputs to model.
         """
-        MixedPercisionActivationMultipleInputs(self).run_test()
+        MixedPrecisionActivationMultipleInputs(self).run_test()
 
     def test_mixed_precision_bops_utilization(self):
         """


### PR DESCRIPTION
## Pull Request Description:
Previous modification to Hessian service didn't handle the remaining samples correctly, allowing the representative dataset generator to terminate even if there were enough samples.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).