### PR TITLE
Filter out candidates for mixed precision in case of activation/weights only

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_candidates_filter.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_candidates_filter.py
@@ -40,8 +40,11 @@ def filter_candidates_for_mixed_precision(graph: Graph,
 
     """
 
+    no_total_restrictions = (target_resource_utilization.total_memory == np.inf and
+                             target_resource_utilization.bops == np.inf)
+
     if target_resource_utilization.weights_memory < np.inf:
-        if target_resource_utilization.activation_memory == np.inf:
+        if target_resource_utilization.activation_memory == np.inf and no_total_restrictions:
             # Running mixed precision for weights compression only -
             # filter out candidates activation only configurable node
             weights_conf = graph.get_weights_configurable_nodes(fw_info)
@@ -58,7 +61,7 @@ def filter_candidates_for_mixed_precision(graph: Graph,
                     n.candidates_quantization_cfg = filtered_conf
 
     elif target_resource_utilization.activation_memory < np.inf:
-        if target_resource_utilization.weights_memory == np.inf:
+        if target_resource_utilization.weights_memory == np.inf and no_total_restrictions:
             # Running mixed precision for activation compression only -
             # filter out candidates weights only configurable node
             activation_conf = graph.get_activation_configurable_nodes()

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_candidates_filter.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_candidates_filter.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+
+from model_compression_toolkit.core import ResourceUtilization, FrameworkInfo
+from model_compression_toolkit.core.common import Graph
+from model_compression_toolkit.logger import Logger
+from model_compression_toolkit.target_platform_capabilities.target_platform import TargetPlatformCapabilities
+
+
+def filter_candidates_for_mixed_precision(graph: Graph,
+                                          target_resource_utilization: ResourceUtilization,
+                                          fw_info: FrameworkInfo,
+                                          tpc: TargetPlatformCapabilities):
+    """
+    Filters out candidates in case of mixed precision search for only weights or activation compression.
+    For instance, if running only weights compression - filters out candidates of activation configurable nodes
+    such that only a single candidate would remain, with the bitwidth equal to the one defined in the matching layer's
+    base config in the TPC.
+
+    Note" This function modifies the graph inplace!
+
+    Args:
+        graph: A graph representation of the model to be quantized.
+        target_resource_utilization: The resource utilization of the target device.
+        fw_info: fw_info: Information needed for quantization about the specific framework.
+        tpc: TargetPlatformCapabilities object that describes the desired inference target platform.
+
+    """
+
+    if target_resource_utilization.weights_memory < np.inf:
+        if target_resource_utilization.activation_memory == np.inf:
+            # Running mixed precision for weights compression only -
+            # filter out candidates activation only configurable node
+            weights_conf = graph.get_weights_configurable_nodes(fw_info)
+            for n in graph.get_activation_configurable_nodes():
+                if n not in weights_conf:
+                    base_cfg_nbits = n.get_qco(tpc).base_config.activation_n_bits
+                    filtered_conf = [c for c in n.candidates_quantization_cfg if
+                                     c.activation_quantization_cfg.enable_activation_quantization and
+                                     c.activation_quantization_cfg.activation_n_bits == base_cfg_nbits]
+
+                    if len(filtered_conf) != 1:
+                        Logger.critical(f"Running weights only mixed precision failed on layer {n.name} with multiple "
+                                        f"activation quantization configurations.")  # pragma: no cover
+                    n.candidates_quantization_cfg = filtered_conf
+
+    elif target_resource_utilization.activation_memory < np.inf:
+        if target_resource_utilization.weights_memory == np.inf:
+            # Running mixed precision for activation compression only -
+            # filter out candidates weights only configurable node
+            activation_conf = graph.get_activation_configurable_nodes()
+            for n in graph.get_weights_configurable_nodes(fw_info):
+                if n not in activation_conf:
+                    kernel_attr = graph.fw_info.get_kernel_op_attributes(n.type)[0]
+                    base_cfg_nbits = n.get_qco(tpc).base_config.attr_weights_configs_mapping[kernel_attr].weights_n_bits
+                    filtered_conf = [c for c in n.candidates_quantization_cfg if
+                                     c.weights_quantization_cfg.get_attr_config(
+                                         kernel_attr).enable_weights_quantization and
+                                     c.weights_quantization_cfg.get_attr_config(
+                                         kernel_attr).weights_n_bits == base_cfg_nbits]
+                    if len(filtered_conf) != 1:
+                        Logger.critical(f"Running activation only mixed precision failed on layer {n.name} with multiple "
+                                        f"weights quantization configurations.")  # pragma: no cover
+                    n.candidates_quantization_cfg = filtered_conf

--- a/model_compression_toolkit/core/runner.py
+++ b/model_compression_toolkit/core/runner.py
@@ -27,6 +27,8 @@ from model_compression_toolkit.core.common.graph.memory_graph.compute_graph_max_
     SchedulerInfo
 from model_compression_toolkit.core.common.graph.memory_graph.memory_graph import MemoryGraph
 from model_compression_toolkit.core.common.hessian.hessian_info_service import HessianInfoService
+from model_compression_toolkit.core.common.mixed_precision.mixed_precision_candidates_filter import \
+    filter_candidates_for_mixed_precision
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization_data import \
     requires_mixed_precision
 from model_compression_toolkit.core.graph_prep_runner import graph_preparation_runner
@@ -137,6 +139,7 @@ def core_runner(in_model: Any,
     if core_config.mixed_precision_enable:
         if core_config.mixed_precision_config.configuration_overwrite is None:
 
+            filter_candidates_for_mixed_precision(graph, target_resource_utilization, fw_info, tpc)
             bit_widths_config = search_bit_width(tg,
                                                  fw_info,
                                                  fw_impl,

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
@@ -18,8 +18,11 @@ import numpy as np
 import tensorflow as tf
 from keras.activations import sigmoid, softmax
 
+from common.tp_models.int8_tp_model import get_op_quantization_configs
 from mct_quantizers import KerasActivationQuantizationHolder
-from model_compression_toolkit.core.keras.constants import SIGMOID, SOFTMAX
+from model_compression_toolkit import DefaultDict
+from model_compression_toolkit.core.keras.constants import SIGMOID, SOFTMAX, BIAS
+from model_compression_toolkit.target_platform_capabilities.constants import KERNEL_ATTR, BIAS_ATTR, KERAS_KERNEL
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_op_qc, generate_test_attr_configs
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from keras import backend as K
@@ -609,3 +612,73 @@ class MixedPrecisionDistanceSigmoidTest(MixedPrecisionActivationBaseTest):
         activation_bits = [layer.activation_holder_quantizer.get_config()['num_bits'] for layer in
                            holder_layers]
         self.unit_test.assertTrue((activation_bits == [4, 4, 4, 4]))
+
+
+class MixedPrecisionActivationOnlyConfigurableWeightsTest(MixedPrecisionActivationBaseTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test, activation_layers_idx=[3, 4])
+
+    def create_networks(self):
+        inputs = layers.Input(shape=self.get_input_shapes()[0][1:])
+        x = layers.Conv2D(32, 4)(inputs)
+        x = layers.Add()([x, x])
+        outputs = layers.ReLU()(x)
+        model = keras.Model(inputs=inputs, outputs=outputs)
+        return model
+
+    def get_tpc(self):
+        cfg, mixed_precision_cfg_list, _ = get_op_quantization_configs()
+
+        act_eight_bit_cfg = cfg.clone_and_edit(activation_n_bits=8,
+                                               attr_weights_configs_mapping={})
+        act_four_bit_cfg = cfg.clone_and_edit(activation_n_bits=4,
+                                              attr_weights_configs_mapping={})
+        act_two_bit_cfg = cfg.clone_and_edit(activation_n_bits=2,
+                                             attr_weights_configs_mapping={})
+
+        mixed_precision_cfg_list = \
+            [c.clone_and_edit(enable_activation_quantization=False) for c in mixed_precision_cfg_list]
+        cfg = mixed_precision_cfg_list[0]
+
+        act_mixed_cfg = tp.QuantizationConfigOptions(
+            [act_eight_bit_cfg, act_four_bit_cfg, act_two_bit_cfg],
+            base_config=act_eight_bit_cfg,
+        )
+
+        weight_mixed_cfg = tp.QuantizationConfigOptions(
+            mixed_precision_cfg_list,
+            base_config=cfg,
+        )
+
+        tp_model = tp.TargetPlatformModel(tp.QuantizationConfigOptions([cfg], cfg),
+                                          name="mp_activation_conf_weights_test")
+
+        with tp_model:
+            tp.OperatorsSet("Activations", act_mixed_cfg)
+            tp.OperatorsSet("Weights", weight_mixed_cfg)
+
+        keras_tpc = tp.TargetPlatformCapabilities(tp_model, name="mp_activation_conf_weights_test")
+
+        with keras_tpc:
+            tp.OperationsSetToLayers(
+                "Weights",
+                [layers.Conv2D],
+                attr_mapping={KERNEL_ATTR: DefaultDict(default_value=KERAS_KERNEL),
+                              BIAS_ATTR: DefaultDict(default_value=BIAS)}
+            )
+
+            tp.OperationsSetToLayers(
+                "Activations",
+                [layers.ReLU, layers.Add]
+            )
+
+        return keras_tpc
+
+    def get_resource_utilization(self):
+        return ResourceUtilization(np.inf, 5407)
+
+    def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
+        holder_layers = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)
+
+        activation_bits = [layer.activation_holder_quantizer.get_config()['num_bits'] for layer in holder_layers]
+        self.unit_test.assertTrue(activation_bits == [4, 4])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_tests.py
@@ -18,12 +18,12 @@ import numpy as np
 import tensorflow as tf
 from keras.activations import sigmoid, softmax
 
-from common.tp_models.int8_tp_model import get_op_quantization_configs
 from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit import DefaultDict
 from model_compression_toolkit.core.keras.constants import SIGMOID, SOFTMAX, BIAS
 from model_compression_toolkit.target_platform_capabilities.constants import KERNEL_ATTR, BIAS_ATTR, KERAS_KERNEL
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_op_qc, generate_test_attr_configs
+from tests.keras_tests.exporter_tests.tflite_int8.imx500_int8_tp_model import get_op_quantization_configs
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from keras import backend as K
 

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -67,6 +67,7 @@ from tests.keras_tests.feature_networks_tests.feature_networks.mixed_precision_t
     MixedPrecisionActivationSearchTest, MixedPrecisionActivationSearch4BitsAvgTest, \
     MixedPrecisionActivationSearch2BitsAvgTest, MixedPrecisionActivationDepthwiseTest, \
     MixedPrecisionActivationSplitLayerTest, MixedPrecisionActivationOnlyWeightsDisabledTest, \
+    MixedPrecisionActivationOnlyConfigurableWeightsTest, \
     MixedPrecisionActivationOnlyTest, MixedPrecisionActivationDepthwise4BitTest, MixedPrecisionActivationAddLayerTest, \
     MixedPrecisionActivationMultipleInputsTest, MixedPrecisionTotalMemoryUtilizationSearchTest, \
     MixedPrecisionMultipleResourcesTightUtilizationSearchTest, MixedPrecisionReducedTotalMemorySearchTest, \
@@ -132,7 +133,7 @@ from tests.keras_tests.feature_networks_tests.feature_networks.uniform_range_sel
     UniformRangeSelectionActivationTest, UniformRangeSelectionBoundedActivationTest
 from tests.keras_tests.feature_networks_tests.feature_networks.weights_mixed_precision_tests import \
     MixedPrecisionSearch4BitsAvgTest, MixedPrecisionSearch2BitsAvgTest, MixedPrecisionActivationDisabled, \
-    MixedPrecisionWithHessianScoresTest, MixedPrecisionSearchTest, \
+    MixedPrecisionWithHessianScoresTest, MixedPrecisionSearchTest, MixedPrecisionWeightsOnlyConfigurableActivationsTest, \
     MixedPrecisionSearchPartWeightsLayersTest, MixedPrecisionDepthwiseTest, MixedPrecisionSearchLastLayerDistanceTest, \
     MixedPrecisionSearchActivationNonConfNodesTest, MixedPrecisionSearchTotalMemoryNonConfNodesTest, \
     MixedPrecisionCombinedNMSTest
@@ -229,6 +230,9 @@ class FeatureNetworkTest(unittest.TestCase):
         MixedPrecisionSearchTest(self, distance_metric=MpDistanceWeighting.LAST_LAYER).run_test()
         MixedPrecisionWithHessianScoresTest(self, distance_metric=MpDistanceWeighting.AVG).run_test()
 
+    def test_mixed_precision_weights_only_activation_conf(self):
+        MixedPrecisionWeightsOnlyConfigurableActivationsTest(self).run_test()
+
     def test_requires_mixed_recision(self):
         RequiresMixedPrecisionWeights(self, weights_memory=True).run_test()
         RequiresMixedPrecision(self,activation_memory=True).run_test()
@@ -262,6 +266,9 @@ class FeatureNetworkTest(unittest.TestCase):
 
     def test_mixed_precision_activation_only_weights_disabled(self):
         MixedPrecisionActivationOnlyWeightsDisabledTest(self).run_test()
+
+    def test_mixed_precision_activation_only_conf_weights(self):
+        MixedPrecisionActivationOnlyConfigurableWeightsTest(self).run_test()
 
     def test_mixed_precision_activation_search_4bits_avg(self):
         MixedPrecisionActivationSearch4BitsAvgTest(self).run_test()

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -17,8 +17,13 @@ import numpy as np
 from torch import softmax, sigmoid
 from torch.nn import Softmax, Sigmoid
 
+from model_compression_toolkit import DefaultDict
 from model_compression_toolkit.core import MixedPrecisionQuantizationConfig, ResourceUtilization
 from model_compression_toolkit.core.common.user_info import UserInformation
+from model_compression_toolkit.target_platform_capabilities.constants import KERNEL_ATTR, BIAS_ATTR, PYTORCH_KERNEL, \
+    BIAS
+from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationConfigOptions, \
+    TargetPlatformModel, OperatorsSet, TargetPlatformCapabilities, OperationsSetToLayers
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import get_op_quantization_configs
 from tests.common_tests.helpers.generate_test_tp_model import generate_tp_model_with_activation_mp
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
@@ -204,6 +209,20 @@ class MixedPrecisionMultipleInputsNet(torch.nn.Module):
         return torch.concat([x1, x2, x3, x4], dim=1)
 
 
+class MixedPrecisionActivationTestNet(torch.nn.Module):
+    def __init__(self, input_shape):
+        super(MixedPrecisionActivationTestNet, self).__init__()
+        _, in_channels, _, _ = input_shape[0]
+        self.conv1 = torch.nn.Conv2d(in_channels, 3, kernel_size=(3, 3))
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = torch.add(x, x)
+        output = self.relu(x)
+        return output
+
+
 class MixedPrecisionDistanceFunctionsNet(torch.nn.Module):
     def __init__(self, input_shape):
         super(MixedPrecisionDistanceFunctionsNet, self).__init__()
@@ -247,6 +266,69 @@ class MixedPrecisionDistanceFunctions(MixedPrecisionActivationBaseTest):
 
     def create_feature_network(self, input_shape):
         return MixedPrecisionDistanceFunctionsNet(input_shape)
+
+    def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
+        self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)
+
+
+class MixedPrecisionActivationConfigurableWeights(MixedPrecisionActivationBaseTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.expected_config = [1, 1]
+
+    def get_tpc(self):
+        cfg, mixed_precision_cfg_list, _ = get_op_quantization_configs()
+
+        act_eight_bit_cfg = cfg.clone_and_edit(activation_n_bits=8,
+                                               attr_weights_configs_mapping={})
+        act_four_bit_cfg = cfg.clone_and_edit(activation_n_bits=4,
+                                              attr_weights_configs_mapping={})
+        act_two_bit_cfg = cfg.clone_and_edit(activation_n_bits=2,
+                                             attr_weights_configs_mapping={})
+
+        mixed_precision_cfg_list = \
+            [c.clone_and_edit(enable_activation_quantization=False) for c in mixed_precision_cfg_list]
+        cfg = mixed_precision_cfg_list[0]
+
+        act_mixed_cfg = QuantizationConfigOptions(
+            [act_eight_bit_cfg, act_four_bit_cfg, act_two_bit_cfg],
+            base_config=act_eight_bit_cfg,
+        )
+
+        weight_mixed_cfg = QuantizationConfigOptions(
+            mixed_precision_cfg_list,
+            base_config=cfg,
+        )
+
+        tp_model = TargetPlatformModel(QuantizationConfigOptions([cfg], cfg),
+                                       name="mp_activation_conf_weights_test")
+
+        with tp_model:
+            OperatorsSet("Activations", act_mixed_cfg)
+            OperatorsSet("Weights", weight_mixed_cfg)
+
+        torch_tpc = TargetPlatformCapabilities(tp_model, name="mp_activation_conf_weights_test")
+
+        with torch_tpc:
+            OperationsSetToLayers(
+                "Weights",
+                [torch.nn.Conv2d],
+                attr_mapping={KERNEL_ATTR: DefaultDict(default_value=PYTORCH_KERNEL),
+                              BIAS_ATTR: DefaultDict(default_value=BIAS)}
+            )
+
+            OperationsSetToLayers(
+                "Activations",
+                [torch.nn.ReLU, torch.add]
+            )
+
+        return {'mixed_precision_activation_model': torch_tpc}
+
+    def create_feature_network(self, input_shape):
+        return MixedPrecisionActivationTestNet(input_shape)
+
+    def get_resource_utilization(self):
+        return ResourceUtilization(np.inf, 1536)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
         self.verify_config(quantization_info.mixed_precision_cfg, self.expected_config)

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -74,7 +74,7 @@ class MixedPrecisionActivationBaseTest(BasePytorchTest):
 class MixedPrecisionActivationSearch8Bit(MixedPrecisionActivationBaseTest):
     def __init__(self, unit_test):
         super().__init__(unit_test)
-        self.expected_config = [1, 0, 0, 0]
+        self.expected_config = [1, 0, 0]
 
     def get_resource_utilization(self):
         return ResourceUtilization(np.inf, 3000)

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_weights_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_weights_test.py
@@ -22,6 +22,8 @@ from model_compression_toolkit.core.common.mixed_precision.distance_weighting im
 from model_compression_toolkit.core.common.user_info import UserInformation
 from model_compression_toolkit.core.pytorch.constants import BIAS
 from model_compression_toolkit.target_platform_capabilities.constants import KERNEL_ATTR, PYTORCH_KERNEL, BIAS_ATTR
+from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationConfigOptions, \
+    TargetPlatformModel, OperatorsSet, TargetPlatformCapabilities, OperationsSetToLayers
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import get_tp_model, get_op_quantization_configs
 from tests.common_tests.helpers.generate_test_tp_model import generate_mixed_precision_test_tp_model
 from tests.pytorch_tests.tpc_pytorch import get_pytorch_test_tpc_dict
@@ -273,5 +275,82 @@ class MixedPrecisionNet(torch.nn.Module):
         x = self.conv1(inp)
         x = self.bn1(x)
         x = self.conv2(x)
+        output = self.relu(x)
+        return output
+
+
+class MixedPrecisionWeightsConfigurableActivations(MixedPrecisionBaseTest):
+    def __init__(self, unit_test):
+        super().__init__(unit_test)
+        self.expected_config = [1]
+
+    def get_tpc(self):
+        cfg, mixed_precision_cfg_list, _ = get_op_quantization_configs()
+
+        act_eight_bit_cfg = cfg.clone_and_edit(activation_n_bits=8,
+                                               attr_weights_configs_mapping={})
+        act_four_bit_cfg = cfg.clone_and_edit(activation_n_bits=4,
+                                              attr_weights_configs_mapping={})
+        act_two_bit_cfg = cfg.clone_and_edit(activation_n_bits=2,
+                                             attr_weights_configs_mapping={})
+
+        mixed_precision_cfg_list = \
+            [c.clone_and_edit(enable_activation_quantization=False) for c in mixed_precision_cfg_list]
+        cfg = mixed_precision_cfg_list[0]
+
+        act_mixed_cfg = QuantizationConfigOptions(
+            [act_eight_bit_cfg, act_four_bit_cfg, act_two_bit_cfg],
+            base_config=act_eight_bit_cfg,
+        )
+
+        weight_mixed_cfg = QuantizationConfigOptions(
+            mixed_precision_cfg_list,
+            base_config=cfg,
+        )
+
+        tp_model = TargetPlatformModel(QuantizationConfigOptions([cfg], cfg),
+                                       name="mp_weights_conf_act_test")
+
+        with tp_model:
+            OperatorsSet("Activations", act_mixed_cfg)
+            OperatorsSet("Weights", weight_mixed_cfg)
+
+        torch_tpc = TargetPlatformCapabilities(tp_model, name="mp_weights_conf_act_test")
+
+        with torch_tpc:
+            OperationsSetToLayers(
+                "Weights",
+                [torch.nn.Conv2d],
+                attr_mapping={KERNEL_ATTR: DefaultDict(default_value=PYTORCH_KERNEL),
+                              BIAS_ATTR: DefaultDict(default_value=BIAS)}
+            )
+
+            OperationsSetToLayers(
+                "Activations",
+                [torch.nn.ReLU, torch.add]
+            )
+
+        return {'mixed_precision_model': torch_tpc}
+
+    def create_feature_network(self, input_shape):
+        return MixedPrecisionWeightsTestNet(input_shape)
+
+    def get_resource_utilization(self):
+        return ResourceUtilization(80)
+
+    def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
+        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == self.expected_config))
+
+
+class MixedPrecisionWeightsTestNet(torch.nn.Module):
+    def __init__(self, input_shape):
+        super(MixedPrecisionWeightsTestNet, self).__init__()
+        _, in_channels, _, _ = input_shape[0]
+        self.conv1 = torch.nn.Conv2d(in_channels, 3, kernel_size=(3, 3))
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, inp):
+        x = self.conv1(inp)
+        x = torch.add(x, x)
         output = self.relu(x)
         return output

--- a/tests/pytorch_tests/model_tests/feature_models/qat_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/qat_test.py
@@ -262,7 +262,7 @@ class QuantizationAwareTrainingMixedPrecisionCfgTest(QuantizationAwareTrainingTe
         self._gen_fixed_input()
         model_float = self.create_networks()
         config = mct.core.CoreConfig(mct.core.QuantizationConfig(shift_negative_activation_correction=False))
-        ru = mct.core.ResourceUtilization(np.inf, 47)  # inf memory
+        ru = mct.core.ResourceUtilization(57, 47)  # inf memory
         qat_ready_model, quantization_info = mct.qat.pytorch_quantization_aware_training_init_experimental(model_float,
                                                                                                            self.representative_data_gen_experimental,
                                                                                                            ru,
@@ -275,8 +275,7 @@ class QuantizationAwareTrainingMixedPrecisionCfgTest(QuantizationAwareTrainingTe
                      input_x=self.representative_data_gen(),
                      quantization_info=quantization_info)
 
-        # check that MP search returns 8 bits configuration for all layers
-        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == [1, 0, 0, 0, 0]))
+        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == [1, 0, 0, 1, 0]))
 
         # check that quantizer gets multiple bits configuration
         for _, layer in qat_ready_model.named_children():

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -620,42 +620,42 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         This test checks the QAT feature.
         """
-        # QuantizationAwareTrainingTest(self).run_test()
-        # QuantizationAwareTrainingTest(self, finalize=True).run_test()
-        # _method = mct.target_platform.QuantizationMethod.SYMMETRIC
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=_method,
-        #                               activation_quantization_method=_method
-        #                               ).run_test()
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=_method,
-        #                               activation_quantization_method=_method,
-        #                               finalize=True).run_test()
-        # _method = mct.target_platform.QuantizationMethod.UNIFORM
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=_method,
-        #                               activation_quantization_method=_method
-        #                               ).run_test()
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=_method,
-        #                               activation_quantization_method=_method,
-        #                               finalize=True).run_test()
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
-        #                               activation_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
-        #                               training_method=mct.qat.TrainingMethod.LSQ,
-        #                               finalize=True).run_test()
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
-        #                               activation_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
-        #                               training_method=mct.qat.TrainingMethod.LSQ,
-        #                               finalize=True).run_test()
-        # QuantizationAwareTrainingTest(self,
-        #                               weights_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
-        #                               activation_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
-        #                               training_method=mct.qat.TrainingMethod.LSQ,
-        #                               finalize=True).run_test()
-        # QuantizationAwareTrainingQuantizerHolderTest(self).run_test()
+        QuantizationAwareTrainingTest(self).run_test()
+        QuantizationAwareTrainingTest(self, finalize=True).run_test()
+        _method = mct.target_platform.QuantizationMethod.SYMMETRIC
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=_method,
+                                      activation_quantization_method=_method
+                                      ).run_test()
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=_method,
+                                      activation_quantization_method=_method,
+                                      finalize=True).run_test()
+        _method = mct.target_platform.QuantizationMethod.UNIFORM
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=_method,
+                                      activation_quantization_method=_method
+                                      ).run_test()
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=_method,
+                                      activation_quantization_method=_method,
+                                      finalize=True).run_test()
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
+                                      activation_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
+                                      training_method=mct.qat.TrainingMethod.LSQ,
+                                      finalize=True).run_test()
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
+                                      activation_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
+                                      training_method=mct.qat.TrainingMethod.LSQ,
+                                      finalize=True).run_test()
+        QuantizationAwareTrainingTest(self,
+                                      weights_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
+                                      activation_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
+                                      training_method=mct.qat.TrainingMethod.LSQ,
+                                      finalize=True).run_test()
+        QuantizationAwareTrainingQuantizerHolderTest(self).run_test()
         QuantizationAwareTrainingMixedPrecisionCfgTest(self).run_test()
         QuantizationAwareTrainingMixedPrecisionRUCfgTest(self).run_test()
 

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -54,7 +54,7 @@ from tests.pytorch_tests.model_tests.feature_models.dynamic_size_inputs_test imp
 from tests.pytorch_tests.model_tests.feature_models.mixed_precision_activation_test import \
     MixedPrecisionActivationSearch8Bit, MixedPrecisionActivationSearch2Bit, MixedPrecisionActivationSearch4Bit, \
     MixedPrecisionActivationSearch4BitFunctional, MixedPrecisionActivationMultipleInputs, \
-    MixedPrecisionDistanceFunctions
+    MixedPrecisionDistanceFunctions, MixedPrecisionActivationConfigurableWeights
 from tests.pytorch_tests.model_tests.feature_models.relu_bound_test import ReLUBoundToPOTNetTest, \
     HardtanhBoundToPOTNetTest
 from tests.pytorch_tests.model_tests.feature_models.scalar_tensor_test import ScalarTensorTest
@@ -79,7 +79,8 @@ from tests.pytorch_tests.model_tests.feature_models.lut_quantizer_test import LU
     LUTActivationQuantizerTest
 from tests.pytorch_tests.model_tests.feature_models.mixed_precision_weights_test import MixedPrecisionSearch4Bit, \
     MixedPrecisionActivationDisabledTest, MixedPrecisionSearchLastLayerDistance, MixedPrecisionWithHessianScores, \
-    MixedPrecisionSearch8Bit, MixedPrecisionSearchPartWeightsLayers, MixedPrecisionSearch2Bit
+    MixedPrecisionSearch8Bit, MixedPrecisionSearchPartWeightsLayers, MixedPrecisionSearch2Bit, \
+    MixedPrecisionWeightsConfigurableActivations
 from tests.pytorch_tests.model_tests.feature_models.multiple_output_nodes_multiple_tensors_test import \
     MultipleOutputsMultipleTensorsNetTest
 from tests.pytorch_tests.model_tests.feature_models.multiple_outputs_node_test import MultipleOutputsNetTest
@@ -521,6 +522,18 @@ class FeatureModelsTestRunner(unittest.TestCase):
         This test checks the activation Mixed Precision search.
         """
         MixedPrecisionActivationSearch4Bit(self).run_test()
+
+    def test_mixed_precision_activation_only_conf_weights(self):
+        """
+        This test checks the Mixed Precision for activation only with configurable weights layers.
+        """
+        MixedPrecisionActivationConfigurableWeights(self).run_test()
+
+    def test_mixed_precision_weights_only_conf_activations(self):
+        """
+        This test checks the Mixed Precision for weights only with configurable activation layers.
+        """
+        MixedPrecisionWeightsConfigurableActivations(self).run_test()
 
     def test_mixed_precision_activation_4bit_functional(self):
         """

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -620,42 +620,42 @@ class FeatureModelsTestRunner(unittest.TestCase):
         """
         This test checks the QAT feature.
         """
-        QuantizationAwareTrainingTest(self).run_test()
-        QuantizationAwareTrainingTest(self, finalize=True).run_test()
-        _method = mct.target_platform.QuantizationMethod.SYMMETRIC
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=_method,
-                                      activation_quantization_method=_method
-                                      ).run_test()
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=_method,
-                                      activation_quantization_method=_method,
-                                      finalize=True).run_test()
-        _method = mct.target_platform.QuantizationMethod.UNIFORM
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=_method,
-                                      activation_quantization_method=_method
-                                      ).run_test()
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=_method,
-                                      activation_quantization_method=_method,
-                                      finalize=True).run_test()
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
-                                      activation_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
-                                      training_method=mct.qat.TrainingMethod.LSQ,
-                                      finalize=True).run_test()
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
-                                      activation_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
-                                      training_method=mct.qat.TrainingMethod.LSQ,
-                                      finalize=True).run_test()
-        QuantizationAwareTrainingTest(self,
-                                      weights_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
-                                      activation_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
-                                      training_method=mct.qat.TrainingMethod.LSQ,
-                                      finalize=True).run_test()
-        QuantizationAwareTrainingQuantizerHolderTest(self).run_test()
+        # QuantizationAwareTrainingTest(self).run_test()
+        # QuantizationAwareTrainingTest(self, finalize=True).run_test()
+        # _method = mct.target_platform.QuantizationMethod.SYMMETRIC
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=_method,
+        #                               activation_quantization_method=_method
+        #                               ).run_test()
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=_method,
+        #                               activation_quantization_method=_method,
+        #                               finalize=True).run_test()
+        # _method = mct.target_platform.QuantizationMethod.UNIFORM
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=_method,
+        #                               activation_quantization_method=_method
+        #                               ).run_test()
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=_method,
+        #                               activation_quantization_method=_method,
+        #                               finalize=True).run_test()
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
+        #                               activation_quantization_method=mct.target_platform.QuantizationMethod.SYMMETRIC,
+        #                               training_method=mct.qat.TrainingMethod.LSQ,
+        #                               finalize=True).run_test()
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
+        #                               activation_quantization_method=mct.target_platform.QuantizationMethod.UNIFORM,
+        #                               training_method=mct.qat.TrainingMethod.LSQ,
+        #                               finalize=True).run_test()
+        # QuantizationAwareTrainingTest(self,
+        #                               weights_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
+        #                               activation_quantization_method=mct.target_platform.QuantizationMethod.POWER_OF_TWO,
+        #                               training_method=mct.qat.TrainingMethod.LSQ,
+        #                               finalize=True).run_test()
+        # QuantizationAwareTrainingQuantizerHolderTest(self).run_test()
         QuantizationAwareTrainingMixedPrecisionCfgTest(self).run_test()
         QuantizationAwareTrainingMixedPrecisionRUCfgTest(self).run_test()
 


### PR DESCRIPTION
## Pull Request Description:

When running mixed precision quantization for weights/activation compression only but there are layers with multiple activation bit-width candidates, we need to filter out the irrelevant activation candidates (to make the layers non-configurable).
The same goes for activation only mixed precision.

For this, we added a new procedure before the mixed precision search which modified the candidates of the relevant nodes in the graph.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).