### PR TITLE
In keras node builder, not define tuple or list of dicts or ints as consts

### DIFF
--- a/model_compression_toolkit/core/keras/reader/node_builder.py
+++ b/model_compression_toolkit/core/keras/reader/node_builder.py
@@ -43,7 +43,8 @@ layers = keras.layers
 
 REUSED_IDENTIFIER = '_reused_'
 
-is_const = lambda x: isinstance(x, (tf.Variable, tf.Tensor, np.ndarray, tuple, list))
+is_const = lambda x: isinstance(x, (tf.Variable, tf.Tensor, np.ndarray)) or \
+                     (isinstance(x, (tuple, list)) and not isinstance(x[0], (int, dict)))
 is_tensor = lambda x: isinstance(x, KerasTensor)
 
 


### PR DESCRIPTION
In Keras model, in case of a node with tuple/list of ints or dicts in the node's args, the MCT will not use these tuple/list as a const.

## Pull Request Description:


## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).