### PR TITLE
use trainable activation quantizers in gptq (pytorch)

### DIFF
--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -32,6 +32,10 @@ class RoundingType(Enum):
     SoftQuantizer = 1
 
 
+class ActivationGradProp(Enum):
+    STE = "GPTQ_ACTIVATION_STE"
+
+
 class GPTQHessianScoresConfig:
     """
     Configuration to use for computing the Hessian-based scores for GPTQ loss metric.

--- a/model_compression_toolkit/gptq/pytorch/quantizer/activation/__init__.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/activation/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/model_compression_toolkit/gptq/pytorch/quantizer/activation/ste_activation.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/activation/ste_activation.py
@@ -1,0 +1,64 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+Created on 8/13/24
+
+@author: irenab
+"""
+import torch
+from mct_quantizers import mark_quantizer, QuantizationTarget, QuantizationMethod
+from mct_quantizers.pytorch.quantizers import ActivationSymmetricInferableQuantizer, ActivationUniformInferableQuantizer
+
+from model_compression_toolkit.gptq.common.gptq_config import ActivationGradProp
+
+
+class BaseActivationPytorchGPTQTrainableQuantizer:
+    """
+    Trainable activation quantization for GPTQ.
+    It's trainable in a sense that it can be used during training (unlike inferable which do not propagate gradients).
+    It does not extend the base trainable quantizer since it doesn't conform to the trainable interface (e.g.
+    doesn't have quantization config, which is required in trainable quantizer)
+    """
+    pass
+
+
+@mark_quantizer(quantization_target=QuantizationTarget.Activation,
+                quantization_method=[QuantizationMethod.POWER_OF_TWO, QuantizationMethod.SYMMETRIC],
+                identifier=ActivationGradProp.STE)
+class STEActivationSymmetricGPTQTrainableQuantizer(BaseActivationPytorchGPTQTrainableQuantizer,
+                                                   ActivationSymmetricInferableQuantizer):
+    """ Symmetric activation quantizer with STE gradient propagation """
+
+    def __call__(self, inputs):
+        return torch.fake_quantize_per_tensor_affine(inputs,
+                                                     scale=self.scales,
+                                                     zero_point=self.zero_points,
+                                                     quant_min=self.min_quantized_domain,
+                                                     quant_max=self.max_quantized_domain)
+
+
+@mark_quantizer(quantization_target=QuantizationTarget.Activation,
+                quantization_method=[QuantizationMethod.UNIFORM],
+                identifier=ActivationGradProp.STE)
+class STEActivationUniformGPTQTrainableQuantizer(BaseActivationPytorchGPTQTrainableQuantizer,
+                                                 ActivationUniformInferableQuantizer):
+    """ Uniform activation quantizer with STE gradient propagation """
+
+    def __call__(self, inputs):
+        return torch.fake_quantize_per_tensor_affine(inputs,
+                                                     scale=self.scale,
+                                                     zero_point=self.zero_point,
+                                                     quant_min=self.min_quantized_domain,
+                                                     quant_max=self.max_quantized_domain)

--- a/model_compression_toolkit/gptq/pytorch/quantizer/quantization_builder.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/quantization_builder.py
@@ -18,10 +18,12 @@ from model_compression_toolkit.gptq import GradientPTQConfig
 from model_compression_toolkit.core import common
 from model_compression_toolkit.exporter.model_wrapper.pytorch.builder.node_to_quantizer import \
     get_activation_inferable_quantizer_kwargs
+from model_compression_toolkit.gptq.common.gptq_config import ActivationGradProp
+from model_compression_toolkit.gptq.pytorch.quantizer.activation.ste_activation import \
+    BaseActivationPytorchGPTQTrainableQuantizer
 from model_compression_toolkit.gptq.pytorch.quantizer.base_pytorch_gptq_quantizer import \
     BasePytorchGPTQTrainableQuantizer
 from mct_quantizers import QuantizationTarget
-from mct_quantizers.common.get_quantizers import get_inferable_quantizer_class
 from mct_quantizers.pytorch.quantizers import BasePyTorchInferableQuantizer
 
 from model_compression_toolkit.logger import Logger
@@ -69,10 +71,11 @@ def quantization_builder(n: common.BaseNode,
 
         quant_method = n.final_activation_quantization_cfg.activation_quantization_method
 
-        quantizer_class = get_inferable_quantizer_class(quant_target=QuantizationTarget.Activation,
+        quantizer_class = get_trainable_quantizer_class(quant_target=QuantizationTarget.Activation,
+                                                        quantizer_id=ActivationGradProp.STE,
                                                         quant_method=quant_method,
-                                                        quantizer_base_class=BasePyTorchInferableQuantizer)
-
+                                                        quantizer_base_class=BaseActivationPytorchGPTQTrainableQuantizer)
+        # gptq trainable activation has the same interface as inferable
         kwargs = get_activation_inferable_quantizer_kwargs(n.final_activation_quantization_cfg)
 
         activation_quantizers.append(quantizer_class(**kwargs))

--- a/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
+++ b/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
@@ -3,7 +3,6 @@ import copy
 import unittest
 import torch
 from mct_quantizers import PytorchActivationQuantizationHolder, PytorchQuantizationWrapper
-from mct_quantizers.pytorch.quantizers import ActivationPOTInferableQuantizer
 from torch.nn import Conv2d
 import numpy as np
 
@@ -12,6 +11,8 @@ from model_compression_toolkit.core.common.mixed_precision.bit_width_setter impo
 from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.gptq.pytorch.gptq_pytorch_implementation import GPTQPytorchImplemantation
 from model_compression_toolkit.gptq.pytorch.gptq_training import PytorchGPTQTrainer
+from model_compression_toolkit.gptq.pytorch.quantizer.activation.ste_activation import \
+    STEActivationSymmetricGPTQTrainableQuantizer
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
 from torch.fx import symbolic_trace
 from tests.common_tests.helpers.prep_graph_for_func_test import prepare_graph_with_quantization_parameters
@@ -73,7 +74,7 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         # check that 4 activation quantization holders where generated
         self.assertTrue(len(activation_quantization_holders_in_model) == 3)
         for a in activation_quantization_holders_in_model:
-            self.assertTrue(isinstance(a.activation_holder_quantizer, ActivationPOTInferableQuantizer))
+            self.assertTrue(isinstance(a.activation_holder_quantizer, STEActivationSymmetricGPTQTrainableQuantizer))
         for name, module in gptq_model.named_modules():
             if isinstance(module, PytorchQuantizationWrapper):
                 self.assertTrue(len(module.weights_quantizers) > 0)
@@ -87,7 +88,7 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         # check that 3 activation quantization holders where generated
         self.assertTrue(len(activation_quantization_holders_in_model) == 3)
         for a in activation_quantization_holders_in_model:
-            self.assertTrue(isinstance(a.activation_holder_quantizer, ActivationPOTInferableQuantizer))
+            self.assertTrue(isinstance(a.activation_holder_quantizer, STEActivationSymmetricGPTQTrainableQuantizer))
         for name, module in gptq_model.named_modules():
             if isinstance(module, PytorchQuantizationWrapper):
                 self.assertTrue(len(module.weights_quantizers) > 0)
@@ -102,7 +103,7 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         # check that 4 activation quantization holders where generated
         self.assertTrue(len(activation_quantization_holders_in_model) == 3)
         for a in activation_quantization_holders_in_model:
-            self.assertTrue(isinstance(a.activation_holder_quantizer, ActivationPOTInferableQuantizer))
+            self.assertTrue(isinstance(a.activation_holder_quantizer, STEActivationSymmetricGPTQTrainableQuantizer))
         for name, module in gptq_model.named_modules():
             if isinstance(module, PytorchQuantizationWrapper):
                 self.assertTrue(len(module.weights_quantizers) > 0)

--- a/tests/pytorch_tests/function_tests/test_gptq_activation_quantizers.py
+++ b/tests/pytorch_tests/function_tests/test_gptq_activation_quantizers.py
@@ -1,0 +1,43 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import unittest
+
+import torch
+from mct_quantizers.pytorch.quantizers import ActivationSymmetricInferableQuantizer, ActivationUniformInferableQuantizer
+
+from model_compression_toolkit.gptq.pytorch.quantizer.activation.ste_activation import \
+    STEActivationSymmetricGPTQTrainableQuantizer, STEActivationUniformGPTQTrainableQuantizer
+
+
+class ActivationQuantTest(unittest.TestCase):
+    def test_symmetric(self):
+        kwargs = dict(num_bits=3, threshold=[1.5], signed=False)
+        q_inferable = ActivationSymmetricInferableQuantizer(**kwargs)
+        q = STEActivationSymmetricGPTQTrainableQuantizer(**kwargs)
+        self._run_test(q_inferable, q)
+
+    def test_uniform(self):
+        kwargs = dict(num_bits=5, min_range=[-3], max_range=[1.5])
+        q_inferable = ActivationUniformInferableQuantizer(**kwargs)
+        q = STEActivationUniformGPTQTrainableQuantizer(**kwargs)
+        self._run_test(q_inferable, q)
+
+    def _run_test(self, q_infer, q):
+        x = torch.randn((5, 10, 20), requires_grad=True, generator=torch.Generator().manual_seed(42))
+        y_infer = q_infer(x)
+        y = q(x)
+        self.assertTrue(torch.equal(y_infer, y))
+        # if autograd cannot propagate, will crash
+        torch.autograd.grad(y.mean(), x)


### PR DESCRIPTION
## Pull Request Description:
GPTQ used inferable activation quantizers which in pytorch do not propagate gradients, thus not all gradients reached the weights. 
Added new trainable activation quantizers without torch.no_grad for POT, symmetric and uniform. 

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).