### PR TITLE
Fix Keras input_as_list in node builder

### DIFF
--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -242,10 +242,12 @@ def build_node(node: KerasNode,
     output_shape = keras_layer.get_output_shape_at(io_index)
 
     if layer_class in [TFOpLambda, SlicingOpLambda]:
-        # Some functional ops (such as tf.concat) should receive the input tensors as a list
-        # and some are not (such as tf.multiply), so each FunctionalNode holds
-        # a flag to indicate that.
-        inputs_as_list = __is_functional_inputs_a_list(op_call_args)
+        # Some functional ops should receive the input tensors as a list,
+        # so each FunctionalNode holds a flag to indicate that.
+        # Other functional ops can receive each argument as list, but in that case not all inputs appear in that list.
+        inputs_as_list = (keras_layer.symbol in [TFOpLambda(tf.concat).symbol, TFOpLambda(tf.stack).symbol,
+                                                 TFOpLambda(tf.add_n).symbol] and len(op_call_args) > 0 and
+                          isinstance(op_call_args[0], list))
 
         kwarg2index = get_kwargs2index(keras_layer)
 
@@ -299,23 +301,3 @@ def build_node(node: KerasNode,
 
     node_name_to_node[node_name] = node
     return node
-
-
-def __is_functional_inputs_a_list(op_call_args: Any) -> bool:
-    """
-    Check whether the input tensors should be passed as a list
-    or not.
-
-    Args:
-        op_call_args: Arguments list to check.
-
-    Returns:
-        Whether the input tensors should be passed as a list or not.
-    """
-
-    if len(op_call_args) > 0 and isinstance(op_call_args[0], list):
-        inputs_as_list = True
-        for arg in op_call_args[0]:
-            inputs_as_list = inputs_as_list and (is_tensor(arg) or is_const(arg))
-        return inputs_as_list
-    return False

--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -245,9 +245,7 @@ def build_node(node: KerasNode,
         # Some functional ops should receive the input tensors as a list,
         # so each FunctionalNode holds a flag to indicate that.
         # Other functional ops can receive each argument as list, but in that case not all inputs appear in that list.
-        inputs_as_list = (keras_layer.symbol in [TFOpLambda(tf.concat).symbol, TFOpLambda(tf.stack).symbol,
-                                                 TFOpLambda(tf.add_n).symbol] and len(op_call_args) > 0 and
-                          isinstance(op_call_args[0], list))
+        inputs_as_list = __is_functional_inputs_a_list(op_call_args, keras_layer)
 
         kwarg2index = get_kwargs2index(keras_layer)
 
@@ -301,3 +299,22 @@ def build_node(node: KerasNode,
 
     node_name_to_node[node_name] = node
     return node
+
+
+def __is_functional_inputs_a_list(op_call_args: Any, keras_layer: Any) -> bool:
+    """
+    Check whether the input tensors should be passed as a list
+    or not. This is relevant only for specific TF operators that are specified in the function's condition.
+
+    Args:
+        op_call_args: Arguments list to check.
+        keras_layer: TFOpLambda layer.
+
+    Returns:
+        Whether the input tensors should be passed as a list or not.
+    """
+
+    return (keras_layer.symbol in
+            [TFOpLambda(tf.concat).symbol, TFOpLambda(tf.stack).symbol,TFOpLambda(tf.add_n).symbol] and
+            len(op_call_args) > 0 and
+            isinstance(op_call_args[0], list))


### PR DESCRIPTION
## Pull Request Description:
Fixing the test to decide whether a function op layer receives the input as a list or not.
The current test checks to see if the first argument is a list, but some ops (like subtract) can receive the arguments as separate lists representing tensors. In this case, the inputs are not in a single list.
The solution is to manually check for inputs list only on specific operators that can get all inputs in a list.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).