### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/run_tests_suite_coverage.yml
+++ b/.github/workflows/run_tests_suite_coverage.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Set up Coverage
+        run: |
+          python -m pip install --upgrade pip
+          pip install coverage
+
       - name: Set up TensorFlow environment
         run: |
           python -m venv tf_env
@@ -57,13 +62,16 @@ jobs:
 
       - name: Combine Multiple Coverage Files
         run: coverage combine
+
       - name: Run Coverage HTML
         run: coverage html -i --directory ./coverage_report_html
+
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: |
             coverage_report_html
+
       - name: Coverage Report
         run: coverage report -i --skip-covered --sort cover --fail-under $COVERAGE_THRESHOLD

--- a/.github/workflows/run_tests_suite_coverage.yml
+++ b/.github/workflows/run_tests_suite_coverage.yml
@@ -23,22 +23,38 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.10'
-      - name: Install dependencies
+
+      - name: Set up TensorFlow environment
         run: |
+          python -m venv tf_env
+          source tf_env/bin/activate
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install coverage
-          pip install pytest
-      - name: Prepare TF env
-        run: pip install tensorflow==2.13.*
-      - name: Run tensorflow testsuite
-        run: coverage run --parallel-mode -m --omit "*__init__.py" --include "model_compression_toolkit/**/*.py" unittest tests/test_suite.py -v
-      - name: Prepare Torch env
-        run: pip uninstall tensorflow -y && pip install torch==2.0.* torchvision onnx onnxruntime onnxruntime-extensions
+          pip install tensorflow==2.13.* coverage pytest
+
+      - name: Run TensorFlow testsuite
+        run: |
+          source tf_env/bin/activate 
+          coverage run --parallel-mode -m --omit "*__init__.py" --include "model_compression_toolkit/**/*.py" unittest tests/test_suite.py -v
+
+      - name: Set up Pytorch environment
+        run: |
+          python -m venv torch_env
+          source torch_env/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install torch==2.0.* torchvision onnx onnxruntime onnxruntime-extensions coverage pytest
+
       - name: Run torch testsuite
-        run: coverage run --parallel-mode -m --omit "*__init__.py" --include "model_compression_toolkit/**/*.py" unittest tests/test_suite.py -v
+        run: |
+          source torch_env/bin/activate
+          coverage run --parallel-mode -m --omit "*__init__.py" --include "model_compression_toolkit/**/*.py" unittest tests/test_suite.py -v
+
       - name: Run torch pytest
-        run: coverage run --parallel-mode -m --omit "*__init__.py" --include "model_compression_toolkit/**/*.py" pytest tests_pytest/pytorch
+        run: |
+          source torch_env/bin/activate
+          coverage run --parallel-mode -m --omit "*__init__.py" --include "model_compression_toolkit/**/*.py" pytest tests_pytest/pytorch
+
       - name: Combine Multiple Coverage Files
         run: coverage combine
       - name: Run Coverage HTML


### PR DESCRIPTION
## Pull Request Description:
Use separate environments for coverage testing of Keras and Torch.
This fixes the issue of the flag "FOUND_TF" being set even if TF is uninstalled. The issue started with the start of pytest usage.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).