### PR TITLE
Fix tf 2.14 installation in tutorials

### DIFF
--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_activation_threshold_search.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_activation_threshold_search.ipynb
@@ -74,8 +74,8 @@
    },
    "outputs": [],
    "source": [
-    "TF_VER = '2.14'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "TF_VER = '2.14.0'\n",
+    "!pip install -q tensorflow~={TF_VER}"
    ]
   },
   {

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_activation_z_score_threshold.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_activation_z_score_threshold.ipynb
@@ -58,8 +58,8 @@
    },
    "outputs": [],
    "source": [
-    "TF_VER = '2.14'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "TF_VER = '2.14.0'\n",
+    "!pip install -q tensorflow~={TF_VER}"
    ]
   },
   {

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_mobilenet_gptq.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_mobilenet_gptq.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "TF_VER = '2.14.0'\n",
     "\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "!pip install -q tensorflow~={TF_VER}"
    ]
   },
   {

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_mobilenet_mixed_precision.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_mobilenet_mixed_precision.ipynb
@@ -39,8 +39,8 @@
    },
    "outputs": [],
    "source": [
-    "TF_VER = '2.14'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "TF_VER = '2.14.0'\n",
+    "!pip install -q tensorflow~={TF_VER}"
    ]
   },
   {

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_network_editor.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_network_editor.ipynb
@@ -47,8 +47,8 @@
    },
    "outputs": [],
    "source": [
-    "TF_VER = '2.14'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "TF_VER = '2.14.0'\n",
+    "!pip install -q tensorflow~={TF_VER}"
    ]
   },
   {

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_post-training_quantization.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_post-training_quantization.ipynb
@@ -31,8 +31,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "TF_VER = '2.14'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "TF_VER = '2.14.0'\n",
+    "!pip install -q tensorflow~={TF_VER}"
    ],
    "metadata": {
     "collapsed": false

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_pruning_mnist.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_pruning_mnist.ipynb
@@ -44,7 +44,7 @@
    "cell_type": "code",
    "source": [
     "TF_VER = '2.14.0'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "!pip install -q tensorflow~={TF_VER}"
    ],
    "metadata": {
     "id": "xTvVA__4NItc"

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_qat.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_qat.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "TF_VER = '2.14.0'\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "!pip install -q tensorflow~={TF_VER}"
    ]
   },
   {

--- a/tutorials/notebooks/mct_features_notebooks/keras/example_keras_xquant.ipynb
+++ b/tutorials/notebooks/mct_features_notebooks/keras/example_keras_xquant.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "TF_VER = '2.14.0'\n",
     "\n",
-    "!pip install -q tensorflow[and-cuda]~={TF_VER}"
+    "!pip install -q tensorflow~={TF_VER}"
    ],
    "metadata": {
     "id": "kCLHJUhTlPDi"


### PR DESCRIPTION
## Pull Request Description:
Add patch part to TF version in tutorials to make sure TF 2.14 is installed (without mentioning the patch version and using ~= in pip install, it kept the 2.17 version that is installed in the colab: https://stackoverflow.com/a/67374648/11404086). In addition, remove [and-cuda] to enable successful installation in colab.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).