### PR TITLE
fix package discovery for wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,7 @@ setup(name='model_compression_toolkit',
       long_description=get_log_description(),
       long_description_content_type="text/markdown",
       description='A Model Compression Toolkit for neural networks',
-      packages=find_packages(
-          exclude=["tests", "tests.*",
-                   "requirements", "requirements.*",
-                   "tutorials", "tutorials.*"]),
+      packages=find_packages(include=["model_compression_toolkit", "model_compression_toolkit.*"]),
       classifiers=[
           "Programming Language :: Python :: 3",
           "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Pull Request Description:
tests_pytest is included in the wheel as it was not explicitly excluded from find_packages.
Use include instead of exclude in find_packages to automatically exclude any new non-product code.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).