### PR TITLE
change functools.cache to lru_cache

### DIFF
--- a/model_compression_toolkit/trainable_infrastructure/pytorch/util.py
+++ b/model_compression_toolkit/trainable_infrastructure/pytorch/util.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from functools import cache
+from functools import lru_cache
 from typing import Callable
 
 from tqdm import tqdm
 
 
-@cache
+@lru_cache
 def get_total_grad_steps(representative_data_gen: Callable) -> int:
     # dry run on the representative dataset to count number of batches
     num_batches = 0


### PR DESCRIPTION
## Pull Request Description:
Change functools.cache to lru_cache, which is supported in python<3.9

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).