### PR TITLE
Skip inline images in links checker test

### DIFF
--- a/tests/doc_tests/test_docs_links.py
+++ b/tests/doc_tests/test_docs_links.py
@@ -59,6 +59,9 @@ class TestDocsLinks(unittest.TestCase):
                                 if _link[0] == '#':
                                     # A link starting with '#' is a local reference to a headline in the current file --> ignore
                                     pass
+                                elif _link.startswith('data:image/'):
+                                    # A link starting with 'data:image/' is a base64-encoded image --> ignore
+                                    print("Inline image, skipping:", _link)
                                 elif 'http://' in _link or 'https://' in _link:
                                     if self.check_link(_link):
                                         print("Link ok:", _link)


### PR DESCRIPTION
## Pull Request Description:
Ignore base64-encoded image links, as they are valid inline images and don't need to be checked as external or local links. 

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).