### PR TITLE
fix hmse overridden by mse after resource utilization computation

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/distance_weighting.py
+++ b/model_compression_toolkit/core/common/mixed_precision/distance_weighting.py
@@ -71,3 +71,6 @@ class MpDistanceWeighting(Enum):
 
     def __call__(self, distance_matrix: np.ndarray) -> np.ndarray:
         return self.value(distance_matrix)
+
+    def __deepcopy__(self, memo):
+        return self

--- a/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization_data.py
+++ b/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization_data.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import copy
+
 import numpy as np
 from typing import Callable, Any, Dict, Tuple
 
@@ -57,6 +59,10 @@ def compute_resource_utilization_data(in_model: Any,
 
 
     """
+    # core_config might be updated in place during graph transformation. Specifically graph_preparation_runner
+    # is run with default running_gptq=False, and in that case weights_error_method HMSE will be overridden with MSE.
+    # We don't want resource utilization computation to modify the config, so we create a copy.
+    core_config = copy.deepcopy(core_config)
 
     # We assume that the resource_utilization_data API is used to compute the model resource utilization for
     # mixed precision scenario, so we run graph preparation under the assumption of enabled mixed precision.
@@ -222,6 +228,12 @@ def requires_mixed_precision(in_model: Any,
     Returns: A boolean indicating if mixed precision is needed.
     """
     is_mixed_precision = False
+
+    # core_config might be updated in place during graph transformation. Specifically graph_preparation_runner
+    # is run with default running_gptq=False, and in that case weights_error_method HMSE will be overridden with MSE.
+    # We don't want resource utilization computation to modify the config, so we create a copy.
+    core_config = copy.deepcopy(core_config)
+
     transformed_graph = graph_preparation_runner(in_model,
                                                  representative_data_gen,
                                                  core_config.quantization_config,


### PR DESCRIPTION
## Pull Request Description:
When GPTQ with HMSE follows resource utilization computation, it runs with MSE instead of HMSE. 
Resource utilization computation runs graph_preparation_runner with default gptq flag which is false. In set_quantization_configuration_to_graph when weights_error_method is HMSE and gptq is false, weights_error_method is set to MSE in the original core_config. So when gptq is run afterwards, its config contains MSE instead of HMSE.

This fix runs resource utilization on a copy of core config, so that the original config is not changed. 

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).