### PR TITLE
Verify bias is not None in GPTQ bias training

### DIFF
--- a/model_compression_toolkit/gptq/keras/gptq_training.py
+++ b/model_compression_toolkit/gptq/keras/gptq_training.py
@@ -353,7 +353,7 @@ class KerasGPTQTrainer(GPTQTrainer):
                     node.final_activation_quantization_cfg.set_quant_config_attr(config_attr, config_value)
                 if self.gptq_config.train_bias:
                     use_bias = layer.layer.get_config().get(USE_BIAS)
-                    if use_bias is not None and use_bias:
+                    if use_bias is not None and use_bias and layer.layer.bias is not None:
                         new_bias = layer.layer.bias.numpy()
                         node.set_weights_by_keys(BIAS, new_bias)
 

--- a/model_compression_toolkit/gptq/keras/graph_info.py
+++ b/model_compression_toolkit/gptq/keras/graph_info.py
@@ -63,7 +63,7 @@ def get_gptq_trainable_parameters(fxp_model: Model,
                 kernel_ops_attrs = fw_info.kernel_ops_attributes_mapping.get(type(layer.layer))
                 use_bias = kernel_ops_attrs is not None and kernel_ops_attrs[0] is not None \
                            and layer.layer.get_config().get(USE_BIAS)
-                if use_bias is not None and use_bias:
+                if use_bias is not None and use_bias and layer.layer.bias is not None:
                     bias_weights.append([layer.layer.bias])
 
     return trainable_weights, bias_weights, trainable_threshold

--- a/model_compression_toolkit/gptq/pytorch/gptq_training.py
+++ b/model_compression_toolkit/gptq/pytorch/gptq_training.py
@@ -299,7 +299,9 @@ class PytorchGPTQTrainer(GPTQTrainer):
                 for config_attr, config_value in activation_quant_config.items():
                     node.final_activation_quantization_cfg.set_quant_config_attr(config_attr, config_value)
                 if self.gptq_config.train_bias and hasattr(layer.layer, BIAS):
-                    node.set_weights_by_keys(BIAS, self.fw_impl.to_numpy(getattr(layer.layer, BIAS)))
+                    bias = getattr(layer.layer, BIAS)
+                    if bias is not None:
+                        node.set_weights_by_keys(BIAS, self.fw_impl.to_numpy(bias))
 
         return graph_quant
 
@@ -316,4 +318,5 @@ class PytorchGPTQTrainer(GPTQTrainer):
             if isinstance(layer, PytorchQuantizationWrapper):
                 if hasattr(layer.layer, BIAS):
                     bias = getattr(layer.layer, BIAS)
-                    bias.requires_grad = self.gptq_config.train_bias
+                    if bias is not None:
+                        bias.requires_grad = self.gptq_config.train_bias

--- a/model_compression_toolkit/gptq/pytorch/graph_info.py
+++ b/model_compression_toolkit/gptq/pytorch/graph_info.py
@@ -56,7 +56,8 @@ def get_gptq_trainable_parameters(fxp_model: nn.Module,
 
             if add_bias and hasattr(layer.layer, BIAS):
                 bias = getattr(layer.layer, BIAS)
-                trainable_bias.append(bias)
+                if bias is not None:
+                    trainable_bias.append(bias)
 
     return trainable_aux_weights, trainable_bias, trainable_threshold
 


### PR DESCRIPTION
## Pull Request Description:
GPTQ with bias train is failing in the rare case where a linear layer doesn't have a bias

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).