### PR TITLE
Fix intermittent bug in MP LP definition when both total and activation targets are constrained

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/search_methods/linear_programming.py
+++ b/model_compression_toolkit/core/common/mixed_precision/search_methods/linear_programming.py
@@ -218,7 +218,12 @@ def _add_ru_constraints(search_manager: MixedPrecisionSearchManager,
             ru_vec = np.concatenate([ru_vec, non_conf_ru_vec])
         ru_indicated_vectors[target] = ru_vec
 
-    # add constraints only for the restricted targets in target resource utilization.
+    # Add constraints only for the restricted targets in target resource utilization.
+    # Adding activation constraints modifies the lp term in ru_indicated_vectors, so if both activation and total
+    # are restricted we first add the constraints for total.
+    if RUTarget.TOTAL in constraints_targets and RUTarget.ACTIVATION in constraints_targets:
+        constraints_targets.remove(RUTarget.ACTIVATION)
+        constraints_targets = list(constraints_targets) + [RUTarget.ACTIVATION]
     for target in constraints_targets:
         target_resource_utilization_value = target_resource_utilization.get_resource_utilization_dict()[target]
         aggr_ru = _aggregate_for_lp(ru_indicated_vectors, target)


### PR DESCRIPTION
## Pull Request Description:
Adding LP constraints for Activation modifies its LP term, which is also used for the Total target. If Activation constraints is added before the Total, the constraint for Total is wrong (by +activation RU target). The failure is intermittent since the targets are kept in a set, so the order is not fixed. 
This PR is a temporary fix that makes sure that Total constraints are added before the Activation constraints.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).