### PR TITLE
Set CoreConfig and its inner configs to be dataclasses

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_quantization_config.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_quantization_config.py
@@ -13,75 +13,61 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import List, Callable
-
+from dataclasses import dataclass, field
+from typing import List, Callable, Optional
 from model_compression_toolkit.constants import MP_DEFAULT_NUM_SAMPLES, ACT_HESSIAN_DEFAULT_BATCH_SIZE
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import MpDistanceWeighting
 
 
+@dataclass
 class MixedPrecisionQuantizationConfig:
+    """
+    Class with mixed precision parameters to quantize the input model.
 
-    def __init__(self,
-                 compute_distance_fn: Callable = None,
-                 distance_weighting_method: MpDistanceWeighting = MpDistanceWeighting.AVG,
-                 num_of_images: int = MP_DEFAULT_NUM_SAMPLES,
-                 configuration_overwrite: List[int] = None,
-                 num_interest_points_factor: float = 1.0,
-                 use_hessian_based_scores: bool = False,
-                 norm_scores: bool = True,
-                 refine_mp_solution: bool = True,
-                 metric_normalization_threshold: float = 1e10,
-                 hessian_batch_size: int = ACT_HESSIAN_DEFAULT_BATCH_SIZE):
-        """
-        Class with mixed precision parameters to quantize the input model.
+    Args:
+        compute_distance_fn (Callable): Function to compute a distance between two tensors. If None, using pre-defined distance methods based on the layer type for each layer.
+        distance_weighting_method (MpDistanceWeighting): MpDistanceWeighting enum value that provides a function to use when weighting the distances among different layers when computing the sensitivity metric.
+        num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
+        configuration_overwrite (List[int]): A list of integers that enables overwrite of mixed precision with a predefined one.
+        num_interest_points_factor (float): A multiplication factor between zero and one (represents percentage) to reduce the number of interest points used to calculate the distance metric.
+        use_hessian_based_scores (bool): Whether to use Hessian-based scores for weighted average distance metric computation.
+        norm_scores (bool): Whether to normalize the returned scores for the weighted distance metric (to get values between 0 and 1).
+        refine_mp_solution (bool): Whether to try to improve the final mixed-precision configuration using a greedy algorithm that searches layers to increase their bit-width, or not.
+        metric_normalization_threshold (float): A threshold for checking the mixed precision distance metric values, In case of values larger than this threshold, the metric will be scaled to prevent numerical issues.
+        hessian_batch_size (int): The Hessian computation batch size. used only if using mixed precision with Hessian-based objective.
+    """
 
-        Args:
-            compute_distance_fn (Callable): Function to compute a distance between two tensors. If None, using pre-defined distance methods based on the layer type for each layer.
-            distance_weighting_method (MpDistanceWeighting): MpDistanceWeighting enum value that provides a function to use when weighting the distances among different layers when computing the sensitivity metric.
-            num_of_images (int): Number of images to use to evaluate the sensitivity of a mixed-precision model comparing to the float model.
-            configuration_overwrite (List[int]): A list of integers that enables overwrite of mixed precision with a predefined one.
-            num_interest_points_factor (float): A multiplication factor between zero and one (represents percentage) to reduce the number of interest points used to calculate the distance metric.
-            use_hessian_based_scores (bool): Whether to use Hessian-based scores for weighted average distance metric computation.
-            norm_scores (bool): Whether to normalize the returned scores for the weighted distance metric (to get values between 0 and 1).
-            refine_mp_solution (bool): Whether to try to improve the final mixed-precision configuration using a greedy algorithm that searches layers to increase their bit-width, or not.
-            metric_normalization_threshold (float): A threshold for checking the mixed precision distance metric values, In case of values larger than this threshold, the metric will be scaled to prevent numerical issues.
-            hessian_batch_size (int): The Hessian computation batch size. used only if using mixed precision with Hessian-based objective.
+    compute_distance_fn: Optional[Callable] = None
+    distance_weighting_method: MpDistanceWeighting = MpDistanceWeighting.AVG
+    num_of_images: int = MP_DEFAULT_NUM_SAMPLES
+    configuration_overwrite: Optional[List[int]] = None
+    num_interest_points_factor: float = field(default=1.0, metadata={"description": "Should be between 0.0 and 1.0"})
+    use_hessian_based_scores: bool = False
+    norm_scores: bool = True
+    refine_mp_solution: bool = True
+    metric_normalization_threshold: float = 1e10
+    hessian_batch_size: int = ACT_HESSIAN_DEFAULT_BATCH_SIZE
+    _is_mixed_precision_enabled: bool = field(init=False, default=False)
 
-        """
-
-        self.compute_distance_fn = compute_distance_fn
-        self.distance_weighting_method = distance_weighting_method
-        self.num_of_images = num_of_images
-        self.configuration_overwrite = configuration_overwrite
-        self.refine_mp_solution = refine_mp_solution
-
-        assert 0.0 < num_interest_points_factor <= 1.0, "num_interest_points_factor should represent a percentage of " \
-                                                        "the base set of interest points that are required to be " \
-                                                        "used for mixed-precision metric evaluation, " \
-                                                        "thus, it should be between 0 to 1"
-        self.num_interest_points_factor = num_interest_points_factor
-
-        self.use_hessian_based_scores = use_hessian_based_scores
-        self.norm_scores = norm_scores
-        self.hessian_batch_size = hessian_batch_size
-
-        self.metric_normalization_threshold = metric_normalization_threshold
-
-        self._mixed_precision_enable = False
+    def __post_init__(self):
+        # Validate num_interest_points_factor
+        assert 0.0 < self.num_interest_points_factor <= 1.0, \
+            "num_interest_points_factor should represent a percentage of " \
+            "the base set of interest points that are required to be " \
+            "used for mixed-precision metric evaluation, " \
+            "thus, it should be between 0 to 1"
 
     def set_mixed_precision_enable(self):
         """
         Set a flag in mixed precision config indicating that mixed precision is enabled.
         """
-
-        self._mixed_precision_enable = True
+        self._is_mixed_precision_enabled = True
 
     @property
-    def mixed_precision_enable(self):
+    def is_mixed_precision_enabled(self):
         """
         A property that indicates whether mixed precision quantization is enabled.
 
         Returns: True if mixed precision quantization is enabled
-
         """
-        return self._mixed_precision_enable
+        return self._is_mixed_precision_enabled

--- a/model_compression_toolkit/core/common/quantization/core_config.py
+++ b/model_compression_toolkit/core/common/quantization/core_config.py
@@ -35,14 +35,9 @@ class CoreConfig:
     """
 
     quantization_config: QuantizationConfig = field(default_factory=QuantizationConfig)
-    mixed_precision_config: Optional[MixedPrecisionQuantizationConfig] = None
+    mixed_precision_config: MixedPrecisionQuantizationConfig = field(default_factory=MixedPrecisionQuantizationConfig)
     bit_width_config: BitWidthConfig = field(default_factory=BitWidthConfig)
     debug_config: DebugConfig = field(default_factory=DebugConfig)
-
-    def __post_init__(self):
-        # Initialize mixed_precision_config with a default instance if it was set to None
-        if self.mixed_precision_config is None:
-            self.mixed_precision_config = MixedPrecisionQuantizationConfig()
 
     @property
     def mixed_precision_enable(self) -> bool:

--- a/model_compression_toolkit/core/common/quantization/core_config.py
+++ b/model_compression_toolkit/core/common/quantization/core_config.py
@@ -40,9 +40,9 @@ class CoreConfig:
     debug_config: DebugConfig = field(default_factory=DebugConfig)
 
     @property
-    def mixed_precision_enable(self) -> bool:
+    def is_mixed_precision_enabled(self) -> bool:
         """
         A property that indicates whether mixed precision is enabled.
         """
-        return bool(self.mixed_precision_config and self.mixed_precision_config.mixed_precision_enable)
+        return bool(self.mixed_precision_config and self.mixed_precision_config.is_mixed_precision_enabled)
 

--- a/model_compression_toolkit/core/common/quantization/core_config.py
+++ b/model_compression_toolkit/core/common/quantization/core_config.py
@@ -12,41 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from dataclasses import dataclass, field
+from typing import Optional
+
 from model_compression_toolkit.core.common.quantization.bit_width_config import BitWidthConfig
 from model_compression_toolkit.core.common.quantization.quantization_config import QuantizationConfig
 from model_compression_toolkit.core.common.quantization.debug_config import DebugConfig
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import MixedPrecisionQuantizationConfig
 
 
+@dataclass
 class CoreConfig:
     """
-    A class to hold the configurations classes of the MCT-core.
-    """
-    def __init__(self,
-                 quantization_config: QuantizationConfig = None,
-                 mixed_precision_config: MixedPrecisionQuantizationConfig = None,
-                 bit_width_config: BitWidthConfig = None,
-                 debug_config: DebugConfig = None
-                 ):
-        """
+    A dataclass to hold the configurations classes of the MCT-core.
 
-        Args:
-            quantization_config (QuantizationConfig): Config for quantization.
-            mixed_precision_config (MixedPrecisionQuantizationConfig): Config for mixed precision quantization.
+    Args:
+        quantization_config (QuantizationConfig): Config for quantization.
+        mixed_precision_config (MixedPrecisionQuantizationConfig): Config for mixed precision quantization.
             If None, a default MixedPrecisionQuantizationConfig is used.
-            bit_width_config (BitWidthConfig): Config for manual bit-width selection.
-            debug_config (DebugConfig): Config for debugging and editing the network quantization process.
-        """
-        self.quantization_config = QuantizationConfig() if quantization_config is None else quantization_config
-        self.bit_width_config = BitWidthConfig() if bit_width_config is None else bit_width_config
-        self.debug_config = DebugConfig() if debug_config is None else debug_config
+        bit_width_config (BitWidthConfig): Config for manual bit-width selection.
+        debug_config (DebugConfig): Config for debugging and editing the network quantization process.
+    """
 
-        if mixed_precision_config is None:
+    quantization_config: QuantizationConfig = field(default_factory=QuantizationConfig)
+    mixed_precision_config: Optional[MixedPrecisionQuantizationConfig] = None
+    bit_width_config: BitWidthConfig = field(default_factory=BitWidthConfig)
+    debug_config: DebugConfig = field(default_factory=DebugConfig)
+
+    def __post_init__(self):
+        # Initialize mixed_precision_config with a default instance if it was set to None
+        if self.mixed_precision_config is None:
             self.mixed_precision_config = MixedPrecisionQuantizationConfig()
-        else:
-            self.mixed_precision_config = mixed_precision_config
 
     @property
-    def mixed_precision_enable(self):
-        return self.mixed_precision_config is not None and self.mixed_precision_config.mixed_precision_enable
+    def mixed_precision_enable(self) -> bool:
+        """
+        A property that indicates whether mixed precision is enabled.
+        """
+        return bool(self.mixed_precision_config and self.mixed_precision_config.mixed_precision_enable)
 

--- a/model_compression_toolkit/core/common/quantization/debug_config.py
+++ b/model_compression_toolkit/core/common/quantization/debug_config.py
@@ -13,29 +13,24 @@
 # limitations under the License.
 # ==============================================================================
 
-
+from dataclasses import dataclass, field
 from typing import List
 
 from model_compression_toolkit.core.common.network_editors.edit_network import EditRule
 
 
+@dataclass
 class DebugConfig:
     """
-    A class for MCT core debug information.
+    A dataclass for MCT core debug information.
+
+    Args:
+        analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is
+         enabled) or not. Can be used to pinpoint problematic layers in the quantization process.
+        network_editor (List[EditRule]): A list of rules and actions to edit the network for quantization.
+        simulate_scheduler (bool): Simulate scheduler behavior to compute operators' order and cuts.
     """
-    def __init__(self,
-                 analyze_similarity: bool = False,
-                 network_editor: List[EditRule] = [],
-                 simulate_scheduler: bool = False):
-        """
 
-        Args:
-
-            analyze_similarity (bool): Whether to plot similarity figures within TensorBoard (when logger is
-             enabled) or not. Can be used to pinpoint problematic layers in the quantization process.
-            network_editor (List[EditRule]): A list of rules and actions to edit the network for quantization.
-            simulate_scheduler (bool): Simulate scheduler behaviour to compute operators order and cuts.
-        """
-        self.analyze_similarity = analyze_similarity
-        self.network_editor = network_editor
-        self.simulate_scheduler = simulate_scheduler
+    analyze_similarity: bool = False
+    network_editor: List[EditRule] = field(default_factory=list)
+    simulate_scheduler: bool = False

--- a/model_compression_toolkit/core/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-
+from dataclasses import dataclass, field
 import math
 from enum import Enum
 
@@ -46,86 +46,45 @@ class QuantizationErrorMethod(Enum):
     HMSE = 6
 
 
+@dataclass
 class QuantizationConfig:
+    """
+    Class to wrap all different parameters the library quantize the input model according to.
 
-    def __init__(self,
-                 activation_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
-                 weights_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE,
-                 relu_bound_to_power_of_2: bool = False,
-                 weights_bias_correction: bool = True,
-                 weights_second_moment_correction: bool = False,
-                 input_scaling: bool = False,
-                 softmax_shift: bool = False,
-                 shift_negative_activation_correction: bool = True,
-                 activation_channel_equalization: bool = False,
-                 z_threshold: float = math.inf,
-                 min_threshold: float = MIN_THRESHOLD,
-                 l_p_value: int = 2,
-                 linear_collapsing: bool = True,
-                 residual_collapsing: bool = True,
-                 shift_negative_ratio: float = 0.05,
-                 shift_negative_threshold_recalculation: bool = False,
-                 shift_negative_params_search: bool = False,
-                 concat_threshold_update: bool = False):
-        """
-        Class to wrap all different parameters the library quantize the input model according to.
+    Examples:
+        One may create a quantization configuration to quantize a model according to.
+        For example, to quantize a model's weights and activation using thresholds, such that
+        weights threshold selection is done using MSE, activation threshold selection is done using NOCLIPPING (min/max),
+        enabling relu_bound_to_power_of_2, weights_bias_correction,
+        one can instantiate a quantization configuration:
 
-        Args:
-            activation_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
-            weights_error_method (QuantizationErrorMethod): Which method to use from QuantizationErrorMethod for activation quantization threshold selection.
-            relu_bound_to_power_of_2 (bool): Whether to use relu to power of 2 scaling correction or not.
-            weights_bias_correction (bool): Whether to use weights bias correction or not.
-            weights_second_moment_correction (bool): Whether to use weights second_moment correction or not.
-            input_scaling (bool): Whether to use input scaling or not.
-            softmax_shift (bool): Whether to use softmax shift or not.
-            shift_negative_activation_correction (bool): Whether to use shifting negative activation correction or not.
-            activation_channel_equalization (bool): Whether to use activation channel equalization correction or not.
-            z_threshold (float): Value of z score for outliers removal.
-            min_threshold (float): Minimum threshold to use during thresholds selection.
-            l_p_value (int): The p value of L_p norm threshold selection.
-            block_collapsing (bool): Whether to collapse block one to another in the input network
-            shift_negative_ratio (float): Value for the ratio between the minimal negative value of a non-linearity output to its activation threshold, which above it - shifting negative activation should occur if enabled.
-            shift_negative_threshold_recalculation (bool): Whether or not to recompute the threshold after shifting negative activation.
-            shift_negative_params_search (bool): Whether to search for optimal shift and threshold in shift negative activation.
-
-        Examples:
-            One may create a quantization configuration to quantize a model according to.
-            For example, to quantize a model's weights and activation using thresholds, such that
-            weights threshold selection is done using MSE, activation threshold selection is done using NOCLIPPING (min/max),
-            enabling relu_bound_to_power_of_2, weights_bias_correction,
-            one can instantiate a quantization configuration:
-
-            >>> import model_compression_toolkit as mct
-            >>> qc = mct.core.QuantizationConfig(activation_error_method=mct.core.QuantizationErrorMethod.NOCLIPPING, weights_error_method=mct.core.QuantizationErrorMethod.MSE, relu_bound_to_power_of_2=True, weights_bias_correction=True)
+        >>> import model_compression_toolkit as mct
+        >>> qc = mct.core.QuantizationConfig(activation_error_method=mct.core.QuantizationErrorMethod.NOCLIPPING, weights_error_method=mct.core.QuantizationErrorMethod.MSE, relu_bound_to_power_of_2=True, weights_bias_correction=True)
 
 
-            The QuantizationConfig instanse can then be passed to
-            :func:`~model_compression_toolkit.ptq.keras_post_training_quantization`
+        The QuantizationConfig instanse can then be passed to
+        :func:`~model_compression_toolkit.ptq.keras_post_training_quantization`
 
-        """
+    """
 
-        self.activation_error_method = activation_error_method
-        self.weights_error_method = weights_error_method
-        self.relu_bound_to_power_of_2 = relu_bound_to_power_of_2
-        self.weights_bias_correction = weights_bias_correction
-        self.weights_second_moment_correction = weights_second_moment_correction
-        self.activation_channel_equalization = activation_channel_equalization
-        self.input_scaling = input_scaling
-        self.softmax_shift = softmax_shift
-        self.min_threshold = min_threshold
-        self.shift_negative_activation_correction = shift_negative_activation_correction
-        self.z_threshold = z_threshold
-        self.l_p_value = l_p_value
-        self.linear_collapsing = linear_collapsing
-        self.residual_collapsing = residual_collapsing
-        self.shift_negative_ratio = shift_negative_ratio
-        self.shift_negative_threshold_recalculation = shift_negative_threshold_recalculation
-        self.shift_negative_params_search = shift_negative_params_search
-        self.concat_threshold_update = concat_threshold_update
-
-    def __repr__(self):
-        # Used for debugging, thus no cover.
-        return str(self.__dict__)  # pragma: no cover
+    activation_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE
+    weights_error_method: QuantizationErrorMethod = QuantizationErrorMethod.MSE
+    relu_bound_to_power_of_2: bool = False
+    weights_bias_correction: bool = True
+    weights_second_moment_correction: bool = False
+    input_scaling: bool = False
+    softmax_shift: bool = False
+    shift_negative_activation_correction: bool = True
+    activation_channel_equalization: bool = False
+    z_threshold: float = math.inf
+    min_threshold: float = MIN_THRESHOLD
+    l_p_value: int = 2
+    linear_collapsing: bool = True
+    residual_collapsing: bool = True
+    shift_negative_ratio: float = 0.05
+    shift_negative_threshold_recalculation: bool = False
+    shift_negative_params_search: bool = False
+    concat_threshold_update: bool = False
 
 
 # Default quantization configuration the library use.

--- a/model_compression_toolkit/core/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_config.py
@@ -49,21 +49,20 @@ class QuantizationErrorMethod(Enum):
 @dataclass
 class QuantizationConfig:
     """
-    Class to wrap all different parameters the library quantize the input model according to.
+    A class that encapsulates all the different parameters used by the library to quantize a model.
 
     Examples:
-        One may create a quantization configuration to quantize a model according to.
-        For example, to quantize a model's weights and activation using thresholds, such that
-        weights threshold selection is done using MSE, activation threshold selection is done using NOCLIPPING (min/max),
-        enabling relu_bound_to_power_of_2, weights_bias_correction,
-        one can instantiate a quantization configuration:
+        You can create a quantization configuration to apply to a model. For example, to quantize a model's weights and
+        activations using thresholds, with weight threshold selection based on MSE and activation threshold selection
+        using NOCLIPPING (min/max), while enabling relu_bound_to_power_of_2 and weights_bias_correction,
+        you can instantiate a quantization configuration like this:
 
         >>> import model_compression_toolkit as mct
         >>> qc = mct.core.QuantizationConfig(activation_error_method=mct.core.QuantizationErrorMethod.NOCLIPPING, weights_error_method=mct.core.QuantizationErrorMethod.MSE, relu_bound_to_power_of_2=True, weights_bias_correction=True)
 
 
-        The QuantizationConfig instanse can then be passed to
-        :func:`~model_compression_toolkit.ptq.keras_post_training_quantization`
+        The QuantizationConfig instance can then be used in the quantization workflow,
+        such as with Keras in the function: :func:~model_compression_toolkit.ptq.keras_post_training_quantization`.
 
     """
 

--- a/model_compression_toolkit/core/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/core/common/substitutions/shift_negative_activation.py
@@ -360,7 +360,7 @@ def shift_negative_function(graph: Graph,
                                          graph=graph,
                                          quant_config=core_config.quantization_config,
                                          tpc=graph.tpc,
-                                         mixed_precision_enable=core_config.mixed_precision_enable)
+                                         mixed_precision_enable=core_config.is_mixed_precision_enabled)
 
         for candidate_qc in pad_node.candidates_quantization_cfg:
             candidate_qc.activation_quantization_cfg.enable_activation_quantization = False
@@ -377,7 +377,7 @@ def shift_negative_function(graph: Graph,
                                      graph=graph,
                                      quant_config=core_config.quantization_config,
                                      tpc=graph.tpc,
-                                     mixed_precision_enable=core_config.mixed_precision_enable)
+                                     mixed_precision_enable=core_config.is_mixed_precision_enabled)
 
     original_non_linear_activation_nbits = non_linear_node_cfg_candidate.activation_n_bits
     # The non-linear node's output should be float, so we approximate it by using 16bits quantization.

--- a/model_compression_toolkit/core/runner.py
+++ b/model_compression_toolkit/core/runner.py
@@ -119,7 +119,7 @@ def core_runner(in_model: Any,
                                      tpc,
                                      core_config.bit_width_config,
                                      tb_w,
-                                     mixed_precision_enable=core_config.mixed_precision_enable,
+                                     mixed_precision_enable=core_config.is_mixed_precision_enabled,
                                      running_gptq=running_gptq)
 
     hessian_info_service = HessianInfoService(graph=graph, representative_dataset_gen=representative_data_gen,
@@ -136,7 +136,7 @@ def core_runner(in_model: Any,
     ######################################
     # Finalize bit widths
     ######################################
-    if core_config.mixed_precision_enable:
+    if core_config.is_mixed_precision_enabled:
         if core_config.mixed_precision_config.configuration_overwrite is None:
 
             filter_candidates_for_mixed_precision(graph, target_resource_utilization, fw_info, tpc)
@@ -161,7 +161,7 @@ def core_runner(in_model: Any,
     else:
         bit_widths_config = []
 
-    tg = set_bit_widths(core_config.mixed_precision_enable,
+    tg = set_bit_widths(core_config.is_mixed_precision_enabled,
                         tg,
                         bit_widths_config)
 
@@ -175,7 +175,7 @@ def core_runner(in_model: Any,
                                     fw_info=fw_info,
                                     fw_impl=fw_impl)
 
-    if core_config.mixed_precision_enable:
+    if core_config.is_mixed_precision_enabled:
         # Retrieve lists of tuples (node, node's final weights/activation bitwidth)
         weights_conf_nodes_bitwidth = tg.get_final_weights_config(fw_info)
         activation_conf_nodes_bitwidth = tg.get_final_activation_config()

--- a/model_compression_toolkit/gptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/gptq/keras/quantization_facade.py
@@ -199,7 +199,7 @@ if FOUND_TF:
         KerasModelValidation(model=in_model,
                              fw_info=DEFAULT_KERAS_INFO).validate()
 
-        if core_config.mixed_precision_enable:
+        if core_config.is_mixed_precision_enabled:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config for mixed-precision is not of type 'MixedPrecisionQuantizationConfig'. "
                                 "Ensure usage of the correct API for keras_post_training_quantization "

--- a/model_compression_toolkit/gptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/gptq/pytorch/quantization_facade.py
@@ -165,7 +165,7 @@ if FOUND_TORCH:
 
         """
 
-        if core_config.mixed_precision_enable:
+        if core_config.is_mixed_precision_enabled:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config for mixed-precision is not of type 'MixedPrecisionQuantizationConfig'. "
                                 "Ensure usage of the correct API for 'pytorch_gradient_post_training_quantization' "

--- a/model_compression_toolkit/ptq/keras/quantization_facade.py
+++ b/model_compression_toolkit/ptq/keras/quantization_facade.py
@@ -124,7 +124,7 @@ if FOUND_TF:
         KerasModelValidation(model=in_model,
                              fw_info=fw_info).validate()
 
-        if core_config.mixed_precision_enable:
+        if core_config.is_mixed_precision_enabled:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config to mixed-precision facade is not of type "
                                 "MixedPrecisionQuantizationConfig. Please use keras_post_training_quantization "

--- a/model_compression_toolkit/ptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/ptq/pytorch/quantization_facade.py
@@ -96,7 +96,7 @@ if FOUND_TORCH:
 
         fw_info = DEFAULT_PYTORCH_INFO
 
-        if core_config.mixed_precision_enable:
+        if core_config.is_mixed_precision_enabled:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config to mixed-precision facade is not of type "
                                 "MixedPrecisionQuantizationConfig. Please use "

--- a/model_compression_toolkit/qat/keras/quantization_facade.py
+++ b/model_compression_toolkit/qat/keras/quantization_facade.py
@@ -176,7 +176,7 @@ if FOUND_TF:
         KerasModelValidation(model=in_model,
                              fw_info=DEFAULT_KERAS_INFO).validate()
 
-        if core_config.mixed_precision_enable:
+        if core_config.is_mixed_precision_enabled:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config to mixed-precision facade is not of type "
                              "MixedPrecisionQuantizationConfig. Please use keras_post_training_quantization API,"

--- a/model_compression_toolkit/qat/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/qat/pytorch/quantization_facade.py
@@ -145,7 +145,7 @@ if FOUND_TORCH:
             f"If you encounter an issue, please open an issue in our GitHub "
             f"project https://github.com/sony/model_optimization")
 
-        if core_config.mixed_precision_enable:
+        if core_config.is_mixed_precision_enabled:
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config to mixed-precision facade is not of type "
                              "MixedPrecisionQuantizationConfig. Please use pytorch_post_training_quantization API,"

--- a/tests/common_tests/helpers/prep_graph_for_func_test.py
+++ b/tests/common_tests/helpers/prep_graph_for_func_test.py
@@ -128,7 +128,7 @@ def prepare_graph_set_bit_widths(in_model,
                                      fw_impl=fw_impl,
                                      tpc=tpc,
                                      bit_width_config=core_config.bit_width_config,
-                                     mixed_precision_enable=core_config.mixed_precision_enable)
+                                     mixed_precision_enable=core_config.is_mixed_precision_enabled)
 
     tg = quantization_preparation_runner(graph,
                                          _representative_data_gen,
@@ -140,7 +140,7 @@ def prepare_graph_set_bit_widths(in_model,
     ######################################
     # Finalize bit widths
     ######################################
-    if core_config.mixed_precision_enable:
+    if core_config.is_mixed_precision_enabled:
 
         if core_config.mixed_precision_config.configuration_overwrite is None:
 
@@ -156,7 +156,7 @@ def prepare_graph_set_bit_widths(in_model,
     else:
         bit_widths_config = []
 
-    tg = set_bit_widths(core_config.mixed_precision_enable,
+    tg = set_bit_widths(core_config.is_mixed_precision_enabled,
                         tg,
                         bit_widths_config)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_16bit_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_16bit_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 
 import model_compression_toolkit as mct
 from model_compression_toolkit.constants import TENSORFLOW
+from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.target_platform_capabilities.constants import IMX500_TP_MODEL
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 
@@ -77,6 +78,9 @@ class Activation16BitMixedPrecisionTest(Activation16BitTest):
 
     def get_resource_utilization(self):
         return mct.core.ResourceUtilization(activation_memory=200)
+
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig()
 
     def create_networks(self):
         inputs = layers.Input(shape=self.get_input_shapes()[0][1:])

--- a/tests/keras_tests/feature_networks_tests/feature_networks/const_quantization_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/const_quantization_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 import numpy as np
 
 import model_compression_toolkit as mct
+from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v3.tp_model import generate_tp_model, \
     get_op_quantization_configs
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v3.tpc_keras import generate_keras_tpc
@@ -131,6 +132,9 @@ class AdvancedConstQuantizationTest(BaseKerasFeatureNetworkTest):
 
     def get_resource_utilization(self):
         return mct.core.ResourceUtilization(9e3)
+
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig()
 
     def generate_inputs(self):
         # need positive inputs so won't divide with zero or take root of negative number

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_qc_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_qc_test.py
@@ -46,7 +46,7 @@ def prepare_graph_for_first_network_editor(in_model, representative_data_gen, co
                                            tpc, target_resource_utilization=None, tb_w=None):
 
     if target_resource_utilization is not None:
-        core_config.mixed_precision_enable.set_mixed_precision_enable()
+        core_config.mixed_precision_config.set_mixed_precision_enable()
 
     transformed_graph = graph_preparation_runner(in_model,
                                                  representative_data_gen,
@@ -56,7 +56,7 @@ def prepare_graph_for_first_network_editor(in_model, representative_data_gen, co
                                                  tpc,
                                                  core_config.bit_width_config,
                                                  tb_w,
-                                                 mixed_precision_enable=core_config.mixed_precision_enable)
+                                                 mixed_precision_enable=core_config.is_mixed_precision_enabled)
 
 
     ######################################
@@ -97,7 +97,7 @@ def prepare_graph_for_second_network_editor(in_model, representative_data_gen, c
                                                                tb_w=tb_w)
 
     if target_resource_utilization is not None:
-        core_config.mixed_precision_enable.set_mixed_precision_enable()
+        core_config.mixed_precision_config.set_mixed_precision_enable()
 
     ######################################
     # Calculate quantization params
@@ -142,7 +142,7 @@ def prepare_graph_for_second_network_editor(in_model, representative_data_gen, c
     # Finalize bit widths
     ######################################
     if target_resource_utilization is not None:
-        assert core_config.mixed_precision_enable
+        assert core_config.is_mixed_precision_enabled
         if core_config.mixed_precision_config.configuration_overwrite is None:
 
             bit_widths_config = search_bit_width(tg_with_bias,
@@ -157,7 +157,7 @@ def prepare_graph_for_second_network_editor(in_model, representative_data_gen, c
     else:
         bit_widths_config = []
 
-    tg = set_bit_widths(core_config.mixed_precision_enable,
+    tg = set_bit_widths(core_config.is_mixed_precision_enabled,
                         tg_with_bias,
                         bit_widths_config)
 

--- a/tests/pytorch_tests/model_tests/feature_models/activation_16bit_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/activation_16bit_test.py
@@ -17,6 +17,7 @@ import torch
 
 import model_compression_toolkit as mct
 from model_compression_toolkit.constants import PYTORCH
+from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.target_platform_capabilities.constants import IMX500_TP_MODEL
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 
@@ -95,6 +96,9 @@ class Activation16BitMixedPrecisionTest(Activation16BitTest):
 
     def create_networks(self):
         return Activation16BitNet(use_concat=False)
+
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig()
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         mul1_act_quant = quantized_model.mul_activation_holder_quantizer

--- a/tests/pytorch_tests/model_tests/feature_models/const_quantization_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/const_quantization_test.py
@@ -17,6 +17,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 import model_compression_toolkit as mct
+from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
@@ -117,6 +118,9 @@ class AdvancedConstQuantizationTest(BasePytorchFeatureNetworkTest):
 
     def get_tpc(self):
         return mct.get_target_platform_capabilities(PYTORCH, IMX500_TP_MODEL, "v3")
+
+    def get_mixed_precision_config(self):
+        return MixedPrecisionQuantizationConfig()
 
     def create_networks(self):
         return AdvancedConstQuantizationNet(self.const)

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -686,7 +686,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
         TpcTest(f'{C.QNNPACK_TP_MODEL}.v1', self).run_test()
 
     def test_16bit_activations(self):
-        Activation16BitTest(self).run_test()
+        # Activation16BitTest(self).run_test()
         Activation16BitMixedPrecisionTest(self).run_test()
 
     def test_invalid_bit_width_selection(self):

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -686,7 +686,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
         TpcTest(f'{C.QNNPACK_TP_MODEL}.v1', self).run_test()
 
     def test_16bit_activations(self):
-        # Activation16BitTest(self).run_test()
+        Activation16BitTest(self).run_test()
         Activation16BitMixedPrecisionTest(self).run_test()
 
     def test_invalid_bit_width_selection(self):


### PR DESCRIPTION
## Pull Request Description:
Conver the following configuration classes to dataclasses and fix some misalignments in those classes: CoreConfig, QuantizationConfig, MixedPrecisionQuantizationConfig, DebugConfig, BitWidthConfig.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).