### PR TITLE
Set default shift negative in quantization config

### DIFF
--- a/model_compression_toolkit/core/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_config.py
@@ -56,7 +56,7 @@ class QuantizationConfig:
                  weights_second_moment_correction: bool = False,
                  input_scaling: bool = False,
                  softmax_shift: bool = False,
-                 shift_negative_activation_correction: bool = False,
+                 shift_negative_activation_correction: bool = True,
                  activation_channel_equalization: bool = False,
                  z_threshold: float = math.inf,
                  min_threshold: float = MIN_THRESHOLD,

--- a/tests/pytorch_tests/model_tests/feature_models/qat_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/qat_test.py
@@ -261,7 +261,7 @@ class QuantizationAwareTrainingMixedPrecisionCfgTest(QuantizationAwareTrainingTe
     def run_test(self):
         self._gen_fixed_input()
         model_float = self.create_networks()
-        config = mct.core.CoreConfig()
+        config = mct.core.CoreConfig(mct.core.QuantizationConfig(shift_negative_activation_correction=False))
         ru = mct.core.ResourceUtilization(np.inf, 47)  # inf memory
         qat_ready_model, quantization_info = mct.qat.pytorch_quantization_aware_training_init_experimental(model_float,
                                                                                                            self.representative_data_gen_experimental,
@@ -306,7 +306,7 @@ class QuantizationAwareTrainingMixedPrecisionRUCfgTest(QuantizationAwareTraining
     def run_test(self):
         self._gen_fixed_input()
         model_float = self.create_networks()
-        config = mct.core.CoreConfig()
+        config = mct.core.CoreConfig(mct.core.QuantizationConfig(shift_negative_activation_correction=False))
         ru = mct.core.ResourceUtilization(weights_memory=50, activation_memory=40)
         qat_ready_model, quantization_info = mct.qat.pytorch_quantization_aware_training_init_experimental(model_float,
                                                                                                            self.representative_data_gen_experimental,


### PR DESCRIPTION
## Pull Request Description:
Update shift negative default setting to be enabled

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).