### PR TITLE
Add initial Sample-Layer Attention for GPTQ (PyTorch)

### DIFF
--- a/model_compression_toolkit/core/common/hessian/__init__.py
+++ b/model_compression_toolkit/core/common/hessian/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.core.common.hessian.hessian_scores_request import HessianScoresRequest, HessianMode, HessianScoresGranularity
+from model_compression_toolkit.core.common.hessian.hessian_scores_request import (
+    HessianScoresRequest, HessianMode, HessianScoresGranularity, HessianEstimationDistribution
+)
 from model_compression_toolkit.core.common.hessian.hessian_info_service import HessianInfoService
 import model_compression_toolkit.core.common.hessian.hessian_info_utils as hessian_utils

--- a/model_compression_toolkit/core/common/hessian/hessian_info_service.py
+++ b/model_compression_toolkit/core/common/hessian/hessian_info_service.py
@@ -23,7 +23,7 @@ from model_compression_toolkit.constants import HESSIAN_NUM_ITERATIONS
 from model_compression_toolkit.core.common.hessian.hessian_scores_request import HessianScoresRequest, \
     HessianScoresGranularity, HessianMode
 from model_compression_toolkit.logger import Logger
-if TYPE_CHECKING:
+if TYPE_CHECKING:    # pragma: no cover
     from model_compression_toolkit.core.common import BaseNode
 
 
@@ -251,9 +251,9 @@ class HessianInfoService:
         hessian_score_by_image_hash = {}
 
         if not isinstance(inputs_batch, list):
-            raise TypeError('Expected a list of inputs')
+            raise TypeError('Expected a list of inputs')    # pragma: no cover
         if len(inputs_batch) > 1:
-            raise NotImplementedError('Per-sample hessian computation is not supported for networks with multiple inputs')
+            raise NotImplementedError('Per-sample hessian computation is not supported for networks with multiple inputs')    # pragma: no cover
 
         # Get the framework-specific calculator Hessian-approximation scores
         fw_hessian_calculator = self.fw_impl.get_hessian_scores_calculator(graph=self.graph,
@@ -271,7 +271,7 @@ class HessianInfoService:
 
     @staticmethod
     def calc_image_hash(image):
-        if len(image.shape) != 3:
+        if len(image.shape) != 3:    # pragma: no cover
             raise ValueError(f'Expected 3d image (without batch) for image hash calculation, got {len(image.shape)}')
         image_bytes = image.astype(np.float32).tobytes()
         return hashlib.md5(image_bytes).hexdigest()
@@ -296,7 +296,7 @@ class HessianInfoService:
             OC for per-output-channel when the requested node has OC output-channels, etc.)
         """
 
-        if len(hessian_scores_request.target_nodes) == 0:
+        if len(hessian_scores_request.target_nodes) == 0:    # pragma: no cover
             return []
 
         if required_size == 0:

--- a/model_compression_toolkit/core/common/hessian/hessian_scores_request.py
+++ b/model_compression_toolkit/core/common/hessian/hessian_scores_request.py
@@ -40,6 +40,14 @@ class HessianScoresGranularity(Enum):
     PER_TENSOR = 2
 
 
+class HessianEstimationDistribution(str, Enum):
+    """
+    Distribution for Hutchinson estimator random vector
+    """
+    GAUSSIAN = 'gaussian'
+    RADEMACHER = 'rademacher'
+
+
 class HessianScoresRequest:
     """
     Request configuration for the Hessian-approximation scores.
@@ -53,7 +61,8 @@ class HessianScoresRequest:
     def __init__(self,
                  mode: HessianMode,
                  granularity: HessianScoresGranularity,
-                 target_nodes: List):
+                 target_nodes: List,
+                 distribution: HessianEstimationDistribution = HessianEstimationDistribution.GAUSSIAN):
         """
         Attributes:
             mode (HessianMode): Mode of Hessian-approximation score (w.r.t weights or activations).
@@ -64,6 +73,7 @@ class HessianScoresRequest:
         self.mode = mode  # w.r.t activations or weights
         self.granularity = granularity  # per element, per layer, per channel
         self.target_nodes = target_nodes
+        self.distribution = distribution
 
     def __eq__(self, other):
         # Checks if the other object is an instance of HessianScoresRequest
@@ -71,9 +81,10 @@ class HessianScoresRequest:
         return isinstance(other, HessianScoresRequest) and \
                self.mode == other.mode and \
                self.granularity == other.granularity and \
-               self.target_nodes == other.target_nodes
+               self.target_nodes == other.target_nodes and \
+               self.distribution == other.distribution
 
     def __hash__(self):
         # Computes the hash based on the attributes.
         # The use of a tuple here ensures that the hash is influenced by all the attributes.
-        return hash((self.mode, self.granularity, tuple(self.target_nodes)))
+        return hash((self.mode, self.granularity, tuple(self.target_nodes), self.distribution))

--- a/model_compression_toolkit/core/pytorch/hessian/activation_hessian_scores_calculator_pytorch.py
+++ b/model_compression_toolkit/core/pytorch/hessian/activation_hessian_scores_calculator_pytorch.py
@@ -21,7 +21,8 @@ import numpy as np
 
 from model_compression_toolkit.constants import MIN_HESSIAN_ITER, HESSIAN_COMP_TOLERANCE, HESSIAN_NUM_ITERATIONS
 from model_compression_toolkit.core.common import Graph
-from model_compression_toolkit.core.common.hessian import HessianScoresRequest, HessianScoresGranularity
+from model_compression_toolkit.core.common.hessian import (HessianScoresRequest, HessianScoresGranularity,
+                                                           HessianEstimationDistribution)
 from model_compression_toolkit.core.pytorch.back2framework.float_model_builder import FloatPyTorchModelBuilder
 from model_compression_toolkit.core.pytorch.hessian.hessian_scores_calculator_pytorch import \
     HessianScoresCalculatorPytorch
@@ -55,6 +56,52 @@ class ActivationHessianScoresCalculatorPytorch(HessianScoresCalculatorPytorch):
                                                                        hessian_scores_request=hessian_scores_request,
                                                                        num_iterations_for_approximation=num_iterations_for_approximation)
 
+    def forward_pass(self):
+        model_output_nodes = [ot.node for ot in self.graph.get_outputs()]
+
+        if len([n for n in self.hessian_request.target_nodes if n in model_output_nodes]) > 0:
+            Logger.critical("Activation Hessian approximation cannot be computed for model outputs. "
+                            "Exclude output nodes from Hessian request targets.")
+
+        grad_model_outputs = self.hessian_request.target_nodes + model_output_nodes
+        model, _ = FloatPyTorchModelBuilder(graph=self.graph, append2output=grad_model_outputs).build_model()
+        model.eval()
+
+        # Run model inference
+        # Set inputs to track gradients during inference
+        for input_tensor in self.input_images:
+            input_tensor.requires_grad_()
+            input_tensor.retain_grad()
+
+        outputs = model(*self.input_images)
+
+        if len(outputs) != len(grad_model_outputs):  # pragma: no cover
+            Logger.critical(f"Mismatch in expected and actual model outputs for activation Hessian approximation. "
+                            f"Expected {len(grad_model_outputs)} outputs, received {len(outputs)}.")
+
+        # Extracting the intermediate activation tensors and the model real output.
+        # Note that we do not allow computing Hessian for output nodes, so there shouldn't be an overlap.
+        num_target_nodes = len(self.hessian_request.target_nodes)
+        # Extract activation tensors of nodes for which we want to compute Hessian
+        target_activation_tensors = outputs[:num_target_nodes]
+        # Extract the model outputs
+        output_tensors = outputs[num_target_nodes:]
+        device = output_tensors[0].device
+
+        # Concat outputs
+        # First, we need to unfold all outputs that are given as list, to extract the actual output tensors
+        output = self.concat_tensors(output_tensors)
+        return output, target_activation_tensors
+
+    def _generate_random_vector(self, shape, distribution: HessianEstimationDistribution, device):
+        if distribution == HessianEstimationDistribution.GAUSSIAN:
+            return torch.randn(shape, device=device)
+
+        if distribution == HessianEstimationDistribution.RADEMACHER:
+            return torch.where(torch.randint(0, 2, shape), 1, -1).to(device)
+
+        raise ValueError(f'Unknown distribution {distribution}')
+
     def compute(self) -> List[np.ndarray]:
         """
         Compute the scores that are based on the approximation of the Hessian w.r.t the requested target nodes' activations.
@@ -62,91 +109,126 @@ class ActivationHessianScoresCalculatorPytorch(HessianScoresCalculatorPytorch):
         Returns:
             List[np.ndarray]: Scores based on the approximated Hessian for the requested nodes.
         """
+        output, target_activation_tensors = self.forward_pass()
+
         if self.hessian_request.granularity == HessianScoresGranularity.PER_TENSOR:
+            hessian_scores = self._compute_per_tensor(output, target_activation_tensors)
+        elif self.hessian_request.granularity == HessianScoresGranularity.PER_OUTPUT_CHANNEL:
+            hessian_scores = self._compute_per_channel(output, target_activation_tensors)
+        else:
+            raise NotImplementedError(f'{HessianScoresGranularity.PER_ELEMENT} is not supported')
 
-            model_output_nodes = [ot.node for ot in self.graph.get_outputs()]
+        # Convert results to list of numpy arrays
+        hessian_results = [torch_tensor_to_numpy(h) for h in hessian_scores]
+        return hessian_results
 
-            if len([n for n in self.hessian_request.target_nodes if n in model_output_nodes]) > 0:
-                Logger.critical("Activation Hessian approximation cannot be computed for model outputs. "
-                                "Exclude output nodes from Hessian request targets.")
+    def _compute_per_tensor(self, output, target_activation_tensors):
+        assert self.hessian_request.granularity == HessianScoresGranularity.PER_TENSOR
+        ipts_hessian_approx_scores = [torch.tensor([0.0], requires_grad=True, device=output.device)
+                                      for _ in range(len(target_activation_tensors))]
+        prev_mean_results = None
+        for j in tqdm(range(self.num_iterations_for_approximation), "Hessian random iterations"):  # Approximation iterations
+            # Getting a random vector with normal distribution
+            v = self._generate_random_vector(output.shape, self.hessian_request.distribution, output.device)
+            f_v = torch.sum(v * output)
+            for i, ipt_tensor in enumerate(target_activation_tensors):  # Per Interest point activation tensor
+                # Computing the hessian-approximation scores by getting the gradient of (output * v)
+                hess_v = autograd.grad(outputs=f_v,
+                                       inputs=ipt_tensor,
+                                       retain_graph=True,
+                                       allow_unused=True)[0]
 
-            grad_model_outputs = self.hessian_request.target_nodes + model_output_nodes
-            model, _ = FloatPyTorchModelBuilder(graph=self.graph, append2output=grad_model_outputs).build_model()
-            model.eval()
+                if hess_v is None:
+                    # In case we have an output node, which is an interest point, but it is not differentiable,
+                    # we consider its Hessian to be the initial value 0.
+                    continue  # pragma: no cover
 
-            # Run model inference
-            # Set inputs to track gradients during inference
-            for input_tensor in self.input_images:
-                input_tensor.requires_grad_()
-                input_tensor.retain_grad()
+                # Mean over all dims but the batch (CXHXW for conv)
+                hessian_approx_scores = torch.sum(hess_v ** 2.0, dim=tuple(d for d in range(1, len(hess_v.shape))))
 
-            outputs = model(*self.input_images)
+                # Update node Hessian approximation mean over random iterations
+                ipts_hessian_approx_scores[i] = (j * ipts_hessian_approx_scores[i] + hessian_approx_scores) / (j + 1)
 
-            if len(outputs) != len(grad_model_outputs):  # pragma: no cover
-                Logger.critical(f"Mismatch in expected and actual model outputs for activation Hessian approximation. "
-                                f"Expected {len(grad_model_outputs)} outputs, received {len(outputs)}.")
+            # If the change to the maximal mean Hessian approximation is insignificant we stop the calculation
+            if j > MIN_HESSIAN_ITER:
+                if prev_mean_results is not None:
+                    new_mean_res = torch.mean(torch.stack(ipts_hessian_approx_scores), dim=1)
+                    relative_delta_per_node = (torch.abs(new_mean_res - prev_mean_results) /
+                                               (torch.abs(new_mean_res) + 1e-6))
+                    max_delta = torch.max(relative_delta_per_node)
+                    if max_delta < HESSIAN_COMP_TOLERANCE:
+                        break
+            prev_mean_results = torch.mean(torch.stack(ipts_hessian_approx_scores), dim=1)
 
-            # Extracting the intermediate activation tensors and the model real output.
-            # Note that we do not allow computing Hessian for output nodes, so there shouldn't be an overlap.
-            num_target_nodes = len(self.hessian_request.target_nodes)
-            # Extract activation tensors of nodes for which we want to compute Hessian
-            target_activation_tensors = outputs[:num_target_nodes]
-            # Extract the model outputs
-            output_tensors = outputs[num_target_nodes:]
-            device = output_tensors[0].device
+        # add extra dimension to preserve previous behaviour
+        ipts_hessian_approx_scores = [torch.unsqueeze(t, -1) for t in ipts_hessian_approx_scores]
+        return ipts_hessian_approx_scores
 
-            # Concat outputs
-            # First, we need to unfold all outputs that are given as list, to extract the actual output tensors
-            output = self.concat_tensors(output_tensors)
+    def _compute_per_channel(self, output, target_activation_tensors):
+        assert self.hessian_request.granularity == HessianScoresGranularity.PER_OUTPUT_CHANNEL
+        ipts_hessian_approx_scores = [torch.tensor(0.0, requires_grad=True, device=output.device)
+                                      for _ in range(len(target_activation_tensors))]
 
-            ipts_hessian_approx_scores = [torch.tensor([0.0],
-                                                      requires_grad=True,
-                                                      device=device)
-                                         for _ in range(len(target_activation_tensors))]
-            prev_mean_results = None
-            for j in tqdm(range(self.num_iterations_for_approximation), "Hessian random iterations"):  # Approximation iterations
-                # Getting a random vector with normal distribution
-                v = torch.randn(output.shape, device=device)
-                f_v = torch.sum(v * output)
-                for i, ipt_tensor in enumerate(target_activation_tensors):  # Per Interest point activation tensor
-                    # Computing the hessian-approximation scores by getting the gradient of (output * v)
-                    hess_v = autograd.grad(outputs=f_v,
-                                           inputs=ipt_tensor,
-                                           retain_graph=True,
-                                           allow_unused=True)[0]
+        for j in tqdm(range(self.num_iterations_for_approximation), "Hessian random iterations"):  # Approximation iterations
+            # Getting a random vector with normal distribution
+            v = self._generate_random_vector(output.shape, self.hessian_request.distribution, output.device)
+            f_v = torch.sum(v * output)
+            for i, ipt_tensor in enumerate(target_activation_tensors):  # Per Interest point activation tensor
+                # Computing the hessian-approximation scores by getting the gradient of (output * v)
+                hess_v = autograd.grad(outputs=f_v,
+                                       inputs=ipt_tensor,
+                                       retain_graph=True,
+                                       allow_unused=True)[0]
 
-                    if hess_v is None:
-                        # In case we have an output node, which is an interest point, but it is not differentiable,
-                        # we consider its Hessian to be the initial value 0.
-                        continue  # pragma: no cover
+                hessian_approx_scores = hess_v ** 2
+                rank = len(hess_v.shape)
+                if rank > 2:
+                    hessian_approx_scores = torch.mean(hess_v, dim=tuple(range(2, rank)))
 
-                    # Mean over all dims but the batch (CXHXW for conv)
-                    hessian_approx_scores = torch.sum(hess_v ** 2.0, dim=tuple(d for d in range(1, len(hess_v.shape))))
+                # Update node Hessian approximation mean over random iterations
+                ipts_hessian_approx_scores[i] = (j * ipts_hessian_approx_scores[i] + hessian_approx_scores) / (j + 1)
 
-                    # Update node Hessian approximation mean over random iterations
-                    ipts_hessian_approx_scores[i] = (j * ipts_hessian_approx_scores[i] + hessian_approx_scores) / (j + 1)
+        return ipts_hessian_approx_scores
 
-                # If the change to the maximal mean Hessian approximation is insignificant we stop the calculation
-                if j > MIN_HESSIAN_ITER:
-                    if prev_mean_results is not None:
-                        new_mean_res = torch.mean(torch.stack(ipts_hessian_approx_scores), dim=1)
-                        relative_delta_per_node = (torch.abs(new_mean_res - prev_mean_results) /
-                                                   (torch.abs(new_mean_res) + 1e-6))
-                        max_delta = torch.max(relative_delta_per_node)
-                        if max_delta < HESSIAN_COMP_TOLERANCE:
-                            break
-                prev_mean_results = torch.mean(torch.stack(ipts_hessian_approx_scores), dim=1)
 
-            # Convert results to list of numpy arrays
-            hessian_results = [torch_tensor_to_numpy(h) for h in ipts_hessian_approx_scores]
-            # Extend the Hessian tensors shape to align with expected return type
-            # TODO: currently, only per-tensor Hessian is available for activation.
-            #  Once implementing per-channel or per-element, this alignment needs to be verified and handled separately.
-            hessian_results = [h[..., np.newaxis] for h in hessian_results]
+class SampleLayerHessianScoresCalculatorPytorch(ActivationHessianScoresCalculatorPytorch):
 
-            return hessian_results
+    def compute(self) -> List[np.ndarray]:
+        """
+        Compute the scores that are based on the approximation of the Hessian w.r.t the requested target nodes' activations.
 
-        else:  # pragma: no cover
-            Logger.critical(f"PyTorch activation Hessian's approximation scores does not support "
-                            f"{self.hessian_request.granularity} granularity.")
+        Returns:
+            List[np.ndarray]: List of approximated Hessian scores of shape (n_samples X n_channels)
+                for the requested nodes.
+        """
+        output, target_activation_tensors = self.forward_pass()
+        device = output.device
 
+        # Score is initialize to a scalar. Upon first update it will get the correct shape.
+        ipts_hessian_approx_scores = [torch.tensor(0., requires_grad=True, device=device)
+                                      for _ in range(len(target_activation_tensors))]
+
+        for j in tqdm(range(self.num_iterations_for_approximation),
+                      "Hessian random iterations"):  # Approximation iterations
+            v = torch.randint_like(output, high=2, device=device)
+            v[v == 0] = -1
+            out_v = torch.sum(v * output)
+            for i, ipt_tensor in enumerate(target_activation_tensors):  # Per Interest point activation tensor
+                # Computing the hessian-approximation scores by getting the gradient of (output * v)
+                hess_v = autograd.grad(outputs=out_v,
+                                       inputs=ipt_tensor,
+                                       retain_graph=True,
+                                       allow_unused=True)[0]
+
+                hessian_approx_scores = hess_v**2
+
+                rank = len(hess_v.shape)
+                if rank > 2:
+                    hessian_approx_scores = torch.mean(hess_v, dim=range(2, rank))
+
+                # Update node Hessian approximation mean over random iterations
+                ipts_hessian_approx_scores[i] = (j * ipts_hessian_approx_scores[i] + hessian_approx_scores) / (j + 1)
+
+        # Convert results to list of numpy arrays
+        hessian_results = [torch_tensor_to_numpy(h) for h in ipts_hessian_approx_scores]
+        return hessian_results

--- a/model_compression_toolkit/core/pytorch/hessian/activation_hessian_scores_calculator_pytorch.py
+++ b/model_compression_toolkit/core/pytorch/hessian/activation_hessian_scores_calculator_pytorch.py
@@ -113,7 +113,7 @@ class ActivationHessianScoresCalculatorPytorch(HessianScoresCalculatorPytorch):
             v[v == 0] = -1
             return v
 
-        raise ValueError(f'Unknown distribution {distribution}')
+        raise ValueError(f'Unknown distribution {distribution}')    # pragma: no cover
 
     def compute(self) -> List[np.ndarray]:
         """
@@ -129,7 +129,7 @@ class ActivationHessianScoresCalculatorPytorch(HessianScoresCalculatorPytorch):
         elif self.hessian_request.granularity == HessianScoresGranularity.PER_OUTPUT_CHANNEL:
             hessian_scores = self._compute_per_channel(output, target_activation_tensors)
         else:
-            raise NotImplementedError(f'{self.hessian_request.granularity} is not supported')
+            raise NotImplementedError(f'{self.hessian_request.granularity} is not supported')    # pragma: no cover
 
         # Convert results to list of numpy arrays
         hessian_results = [torch_tensor_to_numpy(h) for h in hessian_scores]

--- a/model_compression_toolkit/core/pytorch/hessian/activation_hessian_scores_calculator_pytorch.py
+++ b/model_compression_toolkit/core/pytorch/hessian/activation_hessian_scores_calculator_pytorch.py
@@ -93,7 +93,8 @@ class ActivationHessianScoresCalculatorPytorch(HessianScoresCalculatorPytorch):
         output = self.concat_tensors(output_tensors)
         return output, target_activation_tensors
 
-    def _generate_random_vectors_batch(self, shape, distribution: HessianEstimationDistribution, device) -> torch.Tensor:
+    def _generate_random_vectors_batch(self, shape: tuple, distribution: HessianEstimationDistribution,
+                                       device: torch.device) -> torch.Tensor:
         """
         Generate a batch of random vectors for Hutchinson estimation
 

--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import Callable, Any, Dict, Optional
 
 from model_compression_toolkit.constants import GPTQ_HESSIAN_NUM_SAMPLES, ACT_HESSIAN_DEFAULT_BATCH_SIZE
+from model_compression_toolkit.core.common.hessian import HessianScoresGranularity, HessianEstimationDistribution
 from model_compression_toolkit.gptq.common.gptq_constants import REG_DEFAULT
 
 
@@ -39,17 +40,21 @@ class GPTQHessianScoresConfig:
     Configuration to use for computing the Hessian-based scores for GPTQ loss metric.
 
     Args:
-        hessians_num_samples (int): Number of samples to use for computing the Hessian-based scores.
+        hessians_num_samples (int|None): Number of samples to use for computing the Hessian-based scores.
+          If None, compute Hessian for all images.
         norm_scores (bool): Whether to normalize the returned scores of the weighted loss function (to get values between 0 and 1).
         log_norm (bool): Whether to use log normalization for the GPTQ Hessian-based scores.
         scale_log_norm (bool): Whether to scale the final vector of the Hessian-based scores.
         hessian_batch_size (int): The Hessian computation batch size. used only if using GPTQ with Hessian-based objective.
+        per_sample (bool): Whether to use per sample attention score.
     """
-    hessians_num_samples: int = GPTQ_HESSIAN_NUM_SAMPLES
+    hessians_num_samples: Optional[int] = GPTQ_HESSIAN_NUM_SAMPLES
     norm_scores: bool = True
     log_norm: bool = True
     scale_log_norm: bool = False
     hessian_batch_size: int = ACT_HESSIAN_DEFAULT_BATCH_SIZE
+    per_sample: bool = False
+    estimator_distribution: HessianEstimationDistribution = HessianEstimationDistribution.GAUSSIAN
 
 
 @dataclass

--- a/model_compression_toolkit/gptq/pytorch/gptq_loss.py
+++ b/model_compression_toolkit/gptq/pytorch/gptq_loss.py
@@ -79,7 +79,7 @@ def sample_layer_attention_loss(y_list: List[torch.Tensor],
         y_list: First list of tensors.
         x_list: Second list of tensors.
         fxp_w_list, flp_w_list, act_bn_mean, act_bn_std: unused (needed to comply with the interface).
-        loss_weights: A list of weights for each layer. Each weight is a vector of shape (batch,)
+        loss_weights: layer-sample weights tensor of shape (layers, batch)
 
     Returns:
         Sample Layer Attention loss (a scalar).
@@ -88,14 +88,12 @@ def sample_layer_attention_loss(y_list: List[torch.Tensor],
     layers_mean_w = []
 
     for i, (y, x, w) in enumerate(zip(y_list, x_list, loss_weights)):
-        # norm = (y - x).pow(2).sum(1)
-        norm = (y - x).pow(2).mean(1)
+        norm = (y - x).pow(2).sum(1)
         if len(norm.shape) > 1:
             norm = norm.flatten(1).mean(1)
         loss += torch.mean(w * norm)
         layers_mean_w.append(w.mean())
 
-    # loss = loss / len(x_list)
     loss = loss / torch.stack(layers_mean_w).max()
     return loss
 

--- a/model_compression_toolkit/gptq/pytorch/gptq_loss.py
+++ b/model_compression_toolkit/gptq/pytorch/gptq_loss.py
@@ -88,10 +88,14 @@ def sample_layer_attention_loss(y_list: List[torch.Tensor],
     layers_mean_w = []
 
     for i, (y, x, w) in enumerate(zip(y_list, x_list, loss_weights)):
-        norm = (y - x).pow(2).sum(1)
+        # norm = (y - x).pow(2).sum(1)
+        norm = (y - x).pow(2).mean(1)
         if len(norm.shape) > 1:
             norm = norm.flatten(1).mean(1)
         loss += torch.mean(w * norm)
         layers_mean_w.append(w.mean())
+
+    # loss = loss / len(x_list)
     loss = loss / torch.stack(layers_mean_w).max()
     return loss
+

--- a/model_compression_toolkit/gptq/pytorch/quantization_facade.py
+++ b/model_compression_toolkit/gptq/pytorch/quantization_facade.py
@@ -109,8 +109,9 @@ if FOUND_TORCH:
         bias_optimizer = torch.optim.SGD([torch.Tensor([])], lr=LR_BIAS_DEFAULT, momentum=GPTQ_MOMENTUM)
 
         if use_hessian_sample_attention:
-            if not use_hessian_based_weights:
+            if not use_hessian_based_weights:    # pragma: no cover
                 raise ValueError('use_hessian_based_weights must be set to True in order to use Sample Layer Attention.')
+
             hessian_weights_config = GPTQHessianScoresConfig(
                 hessians_num_samples=None,
                 norm_scores=False,
@@ -129,9 +130,9 @@ if FOUND_TORCH:
             gradual_quant_config = GradualActivationQuantizationConfig() if gradual_activation_quantization else None
         elif isinstance(gradual_activation_quantization, GradualActivationQuantizationConfig):
             gradual_quant_config = gradual_activation_quantization
-        else:
+        else:    # pragma: no cover
             raise TypeError(f'gradual_activation_quantization argument should be bool or '
-                            f'GradualActivationQuantizationConfig, received {type(gradual_activation_quantization)}')    # pragma: no cover
+                            f'GradualActivationQuantizationConfig, received {type(gradual_activation_quantization)}')
 
         return GradientPTQConfig(n_epochs, optimizer, optimizer_rest=optimizer_rest, loss=loss,
                                  log_function=log_function, train_bias=True, optimizer_bias=bias_optimizer,
@@ -205,11 +206,11 @@ if FOUND_TORCH:
 
         """
 
-        if core_config.is_mixed_precision_enabled:
+        if core_config.is_mixed_precision_enabled:    # pragma: no cover
             if not isinstance(core_config.mixed_precision_config, MixedPrecisionQuantizationConfig):
                 Logger.critical("Given quantization config for mixed-precision is not of type 'MixedPrecisionQuantizationConfig'. "
                                 "Ensure usage of the correct API for 'pytorch_gradient_post_training_quantization' "
-                                "or provide a valid mixed-precision configuration.")  # pragma: no cover
+                                "or provide a valid mixed-precision configuration.")
 
         tb_w = init_tensorboard_writer(DEFAULT_PYTORCH_INFO)
 

--- a/model_compression_toolkit/gptq/pytorch/quantizer/regularization_factory.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/regularization_factory.py
@@ -41,4 +41,4 @@ def get_regularization(gptq_config: GradientPTQConfig, get_total_grad_steps_fn: 
         scheduler = LinearAnnealingScheduler(t_start=t_start, t_end=total_gradient_steps, initial_val=20, target_val=2)
         return SoftQuantizerRegularization(scheduler)
     else:
-        return lambda m, e_reg: 0
+        return lambda *args, **kwargs: 0

--- a/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/soft_quantizer_reg.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/soft_quantizer_reg.py
@@ -40,21 +40,19 @@ class SoftQuantizerRegularization:
 
         self.count_iter = 0
 
-    def __call__(self, model: nn.Module, entropy_reg: float, layer_weights: torch.Tensor = None):
+    def __call__(self, model: nn.Module, entropy_reg: float, layer_weights: torch.Tensor):
         """
         Returns the soft quantizer regularization value for SoftRounding.
 
         Args:
             model: A model to be quantized with SoftRounding.
             entropy_reg: Entropy value to scale the quantizer regularization.
-            layer_weights: a vector of layer weights. If None, each layers has a weight of 1.
+            layer_weights: a vector of layer weights.
 
         Returns: Regularization value.
         """
         layers = [m for m in model.modules() if isinstance(m, PytorchQuantizationWrapper)]
 
-        if layer_weights is None:
-            layer_weights = torch.ones((len(layers),))
         if len(layer_weights.shape) != 1 or layer_weights.shape[0] != len(layers):
             raise ValueError(f'Expected weights to be a vector of length {len(layers)}, received {layer_weights.shape}.')    # pragma: no cover
         max_w = layer_weights.max()

--- a/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/soft_quantizer_reg.py
+++ b/model_compression_toolkit/gptq/pytorch/quantizer/soft_rounding/soft_quantizer_reg.py
@@ -56,7 +56,7 @@ class SoftQuantizerRegularization:
         if layer_weights is None:
             layer_weights = torch.ones((len(layers),))
         if len(layer_weights.shape) != 1 or layer_weights.shape[0] != len(layers):
-            raise ValueError(f'Expected weights to be a vector of length {len(layers)}, received {layer_weights.shape}.')
+            raise ValueError(f'Expected weights to be a vector of length {len(layers)}, received {layer_weights.shape}.')    # pragma: no cover
         max_w = layer_weights.max()
 
         b = self.beta_scheduler(self.count_iter)

--- a/tests/pytorch_tests/model_tests/feature_models/gptq_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/gptq_test.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 import mct_quantizers
 from model_compression_toolkit import DefaultDict
 from model_compression_toolkit.constants import GPTQ_HESSIAN_NUM_SAMPLES
+from model_compression_toolkit.core.common.hessian import HessianEstimationDistribution
 from model_compression_toolkit.target_platform_capabilities.target_platform import QuantizationMethod
 from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEARNING_STR, MAX_LSB_STR
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
@@ -59,7 +60,7 @@ class GPTQBaseTest(BasePytorchFeatureNetworkTest):
                  hessian_weights=True, norm_scores=True, log_norm_weights=True, scaled_log_norm=False, params_learning=True,
                  num_calibration_iter=GPTQ_HESSIAN_NUM_SAMPLES, gradual_activation_quantization=False,
                  hessian_num_samples=GPTQ_HESSIAN_NUM_SAMPLES, sample_layer_attention=False,
-                 loss=multiple_tensors_mse_loss, hessian_batch_size=1):
+                 loss=multiple_tensors_mse_loss, hessian_batch_size=1, estimator_distribution=HessianEstimationDistribution.GAUSSIAN):
         super().__init__(unit_test, input_shape=(3, 16, 16), num_calibration_iter=num_calibration_iter)
         self.seed = 0
         self.rounding_type = rounding_type
@@ -78,6 +79,7 @@ class GPTQBaseTest(BasePytorchFeatureNetworkTest):
         self.sample_layer_attention = sample_layer_attention
         self.loss = loss
         self.hessian_batch_size = hessian_batch_size
+        self.estimator_distribution = estimator_distribution
 
     def get_quantization_config(self):
         return mct.core.QuantizationConfig(mct.core.QuantizationErrorMethod.NOCLIPPING,
@@ -154,7 +156,8 @@ class GPTQAccuracyTest(GPTQBaseTest):
                                                                                 norm_scores=self.norm_scores,
                                                                                 per_sample=self.sample_layer_attention,
                                                                                 hessians_num_samples=self.hessian_num_samples,
-                                                                                hessian_batch_size=self.hessian_batch_size),
+                                                                                hessian_batch_size=self.hessian_batch_size,
+                                                                                estimator_distribution=self.estimator_distribution),
 
 
                                  gptq_quantizer_params_override=self.override_params,

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -657,11 +657,13 @@ class FeatureModelsTestRunner(unittest.TestCase):
 
     def test_gptq_with_sample_layer_attention(self):
         kwargs = dict(sample_layer_attention=True, loss=sample_layer_attention_loss,
-                      hessian_weights=True, rounding_type=RoundingType.SoftQuantizer,
-                      hessian_num_samples=None, norm_scores=False, log_norm_weights=False, scaled_log_norm=False)
+                      hessian_weights=True, hessian_num_samples=None,
+                      norm_scores=False, log_norm_weights=False, scaled_log_norm=False)
         GPTQAccuracyTest(self, **kwargs).run_test()
-        GPTQAccuracyTest(self, hessian_batch_size=16, **kwargs).run_test()
-        GPTQAccuracyTest(self, hessian_batch_size=5, gradual_activation_quantization=True, **kwargs).run_test()
+        GPTQAccuracyTest(self, hessian_batch_size=16, rounding_type=RoundingType.SoftQuantizer, **kwargs).run_test()
+        GPTQAccuracyTest(self, hessian_batch_size=5, rounding_type=RoundingType.SoftQuantizer,
+                         gradual_activation_quantization=True, **kwargs).run_test()
+        GPTQAccuracyTest(self, rounding_type=RoundingType.STE, **kwargs)
 
     def test_qat(self):
         """

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -24,6 +24,7 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import MpDistanceWeighting
 from model_compression_toolkit.core.common.network_editors import NodeTypeFilter, NodeNameFilter
 from model_compression_toolkit.gptq.common.gptq_config import RoundingType
+from model_compression_toolkit.gptq.pytorch.gptq_loss import sample_layer_attention_loss
 from model_compression_toolkit.target_platform_capabilities import constants as C
 from model_compression_toolkit.trainable_infrastructure import TrainingMethod
 from tests.pytorch_tests.model_tests.feature_models.add_net_test import AddNetTest
@@ -653,6 +654,14 @@ class FeatureModelsTestRunner(unittest.TestCase):
                          gradual_activation_quantization=True).run_test()
         GPTQLearnRateZeroTest(self, rounding_type=RoundingType.SoftQuantizer,
                               gradual_activation_quantization=True).run_test()
+
+    def test_gptq_with_sample_layer_attention(self):
+        kwargs = dict(sample_layer_attention=True, loss=sample_layer_attention_loss,
+                      hessian_weights=True, rounding_type=RoundingType.SoftQuantizer,
+                      hessian_num_samples=None, norm_scores=False, log_norm_weights=False, scaled_log_norm=False)
+        GPTQAccuracyTest(self, **kwargs).run_test()
+        GPTQAccuracyTest(self, hessian_batch_size=16, **kwargs).run_test()
+        GPTQAccuracyTest(self, hessian_batch_size=5, gradual_activation_quantization=True, **kwargs).run_test()
 
     def test_qat(self):
         """

--- a/tests/pytorch_tests/model_tests/test_feature_models_runner.py
+++ b/tests/pytorch_tests/model_tests/test_feature_models_runner.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 from torch import nn
 import model_compression_toolkit as mct
+from model_compression_toolkit.core.common.hessian import HessianEstimationDistribution
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import MpDistanceWeighting
 from model_compression_toolkit.core.common.network_editors import NodeTypeFilter, NodeNameFilter
 from model_compression_toolkit.gptq.common.gptq_config import RoundingType
@@ -658,6 +659,7 @@ class FeatureModelsTestRunner(unittest.TestCase):
     def test_gptq_with_sample_layer_attention(self):
         kwargs = dict(sample_layer_attention=True, loss=sample_layer_attention_loss,
                       hessian_weights=True, hessian_num_samples=None,
+                      estimator_distribution=HessianEstimationDistribution.RADEMACHER,
                       norm_scores=False, log_norm_weights=False, scaled_log_norm=False)
         GPTQAccuracyTest(self, **kwargs).run_test()
         GPTQAccuracyTest(self, hessian_batch_size=16, rounding_type=RoundingType.SoftQuantizer, **kwargs).run_test()


### PR DESCRIPTION
## Pull Request Description:
Add hessian estimation per image hash.
Add sample-layer attention distillation loss.
Add weights per layer to soft round loss.
Update GPTQ config and its generation for sample layer attention.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).