### PR TITLE
Enhance Error Handling for TENSOR_META in Output Shape Calculation for YOLOv8 Quantization

### DIFF
--- a/model_compression_toolkit/core/pytorch/reader/graph_builders.py
+++ b/model_compression_toolkit/core/pytorch/reader/graph_builders.py
@@ -148,7 +148,7 @@ def _extract_input_and_output_shapes(_node: Node) -> Tuple[List, List]:
     if _node.meta[TYPE] == torch.Tensor:
         output_shape = [list(_node.meta[TENSOR_META].shape)]
     elif _node.meta[TYPE] in (list, tuple):
-        output_shape = [list(m.shape) for m in _node.meta[TENSOR_META]]
+        output_shape = [list(m.shape) for m in _node.meta.get(TENSOR_META, [])]
     elif _node.meta[TYPE] == int:
         output_shape = [[1]]
     else:


### PR DESCRIPTION
## Pull Request Description:
The PR addresses the case where a PyTorch graph contains additional input nodes, like `args` and `kwargs`, that have no outputs. Instead of causing an error, these nodes will be removed in the subsequent method: `remove_broken_nodes_from_graph`.

This PR includes a small update to the code that handles the extraction of `output_shape` based on the type of the `_node.meta[TYPE]`.

The old code assumes that `_node.meta[TENSOR_META]` is always present when` _node.meta[TYPE]` is a list or tuple. This assumption could lead to a `KeyError` if `TENSOR_META` is missing from `_node.meta.`

The new code uses `_node.meta.get(TENSOR_META, []) `instead, which returns an empty list if `TENSOR_META` is not found, thereby preventing potential errors and ensuring the code handles such cases more gracefully.

This change is necessary to handle scenarios specific to YOLOv8 quantization, where `TENSOR_META` may not always be present in `_node.meta`.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [X] All function and files are well documented. 
- [X] All function and classes have type hints.
- [X] There is a licenses in all file.
- [X] The function and variable names are informative. 
- [X] I have checked for code duplications.
- [x] I have added new unittest (if necessary).