### PR TITLE
Fixed device selection

### DIFF
--- a/model_compression_toolkit/core/pytorch/__init__.py
+++ b/model_compression_toolkit/core/pytorch/__init__.py
@@ -12,3 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.core.pytorch.pytorch_device_config import DeviceManager

--- a/model_compression_toolkit/core/pytorch/__init__.py
+++ b/model_compression_toolkit/core/pytorch/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.core.pytorch.pytorch_device_config import DeviceManager
+from model_compression_toolkit.core.pytorch.pytorch_device_config import set_working_device

--- a/model_compression_toolkit/core/pytorch/__init__.py
+++ b/model_compression_toolkit/core/pytorch/__init__.py
@@ -12,4 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.core.pytorch.pytorch_device_config import set_working_device

--- a/model_compression_toolkit/core/pytorch/utils.py
+++ b/model_compression_toolkit/core/pytorch/utils.py
@@ -20,7 +20,7 @@ from typing import Union
 from model_compression_toolkit.core.pytorch.constants import MAX_FLOAT16, MIN_FLOAT16
 from model_compression_toolkit.core.pytorch.pytorch_device_config import get_working_device
 from model_compression_toolkit.logger import Logger
-
+from model_compression_toolkit.core.pytorch.constants import CPU
 
 def set_model(model: torch.nn.Module, train_mode: bool = False):
     """
@@ -38,7 +38,10 @@ def set_model(model: torch.nn.Module, train_mode: bool = False):
         model.eval()
 
     device = get_working_device()
-    model.to(device)
+    if device.type == CPU:
+        model.cpu()
+    else:
+        model.cuda()
 
 
 def to_torch_tensor(tensor,


### PR DESCRIPTION
## Pull Request Description:
This PR fixes issue #1189. This PR also allows better import of the `set_working_device` function, facilitating more effective `DeviceManager` singleton management.

Example Usage:
```python
from model_compression_toolkit.core.pytorch import set_working_device

# Set the working device to 'GPU' or 'CPU'
set_working_device('GPU')
```
With this change, the `set_working_device` function can be easily imported and used to configure the `DeviceManager`'s device context. This also allows a quantization to be tested on a specific device.

cc: @Idan-BenAmi 


## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [X] All function and files are well documented. 
- [X] All function and classes have type hints.
- [X] There is a licenses in all file.
- [X] The function and variable names are informative. 
- [X] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).