### PR TITLE
Fix activation gradient backprop in GPTQ

### DIFF
--- a/model_compression_toolkit/gptq/pytorch/quantizer/quantization_builder.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/quantization_builder.py
@@ -25,8 +25,9 @@ from mct_quantizers.common.get_quantizers import get_inferable_quantizer_class
 from mct_quantizers.pytorch.quantizers import BasePyTorchInferableQuantizer
 
 from model_compression_toolkit.logger import Logger
+from model_compression_toolkit.trainable_infrastructure import TrainingMethod, BasePytorchActivationTrainableQuantizer
 from model_compression_toolkit.trainable_infrastructure.common.get_quantizer_config import \
-    get_trainable_quantizer_weights_config
+    get_trainable_quantizer_weights_config, get_trainable_quantizer_activation_config
 from model_compression_toolkit.trainable_infrastructure.common.get_quantizers import \
     get_trainable_quantizer_class
 
@@ -68,12 +69,11 @@ def quantization_builder(n: common.BaseNode,
 
         quant_method = n.final_activation_quantization_cfg.activation_quantization_method
 
-        quantizer_class = get_inferable_quantizer_class(quant_target=QuantizationTarget.Activation,
+        quantizer_class = get_trainable_quantizer_class(quant_target=QuantizationTarget.Activation,
+                                                        quantizer_id=TrainingMethod.STE,
                                                         quant_method=quant_method,
-                                                        quantizer_base_class=BasePyTorchInferableQuantizer)
-
-        kwargs = get_activation_inferable_quantizer_kwargs(n.final_activation_quantization_cfg)
-
-        activation_quantizers.append(quantizer_class(**kwargs))
+                                                        quantizer_base_class=BasePytorchActivationTrainableQuantizer)
+        cfg = get_trainable_quantizer_activation_config(n, None)
+        activation_quantizers.append(quantizer_class(cfg, freeze_quant_params=True))
 
     return weights_quantizers, activation_quantizers

--- a/model_compression_toolkit/trainable_infrastructure/common/base_trainable_quantizer.py
+++ b/model_compression_toolkit/trainable_infrastructure/common/base_trainable_quantizer.py
@@ -14,18 +14,16 @@
 # ==============================================================================
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Union, List, Any
 from inspect import signature
-
-from model_compression_toolkit.logger import Logger
+from typing import Union, List, Any
 
 from mct_quantizers.common.base_inferable_quantizer import BaseInferableQuantizer, \
     QuantizationTarget
-from model_compression_toolkit.trainable_infrastructure.common.trainable_quantizer_config import \
-    TrainableQuantizerActivationConfig, TrainableQuantizerWeightsConfig
 from mct_quantizers.common.constants import QUANTIZATION_METHOD, \
     QUANTIZATION_TARGET
-
+from model_compression_toolkit.logger import Logger
+from model_compression_toolkit.trainable_infrastructure.common.trainable_quantizer_config import \
+    TrainableQuantizerActivationConfig, TrainableQuantizerWeightsConfig
 
 VAR = 'var'
 GROUP = 'group'
@@ -43,12 +41,14 @@ class VariableGroup(Enum):
 
 class BaseTrainableQuantizer(BaseInferableQuantizer, ABC):
     def __init__(self,
-                 quantization_config: Union[TrainableQuantizerActivationConfig, TrainableQuantizerWeightsConfig]):
+                 quantization_config: Union[TrainableQuantizerActivationConfig, TrainableQuantizerWeightsConfig],
+                 freeze_quant_params: bool = False):
         """
         This class is a base quantizer which validates the provided quantization config and defines an abstract function which any quantizer needs to implment.
 
         Args:
             quantization_config: quantizer config class contains all the information about the quantizer configuration.
+            freeze_quant_params: whether to freeze all learnable quantization parameters during training.
         """
 
         # verify the quantizer class that inherits this class only has a config argument and key-word arguments
@@ -85,6 +85,7 @@ class BaseTrainableQuantizer(BaseInferableQuantizer, ABC):
                 f"Unrecognized 'QuantizationTarget': {static_quantization_target}.")  # pragma: no cover
 
         self.quantizer_parameters = {}
+        self.freeze_quant_params = freeze_quant_params
 
     @classmethod
     def get_sig(cls):

--- a/model_compression_toolkit/trainable_infrastructure/pytorch/activation_quantizers/ste/uniform_ste.py
+++ b/model_compression_toolkit/trainable_infrastructure/pytorch/activation_quantizers/ste/uniform_ste.py
@@ -36,14 +36,15 @@ class STEUniformActivationTrainableQuantizer(BasePytorchActivationTrainableQuant
     Trainable constrained quantizer to quantize a layer activations.
     """
 
-    def __init__(self, quantization_config: TrainableQuantizerActivationConfig):
+    def __init__(self, quantization_config: TrainableQuantizerActivationConfig, freeze_quant_params: bool = False):
         """
         Initialize a STEUniformActivationTrainableQuantizer object with parameters to use for uniform quantization.
 
         Args:
-            quantization_config: trainable quantizer config class
+            quantization_config: trainable quantizer config class.
+            freeze_quant_params: whether to freeze learnable quantization parameters.
         """
-        super().__init__(quantization_config)
+        super().__init__(quantization_config, freeze_quant_params)
 
         np_min_range = quantization_config.activation_quantization_params[C.RANGE_MIN]
         np_max_range = quantization_config.activation_quantization_params[C.RANGE_MAX]
@@ -56,7 +57,7 @@ class STEUniformActivationTrainableQuantizer(BasePytorchActivationTrainableQuant
                                 name: str,
                                 layer: PytorchQuantizationWrapper):
         """
-        Add quantizer parameters to the quantizer parameters dictionary
+        Add quantizer parameters to the quantizer parameters dictionary.
 
         Args:
             tensor_shape: tensor shape of the quantized tensor.
@@ -64,9 +65,9 @@ class STEUniformActivationTrainableQuantizer(BasePytorchActivationTrainableQuant
             layer: Layer to quantize.
         """
         layer.register_parameter(name+"_"+FQ_MIN, nn.Parameter(to_torch_tensor(self.min_range_tensor),
-                                                               requires_grad=True))
+                                                               requires_grad=not self.freeze_quant_params))
         layer.register_parameter(name+"_"+FQ_MAX, nn.Parameter(to_torch_tensor(self.max_range_tensor),
-                                                               requires_grad=True))
+                                                               requires_grad=not self.freeze_quant_params))
 
         # Save the quantizer parameters for later calculations
         self.add_quantizer_variable(FQ_MIN, layer.get_parameter(name+"_"+FQ_MIN), VariableGroup.QPARAMS)

--- a/model_compression_toolkit/trainable_infrastructure/pytorch/base_pytorch_quantizer.py
+++ b/model_compression_toolkit/trainable_infrastructure/pytorch/base_pytorch_quantizer.py
@@ -46,6 +46,14 @@ if FOUND_TORCH:
                 quantizer_parameter, parameter_group = parameter_dict[VAR], parameter_dict[GROUP]
                 if quantizer_parameter.requires_grad and parameter_group == group:
                     quantizer_trainable.append(quantizer_parameter)
+
+            # sanity check to catch inconsistent initialization
+            if self.freeze_quant_params and group == VariableGroup.QPARAMS and quantizer_trainable:
+                Logger.critical(
+                    'Found trainable quantization params despite self.freeze_quant_params=True. '
+                    'Quantization parameters were probably not initialized correctly in the Quantizer.'
+                )    # pragma: no cover
+
             return quantizer_trainable
 
 else:

--- a/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
+++ b/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
@@ -2,9 +2,11 @@ import copy
 
 import unittest
 import torch
+from model_compression_toolkit.trainable_infrastructure.common.base_trainable_quantizer import VariableGroup
+
 from mct_quantizers import PytorchActivationQuantizationHolder, PytorchQuantizationWrapper
-from mct_quantizers.pytorch.quantizers import ActivationPOTInferableQuantizer
 from torch.nn import Conv2d
+from torch.fx import symbolic_trace
 import numpy as np
 
 import model_compression_toolkit as mct
@@ -13,7 +15,8 @@ from model_compression_toolkit.core.pytorch.default_framework_info import DEFAUL
 from model_compression_toolkit.gptq.pytorch.gptq_pytorch_implementation import GPTQPytorchImplemantation
 from model_compression_toolkit.gptq.pytorch.gptq_training import PytorchGPTQTrainer
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
-from torch.fx import symbolic_trace
+from model_compression_toolkit.trainable_infrastructure import TrainingMethod
+from model_compression_toolkit.trainable_infrastructure.pytorch.activation_quantizers import STESymmetricActivationTrainableQuantizer
 from tests.common_tests.helpers.prep_graph_for_func_test import prepare_graph_with_quantization_parameters
 
 
@@ -73,7 +76,12 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         # check that 4 activation quantization holders where generated
         self.assertTrue(len(activation_quantization_holders_in_model) == 3)
         for a in activation_quantization_holders_in_model:
-            self.assertTrue(isinstance(a.activation_holder_quantizer, ActivationPOTInferableQuantizer))
+            self.assertTrue(isinstance(a.activation_holder_quantizer, STESymmetricActivationTrainableQuantizer))
+            self.assertEquals(a.activation_holder_quantizer.identifier, TrainingMethod.STE)
+            # activation quantization params for gptq should be frozen (non-learnable)
+            self.assertTrue(a.activation_holder_quantizer.freeze_quant_params is True)
+            self.assertEquals(a.activation_holder_quantizer.get_trainable_variables(VariableGroup.QPARAMS), [])
+
         for name, module in gptq_model.named_modules():
             if isinstance(module, PytorchQuantizationWrapper):
                 self.assertTrue(len(module.weights_quantizers) > 0)
@@ -87,7 +95,7 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         # check that 3 activation quantization holders where generated
         self.assertTrue(len(activation_quantization_holders_in_model) == 3)
         for a in activation_quantization_holders_in_model:
-            self.assertTrue(isinstance(a.activation_holder_quantizer, ActivationPOTInferableQuantizer))
+            self.assertTrue(isinstance(a.activation_holder_quantizer, STESymmetricActivationTrainableQuantizer))
         for name, module in gptq_model.named_modules():
             if isinstance(module, PytorchQuantizationWrapper):
                 self.assertTrue(len(module.weights_quantizers) > 0)
@@ -102,14 +110,18 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
         # check that 4 activation quantization holders where generated
         self.assertTrue(len(activation_quantization_holders_in_model) == 3)
         for a in activation_quantization_holders_in_model:
-            self.assertTrue(isinstance(a.activation_holder_quantizer, ActivationPOTInferableQuantizer))
+            self.assertTrue(isinstance(a.activation_holder_quantizer, STESymmetricActivationTrainableQuantizer))
         for name, module in gptq_model.named_modules():
             if isinstance(module, PytorchQuantizationWrapper):
                 self.assertTrue(len(module.weights_quantizers) > 0)
         # Test that two holders are getting inputs from reused conv2d (the layer that is wrapped)
-        fx_model = symbolic_trace(gptq_model)
-        self.assertTrue(list(fx_model.graph.nodes)[3].all_input_nodes[0] == list(fx_model.graph.nodes)[2])
-        self.assertTrue(list(fx_model.graph.nodes)[6].all_input_nodes[0] == list(fx_model.graph.nodes)[5])
+
+        # FIXME there is no reuse support and the test doesn't test what it says it tests. It doesn't even look
+        # at correct layers. After moving to trainable quantizer the test makes even less sense since now fx traces
+        # all quantization operations instead of fake_quant layer.
+        # fx_model = symbolic_trace(gptq_model)
+        # self.assertTrue(list(fx_model.graph.nodes)[3].all_input_nodes[0] == list(fx_model.graph.nodes)[2])
+        # self.assertTrue(list(fx_model.graph.nodes)[6].all_input_nodes[0] == list(fx_model.graph.nodes)[5])
 
     def _get_gptq_model(self, input_shape, in_model):
         pytorch_impl = GPTQPytorchImplemantation()

--- a/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
+++ b/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
@@ -1,24 +1,22 @@
 import copy
-
 import unittest
-import torch
-from model_compression_toolkit.trainable_infrastructure.common.base_trainable_quantizer import VariableGroup
 
-from mct_quantizers import PytorchActivationQuantizationHolder, PytorchQuantizationWrapper
-from torch.nn import Conv2d
-from torch.fx import symbolic_trace
 import numpy as np
+import torch
+from torch.nn import Conv2d
 
 import model_compression_toolkit as mct
+from mct_quantizers import PytorchActivationQuantizationHolder, PytorchQuantizationWrapper
 from model_compression_toolkit.core.common.mixed_precision.bit_width_setter import set_bit_widths
 from model_compression_toolkit.core.pytorch.default_framework_info import DEFAULT_PYTORCH_INFO
 from model_compression_toolkit.gptq.pytorch.gptq_pytorch_implementation import GPTQPytorchImplemantation
 from model_compression_toolkit.gptq.pytorch.gptq_training import PytorchGPTQTrainer
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
 from model_compression_toolkit.trainable_infrastructure import TrainingMethod
-from model_compression_toolkit.trainable_infrastructure.pytorch.activation_quantizers import STESymmetricActivationTrainableQuantizer
+from model_compression_toolkit.trainable_infrastructure.common.base_trainable_quantizer import VariableGroup
+from model_compression_toolkit.trainable_infrastructure.pytorch.activation_quantizers import \
+    STESymmetricActivationTrainableQuantizer
 from tests.common_tests.helpers.prep_graph_for_func_test import prepare_graph_with_quantization_parameters
-
 
 INPUT_SHAPE = [3, 8, 8]
 

--- a/tests/pytorch_tests/trainable_infrastructure_tests/base_pytorch_trainable_infra_test.py
+++ b/tests/pytorch_tests/trainable_infrastructure_tests/base_pytorch_trainable_infra_test.py
@@ -105,9 +105,10 @@ class BasePytorchInfrastructureTest:
                                                weights_per_channel_threshold=True,
                                                min_threshold=0)
 
-    def get_activation_quantization_config(self):
-        return TrainableQuantizerActivationConfig(activation_quantization_method=QuantizationMethod.POWER_OF_TWO,
+    def get_activation_quantization_config(self, quant_method=QuantizationMethod.POWER_OF_TWO,
+                                           activation_quant_params=None):
+        return TrainableQuantizerActivationConfig(activation_quantization_method=quant_method,
                                                   activation_n_bits=8,
-                                                  activation_quantization_params={},
+                                                  activation_quantization_params=activation_quant_params or {},
                                                   enable_activation_quantization=True,
                                                   min_threshold=0)

--- a/tests/pytorch_tests/trainable_infrastructure_tests/test_pytorch_trainable_infra_runner.py
+++ b/tests/pytorch_tests/trainable_infrastructure_tests/test_pytorch_trainable_infra_runner.py
@@ -34,7 +34,8 @@ from model_compression_toolkit.trainable_infrastructure.pytorch.activation_quant
 from model_compression_toolkit.trainable_infrastructure.pytorch.base_pytorch_quantizer import \
     BasePytorchTrainableQuantizer
 from tests.pytorch_tests.trainable_infrastructure_tests.trainable_pytorch.test_pytorch_base_quantizer import \
-    TestPytorchBaseWeightsQuantizer, TestPytorchBaseActivationQuantizer, TestPytorchQuantizerWithoutMarkDecorator
+    TestPytorchBaseWeightsQuantizer, TestPytorchBaseActivationQuantizer, TestPytorchQuantizerWithoutMarkDecorator, \
+    TestPytorchSTEActivationQuantizerQParamFreeze
 from tests.pytorch_tests.trainable_infrastructure_tests.trainable_pytorch.test_pytorch_get_quantizers import \
     TestGetTrainableQuantizer
 
@@ -45,6 +46,9 @@ class PytorchTrainableInfrastructureTestRunner(unittest.TestCase):
         TestPytorchBaseWeightsQuantizer(self).run_test()
         TestPytorchBaseActivationQuantizer(self).run_test()
         TestPytorchQuantizerWithoutMarkDecorator(self).run_test()
+
+    def test_pytorch_ste_activation_quantizers_qparams_freeze(self):
+        TestPytorchSTEActivationQuantizerQParamFreeze(self).run_test()
 
     def test_pytorch_get_quantizers(self):
         TestGetTrainableQuantizer(self, quant_target=QuantizationTarget.Weights,


### PR DESCRIPTION
## Pull Request Description:
Add freeze_quant_params flag to base trainable quantizer with False as default.
Implement quant params freezing for STE activation quantizers. 
Use activation trainable quantizers in GPTQ instead of inferable quantizers, with frozen quant params.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).