### PR TITLE
Keras node builder refactor

### DIFF
--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -36,7 +36,7 @@ class BaseNode:
                  framework_attr: Dict[str, Any],
                  input_shape: Tuple[Any],
                  output_shape: Tuple[Any],
-                 weights: Dict[str, np.ndarray],
+                 weights: Dict[Union[str, int], np.ndarray],
                  layer_class: type,
                  reuse: bool = False,
                  reuse_group: str = None,

--- a/model_compression_toolkit/core/common/graph/functional_node.py
+++ b/model_compression_toolkit/core/common/graph/functional_node.py
@@ -59,7 +59,7 @@ class FunctionalNode(BaseNode):
                          has_activation=has_activation)
 
         self.op_call_kwargs = op_call_kwargs
-        self.op_call_args = op_call_args
+        self.op_call_args = list(op_call_args)
         self.functional_op = functional_op
         self.inputs_as_list = inputs_as_list
         self.tensor_input_allocs = [] if tensor_input_allocs is None else tensor_input_allocs

--- a/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
+++ b/model_compression_toolkit/core/keras/back2framework/keras_model_builder.py
@@ -282,6 +282,8 @@ class KerasModelBuilder(BaseModelBuilder):
                         if n.inputs_as_list:
                             input_tensors = n.insert_positional_weights_to_input_list(input_tensors)
                         else:
+                            # If the were any const attributes in the layer's inputs, we retrieve them as kwargs
+                            # for the operator call.
                             for pos, k in enumerate(n.tensor_input_allocs):
                                 if k not in op_call_kwargs:  # op_call_kwargs is initialized because we are under FunctionalNode
                                     # If the argument is saved in tensor_input_allocs but does not exists in the node kwargs

--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -137,7 +137,6 @@ def _build_arguments_alloc(n: KerasNode, inputs_as_list: bool, kwarg2index: Dict
 def _extract_const_attrs_from_args(op_call_args: List[Any],
                                    op_call_kwargs: Dict[str, Any],
                                    inputs_as_list: bool,
-                                   kwarg2index: Dict[str, int],
                                    tensor_inputs_alloc: List,
                                    weights: Dict[Union[str, int], Any]) -> List[Any]:
     """
@@ -147,8 +146,9 @@ def _extract_const_attrs_from_args(op_call_args: List[Any],
 
     Args:
         op_call_args: A list of the operator arguments.
+        op_call_kwargs: A mapping of key-arguments of the operator.
         inputs_as_list: Whether the input of the layer is a list.
-        kwarg2index: A dictionary with argument number and index: {arg_name: arg_index}.
+        tensor_inputs_alloc: Allocation of argument inputs to the operator (if there are const inputs, otherwise None).
         weights: Node weights mapping. This dictionary is modified by this function.
 
     Returns: A modified operator arguments list.
@@ -260,7 +260,7 @@ def build_node(node: KerasNode,
         tensor_input_alloc = None if not _has_const_attributes(op_call_args, op_call_kwargs, inputs_as_list) \
             else _build_arguments_alloc(node, inputs_as_list, kwarg2index)
 
-        op_call_args = _extract_const_attrs_from_args(op_call_args, op_call_kwargs, inputs_as_list, kwarg2index,
+        op_call_args = _extract_const_attrs_from_args(op_call_args, op_call_kwargs, inputs_as_list,
                                                       tensor_input_alloc, weights)
         op_call_kwargs = _extract_const_attrs_from_kwargs(op_call_kwargs, kwarg2index, weights)
 

--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -82,7 +82,7 @@ def get_kwargs2index(tfoplambda_layer: TFOpLambda) -> Dict[str, int]:
 
 def _extract_const_attrs_from_kwargs(op_call_kwargs: Dict[str, Any],
                                      kwarg2index: Dict[str, int],
-                                     weights: Dict[Union[str, int], Any]):
+                                     weights: Dict[Union[str, int], Any]) -> Dict[str, Any]:
     """
     Extract const weights of the layer from the operator's key arguments dictionary.
     This function extracts the attributes, updates the nodes weights dictionary and removes them from the original
@@ -93,7 +93,7 @@ def _extract_const_attrs_from_kwargs(op_call_kwargs: Dict[str, Any],
         kwarg2index: A dictionary with argument number and index: {arg_name: arg_index}.
         weights: Node weights mapping. This dictionary is modified by this function.
 
-    Returns: A modified operator arguments list.
+    Returns: A modified operator key arguments mapping.
 
     """
 
@@ -139,7 +139,7 @@ def _build_arguments_alloc(n: KerasNode, inputs_as_list: bool, kwarg2index: Dict
 def _extract_const_attrs_from_args(op_call_args: List[Any],
                                    inputs_as_list: bool,
                                    kwarg2index: Dict[str, int],
-                                   weights: Dict[Union[str, int], Any]):
+                                   weights: Dict[Union[str, int], Any]) -> List[Any]:
     """
     Extract const weights of the layer from the operator's arguments list.
     This function extracts the attributes, updates the nodes weights dictionary and removes them from the original
@@ -170,7 +170,18 @@ def _extract_const_attrs_from_args(op_call_args: List[Any],
     return op_call_args
 
 
-def _has_const_attributes(op_call_args, op_call_kwargs, input_as_list):
+def _has_const_attributes(op_call_args: List, op_call_kwargs: Dict, input_as_list: bool) -> bool:
+    """
+    Returns whether the layer's input include a constant tensor (that we might want to quantize).
+
+    Args:
+        op_call_args: A list of arguments to the layer.
+        op_call_kwargs: A dictionary of key-arguments to the layer.
+        input_as_list: Whether the input to the layer is a list of tensors.
+
+    Returns: True if the input arguments include a constant tensor, False otherwise.
+
+    """
     if input_as_list:
         return any([is_const(a) for a in op_call_args[0]])
     const_args = [a for a in op_call_args if is_const(a)]

--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, List, Dict, Union
+from copy import copy
+
+from typing import Any, List, Dict, Union, Tuple
 
 import tensorflow as tf
 from tensorflow.python.util import tf_inspect
@@ -138,7 +140,7 @@ def _extract_const_attrs_from_args(op_call_args: List[Any],
                                    op_call_kwargs: Dict[str, Any],
                                    inputs_as_list: bool,
                                    tensor_inputs_alloc: List,
-                                   weights: Dict[Union[str, int], Any]) -> List[Any]:
+                                   weights: Dict[Union[str, int], Any]) -> Tuple:
     """
     Extract const weights of the layer from the operator's arguments list.
     This function extracts the attributes, updates the nodes weights dictionary and removes them from the original
@@ -158,7 +160,6 @@ def _extract_const_attrs_from_args(op_call_args: List[Any],
     # read weights from call args
     for i, arg in enumerate(op_call_args[0] if inputs_as_list else op_call_args):
         if is_const(arg):
-            # if inputs_as_list or i in kwarg2index.values():
             weights.update({i: to_numpy(arg, is_single_tensor=True)})
         else:
             if not inputs_as_list:
@@ -213,8 +214,8 @@ def build_node(node: KerasNode,
     """
     keras_layer = node.layer  # get the layer the node represents.
     layer_config = keras_layer.get_config()  # layer configuration to reconstruct it.
-    op_call_args = node.call_args
-    op_call_kwargs = node.call_kwargs
+    op_call_args = copy(node.call_args)
+    op_call_kwargs = copy(node.call_kwargs)
     layer_class = type(keras_layer)  # class path to instantiating it in back2framework.
     weights = {v.name: v.numpy() for v in keras_layer.weights}  # layer's weights
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/const_quantization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/const_quantization_test.py
@@ -17,9 +17,10 @@ import tensorflow as tf
 import numpy as np
 
 import model_compression_toolkit as mct
+from tests.common_tests.helpers.generate_test_tp_model import generate_test_attr_configs, DEFAULT_WEIGHT_ATTR_CONFIG
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
-from mct_quantizers import KerasQuantizationWrapper
+from mct_quantizers import KerasQuantizationWrapper, QuantizationMethod
 
 from model_compression_toolkit.constants import TENSORFLOW
 from model_compression_toolkit.target_platform_capabilities.constants import IMX500_TP_MODEL

--- a/tests/keras_tests/feature_networks_tests/feature_networks/const_representation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/const_representation_test.py
@@ -77,7 +77,7 @@ class ConstRepresentationTest(BaseKerasFeatureNetworkTest):
         y_hat = quantized_model.predict(input_x)
         self.unit_test.assertTrue(y.shape == y_hat.shape, msg=f'out shape is not as expected!')
         cs = cosine_similarity(y, y_hat)
-        self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')
+        self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}, for operator {self.layer}')
 
 
 class ConstRepresentationListTypeArgsTest(BaseKerasFeatureNetworkTest):

--- a/tests/keras_tests/feature_networks_tests/feature_networks/const_representation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/const_representation_test.py
@@ -16,6 +16,9 @@ import tensorflow as tf
 import numpy as np
 
 import model_compression_toolkit as mct
+from model_compression_toolkit import get_target_platform_capabilities
+from model_compression_toolkit.constants import TENSORFLOW
+from model_compression_toolkit.target_platform_capabilities.constants import DEFAULT_TP_MODEL
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_keras_tpc
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
@@ -67,6 +70,31 @@ class ConstRepresentationTest(BaseKerasFeatureNetworkTest):
                     x = self.layer(x=x, y=self.const)
                 else:
                     x = self.layer(x, self.const)
+        return tf.keras.models.Model(inputs=inputs, outputs=x)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        y = float_model.predict(input_x)
+        y_hat = quantized_model.predict(input_x)
+        self.unit_test.assertTrue(y.shape == y_hat.shape, msg=f'out shape is not as expected!')
+        cs = cosine_similarity(y, y_hat)
+        self.unit_test.assertTrue(np.isclose(cs, 1), msg=f'fail cosine similarity check:{cs}')
+
+
+class ConstRepresentationListTypeArgsTest(BaseKerasFeatureNetworkTest):
+
+    def __init__(self, unit_test, input_shape=(32, 32, 16)):
+        super(ConstRepresentationListTypeArgsTest, self).__init__(unit_test=unit_test, input_shape=input_shape)
+
+    def generate_inputs(self):
+        # need positive inputs so won't divide with zero or take root of negative number
+        return [1 + np.random.random(in_shape) for in_shape in self.get_input_shapes()]
+
+    def get_tpc(self):
+        return get_target_platform_capabilities(TENSORFLOW, DEFAULT_TP_MODEL)
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = tf.image.resize(inputs, size=self.get_input_shapes()[0][1:3])
         return tf.keras.models.Model(inputs=inputs, outputs=x)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -137,7 +137,7 @@ from tests.keras_tests.feature_networks_tests.feature_networks.matmul_substituti
 from tests.keras_tests.feature_networks_tests.feature_networks.metadata_test import MetadataTest
 from tests.keras_tests.feature_networks_tests.feature_networks.tpc_test import TpcTest
 from tests.keras_tests.feature_networks_tests.feature_networks.const_representation_test import ConstRepresentationTest, \
-    ConstRepresentationMultiInputTest, ConstRepresentationMatMulTest
+    ConstRepresentationMultiInputTest, ConstRepresentationMatMulTest, ConstRepresentationListTypeArgsTest
 from tests.keras_tests.feature_networks_tests.feature_networks.concatination_threshold_update import ConcatThresholdtest
 from tests.keras_tests.feature_networks_tests.feature_networks.const_quantization_test import ConstQuantizationTest, \
     AdvancedConstQuantizationTest
@@ -586,6 +586,7 @@ class FeatureNetworkTest(unittest.TestCase):
             ConstRepresentationTest(self, func, c, use_kwargs=True, is_list_input=True).run_test()
 
         ConstRepresentationMultiInputTest(self).run_test()
+        ConstRepresentationListTypeArgsTest(self).run_test()
 
     def test_second_moment(self):
         DepthwiseConv2DSecondMomentTest(self).run_test()

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -565,24 +565,24 @@ class FeatureNetworkTest(unittest.TestCase):
         AdvancedConstQuantizationTest(self).run_test()
 
     def test_const_representation(self):
-        # c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32)
-        # for func in [tf.add, tf.multiply, tf.subtract, tf.divide, tf.truediv, tf.pow]:
-        #     ConstRepresentationTest(self, func, c).run_test()
-        #     ConstRepresentationTest(self, func, c, input_reverse_order=True).run_test()
-        #     ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True).run_test()
-        #     ConstRepresentationTest(self, func, c, use_kwargs=True).run_test()
-        #     ConstRepresentationTest(self, func, 2.45).run_test()
-        #     ConstRepresentationTest(self, func, 5.1, input_reverse_order=True).run_test()
-        #
-        # # tf.matmul test
-        # ConstRepresentationMatMulTest(self).run_test()
-        #
-        # c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32).reshape((1, -1))
-        # for func in [layers.Add(), layers.Multiply(), layers.Subtract()]:
-        #     ConstRepresentationTest(self, func, c, is_list_input=True).run_test()
-        #     ConstRepresentationTest(self, func, c, input_reverse_order=True, is_list_input=True).run_test()
-        #     ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True, is_list_input=True).run_test()
-        #     ConstRepresentationTest(self, func, c, use_kwargs=True, is_list_input=True).run_test()
+        c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32)
+        for func in [tf.add, tf.multiply, tf.subtract, tf.divide, tf.truediv, tf.pow]:
+            ConstRepresentationTest(self, func, c).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True).run_test()
+            ConstRepresentationTest(self, func, c, use_kwargs=True).run_test()
+            ConstRepresentationTest(self, func, 2.45).run_test()
+            ConstRepresentationTest(self, func, 5.1, input_reverse_order=True).run_test()
+
+        # tf.matmul test
+        ConstRepresentationMatMulTest(self).run_test()
+
+        c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32).reshape((1, -1))
+        for func in [layers.Add(), layers.Multiply(), layers.Subtract()]:
+            ConstRepresentationTest(self, func, c, is_list_input=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True, is_list_input=True).run_test()
+            ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True, is_list_input=True).run_test()
+            ConstRepresentationTest(self, func, c, use_kwargs=True, is_list_input=True).run_test()
 
         ConstRepresentationMultiInputTest(self).run_test()
         ConstRepresentationListTypeArgsTest(self).run_test()

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -560,30 +560,29 @@ class FeatureNetworkTest(unittest.TestCase):
                 ConstQuantizationTest(self, func, c, input_reverse_order=True, qmethod=qmethod).run_test()
                 ConstQuantizationTest(self, func, c, input_reverse_order=True, use_kwargs=True, qmethod=qmethod).run_test()
                 ConstQuantizationTest(self, func, c, use_kwargs=True, qmethod=qmethod).run_test()
-                ConstQuantizationTest(self, func, 2.45, qmethod=qmethod).run_test()
                 ConstQuantizationTest(self, func, 5.1, input_reverse_order=True, qmethod=qmethod).run_test()
 
         AdvancedConstQuantizationTest(self).run_test()
 
     def test_const_representation(self):
-        c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32)
-        for func in [tf.add, tf.multiply, tf.subtract, tf.divide, tf.truediv, tf.pow]:
-            ConstRepresentationTest(self, func, c).run_test()
-            ConstRepresentationTest(self, func, c, input_reverse_order=True).run_test()
-            ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True).run_test()
-            ConstRepresentationTest(self, func, c, use_kwargs=True).run_test()
-            ConstRepresentationTest(self, func, 2.45).run_test()
-            ConstRepresentationTest(self, func, 5.1, input_reverse_order=True).run_test()
-
-        # tf.matmul test
-        ConstRepresentationMatMulTest(self).run_test()
-
-        c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32).reshape((1, -1))
-        for func in [layers.Add(), layers.Multiply(), layers.Subtract()]:
-            ConstRepresentationTest(self, func, c, is_list_input=True).run_test()
-            ConstRepresentationTest(self, func, c, input_reverse_order=True, is_list_input=True).run_test()
-            ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True, is_list_input=True).run_test()
-            ConstRepresentationTest(self, func, c, use_kwargs=True, is_list_input=True).run_test()
+        # c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32)
+        # for func in [tf.add, tf.multiply, tf.subtract, tf.divide, tf.truediv, tf.pow]:
+        #     ConstRepresentationTest(self, func, c).run_test()
+        #     ConstRepresentationTest(self, func, c, input_reverse_order=True).run_test()
+        #     ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True).run_test()
+        #     ConstRepresentationTest(self, func, c, use_kwargs=True).run_test()
+        #     ConstRepresentationTest(self, func, 2.45).run_test()
+        #     ConstRepresentationTest(self, func, 5.1, input_reverse_order=True).run_test()
+        #
+        # # tf.matmul test
+        # ConstRepresentationMatMulTest(self).run_test()
+        #
+        # c = (np.ones((16,)) + np.random.random((16,))).astype(np.float32).reshape((1, -1))
+        # for func in [layers.Add(), layers.Multiply(), layers.Subtract()]:
+        #     ConstRepresentationTest(self, func, c, is_list_input=True).run_test()
+        #     ConstRepresentationTest(self, func, c, input_reverse_order=True, is_list_input=True).run_test()
+        #     ConstRepresentationTest(self, func, c, input_reverse_order=True, use_kwargs=True, is_list_input=True).run_test()
+        #     ConstRepresentationTest(self, func, c, use_kwargs=True, is_list_input=True).run_test()
 
         ConstRepresentationMultiInputTest(self).run_test()
         ConstRepresentationListTypeArgsTest(self).run_test()

--- a/tests/keras_tests/non_parallel_tests/test_keras_tp_model.py
+++ b/tests/keras_tests/non_parallel_tests/test_keras_tp_model.py
@@ -88,8 +88,9 @@ class TestKerasTPModel(unittest.TestCase):
         self.assertFalse(get_node(ReLU(max_value=8)).is_match_filter_params(relu_with_params))
 
         lrelu_with_params = LayerFilterParams(tf.nn.leaky_relu, SmallerEq("alpha", 2))
-        self.assertFalse(get_node(partial(tf.nn.leaky_relu, alpha=0.4)).is_match_filter_params(lrelu_with_params))  # alpha is float so it is consideres a consant weight of the op
+        self.assertTrue(get_node(partial(tf.nn.leaky_relu, alpha=0.4)).is_match_filter_params(lrelu_with_params))
         self.assertTrue(get_node(partial(tf.nn.leaky_relu, alpha=2)).is_match_filter_params(lrelu_with_params))
+        self.assertFalse(get_node(partial(tf.nn.leaky_relu, alpha=2.1)).is_match_filter_params(lrelu_with_params))
 
         lrelu_with_params = LayerFilterParams(tf.nn.leaky_relu)
         self.assertTrue(get_node(partial(tf.nn.leaky_relu, alpha=0.4)).is_match_filter_params(lrelu_with_params))

--- a/tests/keras_tests/non_parallel_tests/test_keras_tp_model.py
+++ b/tests/keras_tests/non_parallel_tests/test_keras_tp_model.py
@@ -88,9 +88,8 @@ class TestKerasTPModel(unittest.TestCase):
         self.assertFalse(get_node(ReLU(max_value=8)).is_match_filter_params(relu_with_params))
 
         lrelu_with_params = LayerFilterParams(tf.nn.leaky_relu, SmallerEq("alpha", 2))
-        self.assertTrue(get_node(partial(tf.nn.leaky_relu, alpha=0.4)).is_match_filter_params(lrelu_with_params))
+        self.assertFalse(get_node(partial(tf.nn.leaky_relu, alpha=0.4)).is_match_filter_params(lrelu_with_params))  # alpha is float so it is consideres a consant weight of the op
         self.assertTrue(get_node(partial(tf.nn.leaky_relu, alpha=2)).is_match_filter_params(lrelu_with_params))
-        self.assertFalse(get_node(partial(tf.nn.leaky_relu, alpha=2.1)).is_match_filter_params(lrelu_with_params))
 
         lrelu_with_params = LayerFilterParams(tf.nn.leaky_relu)
         self.assertTrue(get_node(partial(tf.nn.leaky_relu, alpha=0.4)).is_match_filter_params(lrelu_with_params))


### PR DESCRIPTION
## Pull Request Description:
A small refactor to the Keras Node builder.
Two main modifications:

1. Remove hard-coded operator mapping and replace with tf.inspect to extract const weights from TFOpLambda layers.
2. Move the const extraction from op_call_args and op_call_kwargs to functions.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).