### PR TITLE
restricting matplotlib to version < 3.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ scikit-image
 scikit-learn
 tensorboard
 PuLP
-matplotlib
+matplotlib<3.10.0
 scipy
 protobuf
 mct-quantizers==1.5.2


### PR DESCRIPTION
## Pull Request Description:
This fixes an issue with tensorboard when using this version of matplotlib.
See [this issue](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/issues/2411)

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).