### PR TITLE
Move splitting ops from default to qpreserving configs in TPCv4.

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v4/tpc_keras.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v4/tpc_keras.py
@@ -39,7 +39,8 @@ from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tp
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v4.tp_model import OPSET_NO_QUANTIZATION, \
     OPSET_QUANTIZATION_PRESERVING, OPSET_DIMENSION_MANIPULATION_OPS_WITH_WEIGHTS, OPSET_DIMENSION_MANIPULATION_OPS, \
     OPSET_MERGE_OPS, OPSET_CONV, OPSET_FULLY_CONNECTED, OPSET_ANY_RELU, OPSET_ADD, OPSET_SUB, OPSET_MUL, OPSET_DIV, \
-    OPSET_PRELU, OPSET_SWISH, OPSET_SIGMOID, OPSET_TANH, OPSET_GELU, OPSET_BATCH_NORM, OPSET_MIN_MAX, OPSET_HARDSIGMOID
+    OPSET_PRELU, OPSET_SWISH, OPSET_SIGMOID, OPSET_TANH, OPSET_GELU, OPSET_BATCH_NORM, OPSET_MIN_MAX, OPSET_HARDSIGMOID, \
+    OPSET_SPLIT_OPS
 
 tp = mct.target_platform
 
@@ -78,11 +79,7 @@ def generate_keras_tpc(name: str, tp_model: schema.TargetPlatformModel):
                                ZeroPadding2D,
                                Dropout,
                                MaxPooling2D,
-                               tf.split,
-                               tf.cast,
-                               tf.unstack,
-                               tf.__operators__.getitem,
-                               tf.strided_slice]
+                               tf.cast]
     quantization_preserving_list_16bit_input = [Reshape,
                                                 tf.reshape,
                                                 Permute,
@@ -97,6 +94,7 @@ def generate_keras_tpc(name: str, tp_model: schema.TargetPlatformModel):
         tp.OperationsSetToLayers(OPSET_QUANTIZATION_PRESERVING, quantization_preserving)
         tp.OperationsSetToLayers(OPSET_DIMENSION_MANIPULATION_OPS, quantization_preserving_list_16bit_input)
         tp.OperationsSetToLayers(OPSET_DIMENSION_MANIPULATION_OPS_WITH_WEIGHTS, [tf.gather, tf.compat.v1.gather])
+        tp.OperationsSetToLayers(OPSET_SPLIT_OPS,[tf.unstack, tf.split, tf.strided_slice, tf.__operators__.getitem])
         tp.OperationsSetToLayers(OPSET_MERGE_OPS, [tf.stack, tf.concat, Concatenate])
         tp.OperationsSetToLayers(OPSET_CONV,
                                  [Conv2D,

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v4/tpc_pytorch.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v4/tpc_pytorch.py
@@ -36,7 +36,7 @@ from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tp
     OPSET_QUANTIZATION_PRESERVING, OPSET_DIMENSION_MANIPULATION_OPS_WITH_WEIGHTS, OPSET_DIMENSION_MANIPULATION_OPS, \
     OPSET_MERGE_OPS, OPSET_CONV, OPSET_FULLY_CONNECTED, OPSET_ANY_RELU, OPSET_ADD, OPSET_SUB, OPSET_MUL, OPSET_DIV, \
     OPSET_PRELU, OPSET_SWISH, OPSET_SIGMOID, OPSET_TANH, OPSET_GELU, OPSET_BATCH_NORM, OPSET_MIN_MAX, OPSET_HARDSIGMOID, \
-    OPSET_HARDSWISH
+    OPSET_HARDSWISH, OPSET_SPLIT_OPS
 
 tp = mct.target_platform
 
@@ -77,9 +77,6 @@ def generate_pytorch_tpc(name: str, tp_model: schema.TargetPlatformModel):
                                                          topk])
         tp.OperationsSetToLayers(OPSET_QUANTIZATION_PRESERVING, [Dropout,
                                                                  dropout,
-                                                                 split,
-                                                                 chunk,
-                                                                 unbind,
                                                                  MaxPool2d])
         tp.OperationsSetToLayers(OPSET_DIMENSION_MANIPULATION_OPS, [Flatten,
                                                                     flatten,
@@ -90,6 +87,7 @@ def generate_pytorch_tpc(name: str, tp_model: schema.TargetPlatformModel):
                                                                     permute,
                                                                     transpose])
         tp.OperationsSetToLayers(OPSET_DIMENSION_MANIPULATION_OPS_WITH_WEIGHTS, [gather, torch.Tensor.expand])
+        tp.OperationsSetToLayers(OPSET_SPLIT_OPS,[split, chunk, unbind])
         tp.OperationsSetToLayers(OPSET_MERGE_OPS,
                                  [torch.stack, torch.cat, torch.concat, torch.concatenate])
 


### PR DESCRIPTION
## Pull Request Description:
This PR moves splitting ops (e.g. split, unstack and slice) to a "qpreserving" opset. This opset disables activation quantiztion, enables quantization preserving and enables input & output tensors to be 16 bits.
This PR is compatible with the op definitions in the converter release 3.16.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).