### PR TITLE
Add test for concat with 16 bit

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v4/tpc_pytorch.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v4/tpc_pytorch.py
@@ -85,7 +85,8 @@ def generate_pytorch_tpc(name: str, tp_model: tp.TargetPlatformModel):
                                                     topk,
                                                     squeeze,
                                                     MaxPool2d])
-        tp.OperationsSetToLayers("Default16BitInout", [torch.stack, torch.cat])
+        tp.OperationsSetToLayers("Default16BitInout",
+                                 [torch.stack, torch.cat, torch.concat, torch.concatenate])
 
         tp.OperationsSetToLayers("Conv", [Conv2d, ConvTranspose2d],
                                  attr_mapping=pytorch_linear_attr_mapping)


### PR DESCRIPTION
## Pull Request Description:
Add test for 16 bits for concat node.
Add `torch.concat` & `torch.concatenate` to TPC, as their types don't match `torch.cat`.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).