### PR TITLE
MP cleanup and partial refactoring

### DIFF
--- a/model_compression_toolkit/core/common/graph/base_graph.py
+++ b/model_compression_toolkit/core/common/graph/base_graph.py
@@ -706,14 +706,24 @@ class Graph(nx.MultiDiGraph, GraphSearches):
         """
         self.fused_nodes.append(fusion)
 
-    def is_single_activation_cfg(self):
+    def has_any_configurable_activation(self) -> bool:
         """
-        Checks whether all nodes in the graph that have activation quantization are quantized with the same bit-width.
+        Checks whether any node in the graph has a configurable activation quantization.
 
-        Returns: True if all quantization config candidates of all nodes have the same activation quantization bit-width.
-
+        Returns:
+            Whether any node in the graph has a configurable activation quantization.
         """
-        return all([n.is_all_activation_candidates_equal() for n in self.nodes])
+        return any([n.has_configurable_activation() for n in self.nodes])
+
+    def has_any_configurable_weights(self):
+        """
+        Checks whether any node in the graph has any configurable weights quantization.
+
+        Returns:
+            Whether any node in the graph has any configurable weights quantization.
+        """
+
+        return any([n.has_any_configurable_weight() for n in self.nodes])
 
     def replace_node(self, node_to_replace: BaseNode, new_node: BaseNode):
         """

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -170,6 +170,7 @@ class BaseNode:
     def has_any_configurable_weight(self) -> bool:
         """
         Check whether any of the node's weights is configurable.
+        
         Returns:
             Whether any of the node's weights is configurable.
         """

--- a/model_compression_toolkit/core/common/graph/base_node.py
+++ b/model_compression_toolkit/core/common/graph/base_node.py
@@ -170,7 +170,6 @@ class BaseNode:
     def has_any_configurable_weight(self) -> bool:
         """
         Check whether any of the node's weights is configurable.
-        
         Returns:
             Whether any of the node's weights is configurable.
         """

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_ru_helper.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_ru_helper.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import List, Set, Dict, Optional, Tuple, Any, Union
+from typing import List, Set, Dict, Tuple
 
 import numpy as np
 

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -24,7 +24,7 @@ from model_compression_toolkit.core.common.hessian import HessianInfoService
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import \
     MixedPrecisionSearchManager
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import \
-    ResourceUtilization, RUTarget
+    ResourceUtilization
 from model_compression_toolkit.core.common.mixed_precision.solution_refinement_procedure import \
     greedy_solution_refinement_procedure
 

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -13,24 +13,20 @@
 # limitations under the License.
 # ==============================================================================
 
-import copy
 from enum import Enum
-import numpy as np
-from typing import List, Callable, Dict
+from typing import List, Callable
 
 from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.common import Graph
-from model_compression_toolkit.core.common.hessian import HessianInfoService
-from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import ResourceUtilization, RUTarget
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
-from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import MixedPrecisionSearchManager
-from model_compression_toolkit.core.common.mixed_precision.search_methods.linear_programming import \
-    mp_integer_programming_search
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo
+from model_compression_toolkit.core.common.hessian import HessianInfoService
+from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import \
+    MixedPrecisionSearchManager
+from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import \
+    ResourceUtilization, RUTarget
 from model_compression_toolkit.core.common.mixed_precision.solution_refinement_procedure import \
     greedy_solution_refinement_procedure
-from model_compression_toolkit.core.common.substitutions.apply_substitutions import substitute
-from model_compression_toolkit.logger import Logger
 
 
 class BitWidthSearchMethod(Enum):

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -65,6 +65,8 @@ def search_bit_width(graph: Graph,
         bit-width index on the node).
 
     """
+    assert target_resource_utilization.is_any_restricted()
+
     # If we only run weights compression with MP than no need to consider activation quantization when computing the
     # MP metric (it adds noise to the computation)
     tru = target_resource_utilization

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 
 from tqdm import tqdm
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -199,7 +199,7 @@ class MixedPrecisionSearchManager:
 
         return layer_to_metrics_mapping
 
-    def _get_mp_graph(self, graph, target_resource_utilization):
+    def _get_mp_graph(self, graph: Graph, target_resource_utilization: ResourceUtilization) -> Tuple[Graph, bool]:
         """
         Get graph for mixed precision search. Virtual graph is built if bops is restricted and both activation and
         weights are configurable.
@@ -209,7 +209,8 @@ class MixedPrecisionSearchManager:
             target_resource_utilization: target resource utilization.
 
         Returns:
-            Graph for mixed precision search (virtual or original).
+            Graph for mixed precision search (virtual or original), and a boolean flag whether a virtual graph has been
+            constructed.
         """
         if (target_resource_utilization.bops_restricted() and
                 graph.has_any_configurable_activation() and

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
@@ -85,7 +85,6 @@ class MixedPrecisionSearchManager:
         self.min_ru_config = self.mp_graph.get_min_candidates_config(fw_info)
         self.max_ru_config = self.mp_graph.get_max_candidates_config(fw_info)
         self.min_ru = self.ru_helper.compute_utilization(self.ru_targets_to_compute, self.min_ru_config)
-        self.non_conf_ru_dict = self.ru_helper.compute_utilization(self.ru_targets_to_compute, None)
 
         self.config_reconstruction_helper = ConfigReconstructionHelper(virtual_graph=self.mp_graph,
                                                                        original_graph=self.original_graph)

--- a/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization.py
+++ b/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization.py
@@ -51,25 +51,34 @@ class ResourceUtilization:
     bops: float = np.inf
 
     def weight_restricted(self):
-        return self.weights_memory < np.inf
+        return self._is_restricted(self.weights_memory)
 
     def activation_restricted(self):
-        return self.activation_memory < np.inf
+        return self._is_restricted(self.activation_memory)
 
     def total_mem_restricted(self):
-        return self.total_memory < np.inf
+        return self._is_restricted(self.total_memory)
 
     def bops_restricted(self):
-        return self.bops < np.inf
+        return self._is_restricted(self.bops)
 
-    def get_resource_utilization_dict(self) -> Dict[RUTarget, float]:
+    def get_resource_utilization_dict(self, restricted_only: bool = False) -> Dict[RUTarget, float]:
         """
-        Returns: a dictionary with the ResourceUtilization object's values for each resource utilization target.
+        Get resource utilization as a dictionary.
+
+        Args:
+            restricted_only: whether to include only targets with restricted utilization.
+
+        Returns:
+            A dictionary containing the resource utilization with targets as keys.
         """
-        return {RUTarget.WEIGHTS: self.weights_memory,
-                RUTarget.ACTIVATION: self.activation_memory,
-                RUTarget.TOTAL: self.total_memory,
-                RUTarget.BOPS: self.bops}
+        ru_dict = {RUTarget.WEIGHTS: self.weights_memory,
+                   RUTarget.ACTIVATION: self.activation_memory,
+                   RUTarget.TOTAL: self.total_memory,
+                   RUTarget.BOPS: self.bops}
+        if restricted_only:
+            ru_dict = {k: v for k, v in ru_dict.items() if self._is_restricted(v)}
+        return ru_dict
 
     def is_satisfied_by(self, ru: 'ResourceUtilization') -> bool:
         """
@@ -114,3 +123,6 @@ class ResourceUtilization:
         if RUTarget.BOPS in targets:
             summary.append(f"BOPS: {self.bops}")
         return ', '.join(summary)
+
+    def _is_restricted(self, v):
+        return v < np.inf

--- a/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization_calculator.py
+++ b/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization_calculator.py
@@ -431,8 +431,7 @@ class ResourceUtilizationCalculator:
         Returns:
             Node's activation utilization.
         """
-        if qc and bitwidth_mode != BitwidthMode.QCustom:
-            raise ValueError(self.unexpected_qc_error)
+        self._validate_custom_qcs(qc, bitwidth_mode)
 
         if target_criterion:
             # only check whether the node meets the criterion
@@ -470,9 +469,6 @@ class ResourceUtilizationCalculator:
             - Total BOPS count of the network.
             - Detailed BOPS count per node.
         """
-        self._validate_custom_qcs(act_qcs, bitwidth_mode)
-        self._validate_custom_qcs(w_qcs, bitwidth_mode)
-
         nodes_bops = {}
         for n in self.graph.get_topo_sorted_nodes():
             w_qc = w_qcs.get(n.name) if w_qcs else None

--- a/model_compression_toolkit/core/common/mixed_precision/search_methods/linear_programming.py
+++ b/model_compression_toolkit/core/common/mixed_precision/search_methods/linear_programming.py
@@ -162,8 +162,7 @@ def _formalize_problem(layer_to_indicator_vars_mapping: Dict[int, Dict[int, LpVa
         _add_ru_constraints(search_manager=search_manager,
                             target_resource_utilization=target_resource_utilization,
                             indicators_matrix=indicators_matrix,
-                            lp_problem=lp_problem,
-                            non_conf_ru_dict=search_manager.non_conf_ru_dict)
+                            lp_problem=lp_problem)
     else:  # pragma: no cover
         Logger.critical("Unable to execute mixed-precision search: 'target_resource_utilization' is None. "
                         "A valid 'target_resource_utilization' is required.")
@@ -173,8 +172,7 @@ def _formalize_problem(layer_to_indicator_vars_mapping: Dict[int, Dict[int, LpVa
 def _add_ru_constraints(search_manager: MixedPrecisionSearchManager,
                         target_resource_utilization: ResourceUtilization,
                         indicators_matrix: np.ndarray,
-                        lp_problem: LpProblem,
-                        non_conf_ru_dict: Dict[RUTarget, np.ndarray]):
+                        lp_problem: LpProblem):
     """
     Adding targets constraints for the Lp problem for the given target resource utilization.
     The update to the Lp problem object is done inplace.
@@ -184,7 +182,6 @@ def _add_ru_constraints(search_manager: MixedPrecisionSearchManager,
         target_resource_utilization: Target resource utilization.
         indicators_matrix: A diagonal matrix of the Lp problem's indicators.
         lp_problem: An Lp problem object to add constraint to.
-        non_conf_ru_dict: A non-configurable nodes' resource utilization vectors for the constrained targets.
     """
     ru_indicated_vectors = {}
     # targets to add constraints for
@@ -203,11 +200,6 @@ def _add_ru_constraints(search_manager: MixedPrecisionSearchManager,
         # that would be required if that configuration is selected).
         # Each element in a vector is an lp object representing the configurations sum term for a memory element.
         ru_vec = indicated_ru_matrix.sum(axis=1) + search_manager.min_ru[target]
-
-        non_conf_ru_vec = non_conf_ru_dict[target]
-        if non_conf_ru_vec is not None and non_conf_ru_vec.size:
-            # add non-conf value as additional mem elements so that they get aggregated
-            ru_vec = np.concatenate([ru_vec, non_conf_ru_vec])
         ru_indicated_vectors[target] = ru_vec
 
     # Add constraints only for the restricted targets in target resource utilization.

--- a/model_compression_toolkit/core/common/mixed_precision/search_methods/linear_programming.py
+++ b/model_compression_toolkit/core/common/mixed_precision/search_methods/linear_programming.py
@@ -12,198 +12,146 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 import numpy as np
 from pulp import *
-from typing import Dict, Tuple, Any
+from typing import Dict, Tuple
 
-from model_compression_toolkit.logger import Logger
-from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import ResourceUtilization, RUTarget
-from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import MixedPrecisionSearchManager
+from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import RUTarget
 
 # Limit ILP solver runtime in seconds
 SOLVER_TIME_LIMIT = 60
 
 
-def mp_integer_programming_search(search_manager: MixedPrecisionSearchManager,
-                                  target_resource_utilization: ResourceUtilization) -> List[int]:
+class MixedPrecisionIntegerLPSolver:
+    """ Integer Linear Programming solver for Mixed Precision.
+
+        Args:
+            layer_to_sensitivity_mapping: sensitivity per candidate per layer.
+            candidates_ru: resource utilization per candidate.
+            ru_constraints: resource utilization constraints corresponding to 'candidates_ru'.
     """
-    Searching and returning a mixed-precision configuration using an ILP optimization solution.
-    It first builds a mapping from each layer's index (in the model) to a dictionary that maps the
-    bitwidth index to the observed sensitivity of the model when using that bitwidth for that layer.
-    Then, it creates a mapping from each node's index (in the graph) to a dictionary
-    that maps the bitwidth index to the contribution of configuring this node with this
-    bitwidth to the minimal possible resource utilization of the model.
-    Then, and using these mappings, it builds an LP problem and finds an optimal solution.
-    If a solution could not be found, exception is thrown.
+    def __init__(self, layer_to_sensitivity_mapping: Dict[int, Dict[int, float]],
+                 candidates_ru: Dict[RUTarget, np.ndarray],
+                 ru_constraints: Dict[RUTarget, np.ndarray]):
+        self.layer_to_sensitivity_mapping = layer_to_sensitivity_mapping
+        self.candidates_ru = candidates_ru
+        self.ru_constraints = ru_constraints
 
-    Args:
-        search_manager: MixedPrecisionSearchManager object to be used for problem formalization.
-        target_resource_utilization: Target resource utilization to constrain our LP problem with some resources limitations (like model' weights memory
-        consumption).
+        self.layer_to_indicator_vars_mapping, self.layer_to_objective_vars_mapping = (
+            self._init_problem_vars(layer_to_sensitivity_mapping))
 
-    Returns:
-        The mixed-precision configuration (A list of indices. Each indicates the bitwidth index of a node).
+    def run(self) -> List[int]:
+        """
+        Build and solve an ILP optimization problem.
 
-    """
+        Returns:
+            The mixed-precision configuration (A list of indices. Each indicates the bitwidth index of a node).
 
-    # Build a mapping from each layer's index (in the model) to a dictionary that maps the
-    # bitwidth index to the observed sensitivity of the model when using that bitwidth for that layer.
+        """
+        # Add all equations and inequalities that define the problem.
+        lp_problem = self._formalize_problem()
 
-    layer_to_sensitivity_mapping = search_manager.build_sensitivity_mapping()
+        # Use default PULP solver. Limit runtime in seconds
+        solver = PULP_CBC_CMD(timeLimit=SOLVER_TIME_LIMIT)
+        lp_problem.solve(solver=solver)  # Try to solve the problem.
 
-    # Init variables to find their values when solving the lp problem.
-    layer_to_indicator_vars_mapping, layer_to_objective_vars_mapping = _init_problem_vars(layer_to_sensitivity_mapping)
+        if lp_problem.status != LpStatusOptimal:
+            raise RuntimeError(f'No solution was found for the LP problem, with status {lp_problem.status}')
 
-    # Add all equations and inequalities that define the problem.
-    lp_problem = _formalize_problem(layer_to_indicator_vars_mapping,
-                                    layer_to_sensitivity_mapping,
-                                    layer_to_objective_vars_mapping,
-                                    target_resource_utilization,
-                                    search_manager)
+        # Take the bitwidth index only if its corresponding indicator is one.
+        config = np.asarray(
+            [[nbits for nbits, indicator in nbits_to_indicator.items() if indicator.varValue == 1.0] for
+             nbits_to_indicator
+             in self.layer_to_indicator_vars_mapping.values()]
+        ).flatten()
 
-    # Use default PULP solver. Limit runtime in seconds
-    solver = PULP_CBC_CMD(timeLimit=SOLVER_TIME_LIMIT)
-    lp_problem.solve(solver=solver)  # Try to solve the problem.
+        return config.tolist()
 
-    assert lp_problem.status == LpStatusOptimal, Logger.critical(
-        "No solution was found during solving the LP problem")
-    Logger.info(f"ILP status: {LpStatus[lp_problem.status]}")
+    @staticmethod
+    def _init_problem_vars(layer_to_metrics_mapping: Dict[int, Dict[int, float]]) -> Tuple[
+        Dict[int, Dict[int, LpVariable]], Dict[int, LpVariable]]:
+        """
+        Initialize the LP problem variables: Variable for each layer as to the index of the bitwidth it should use,
+        and a variable for each indicator for whether we use the former variable or not.
 
-    # Take the bitwidth index only if its corresponding indicator is one.
-    config = np.asarray(
-        [[nbits for nbits, indicator in nbits_to_indicator.items() if indicator.varValue == 1.0] for
-         nbits_to_indicator
-         in layer_to_indicator_vars_mapping.values()]
-    ).flatten()
+        Args:
+            layer_to_metrics_mapping: Mapping from each layer's index (in the model) to a dictionary that maps the
+            bitwidth index to the observed sensitivity of the model.
 
-    return config.tolist()
+        Returns:
+            A tuple of two dictionaries: One from a layer to the variable for the bitwidth problem,
+            and the second for indicators for each variable.
+        """
 
+        layer_to_indicator_vars_mapping = dict()
+        layer_to_objective_vars_mapping = dict()
 
-def _init_problem_vars(layer_to_metrics_mapping: Dict[int, Dict[int, float]]) -> Tuple[
-    Dict[int, Dict[int, LpVariable]], Dict[int, LpVariable]]:
-    """
-    Initialize the LP problem variables: Variable for each layer as to the index of the bitwidth it should use,
-    and a variable for each indicator for whether we use the former variable or not.
+        for layer, nbits_to_metric in layer_to_metrics_mapping.items():
+            layer_to_indicator_vars_mapping[layer] = dict()
 
-    Args:
-        layer_to_metrics_mapping: Mapping from each layer's index (in the model) to a dictionary that maps the
-        bitwidth index to the observed sensitivity of the model.
+            for nbits in nbits_to_metric.keys():
+                layer_to_indicator_vars_mapping[layer][nbits] = LpVariable(f"layer_{layer}_{nbits}",
+                                                                           lowBound=0,
+                                                                           upBound=1,
+                                                                           cat=LpInteger)
 
-    Returns:
-        A tuple of two dictionaries: One from a layer to the variable for the bitwidth problem,
-        and the second for indicators for each variable.
-    """
+            layer_to_objective_vars_mapping[layer] = LpVariable(f"s_{layer}", 0)
 
-    layer_to_indicator_vars_mapping = dict()
-    layer_to_objective_vars_mapping = dict()
+        return layer_to_indicator_vars_mapping, layer_to_objective_vars_mapping
 
-    for layer, nbits_to_metric in layer_to_metrics_mapping.items():
-        layer_to_indicator_vars_mapping[layer] = dict()
+    def _formalize_problem(self) -> LpProblem:
+        """
+        Formalize the LP problem by defining all inequalities that define the solution space.
 
-        for nbits in nbits_to_metric.keys():
-            layer_to_indicator_vars_mapping[layer][nbits] = LpVariable(f"layer_{layer}_{nbits}",
-                                                                       lowBound=0,
-                                                                       upBound=1,
-                                                                       cat=LpInteger)
+        Returns:
+            The formalized LP problem.
+        """
 
-        layer_to_objective_vars_mapping[layer] = LpVariable(f"s_{layer}", 0)
+        lp_problem = LpProblem()  # minimization problem by default
+        lp_problem += lpSum([self.layer_to_objective_vars_mapping[layer] for layer in
+                             self.layer_to_sensitivity_mapping.keys()])  # Objective (minimize acc loss)
 
-    return layer_to_indicator_vars_mapping, layer_to_objective_vars_mapping
+        for layer in self.layer_to_sensitivity_mapping.keys():
+            # Use every bitwidth for every layer with its indicator.
+            lp_problem += lpSum([indicator * self.layer_to_sensitivity_mapping[layer][nbits]
+                                 for nbits, indicator in self.layer_to_indicator_vars_mapping[layer].items()]) == \
+                          self.layer_to_objective_vars_mapping[layer]
 
+            # Constraint of only one indicator==1
+            lp_problem += lpSum(
+                [v for v in self.layer_to_indicator_vars_mapping[layer].values()]) == 1
 
-def _formalize_problem(layer_to_indicator_vars_mapping: Dict[int, Dict[int, LpVariable]],
-                       layer_to_metrics_mapping: Dict[int, Dict[int, float]],
-                       layer_to_objective_vars_mapping: Dict[int, LpVariable],
-                       target_resource_utilization: ResourceUtilization,
-                       search_manager: MixedPrecisionSearchManager) -> LpProblem:
-    """
-    Formalize the LP problem by defining all inequalities that define the solution space.
+        # Bound the feasible solution space with the desired resource utilization values.
+        self._add_ru_constraints(lp_problem=lp_problem)
 
-    Args:
-        layer_to_indicator_vars_mapping: Dictionary that maps each node's index to a dictionary of bitwidth to
-        indicator variable.
-        layer_to_metrics_mapping: Dictionary that maps each node's index to a dictionary of bitwidth to sensitivity
-        evaluation.
-        layer_to_objective_vars_mapping: Dictionary that maps each node's index to a bitwidth variable we find its
-        value.
-        target_resource_utilization: Target resource utilization to reduce our feasible solution space.
-        search_manager: MixedPrecisionSearchManager object to be used for resource utilization constraints formalization.
+        return lp_problem
 
-    Returns:
-        The formalized LP problem.
-    """
+    def _add_ru_constraints(self, lp_problem: LpProblem):
+        """
+        Adding targets constraints for the Lp problem for the given target resource utilization.
+        The update to the Lp problem object is done inplace.
 
-    lp_problem = LpProblem()  # minimization problem by default
-    lp_problem += lpSum([layer_to_objective_vars_mapping[layer] for layer in
-                         layer_to_metrics_mapping.keys()])  # Objective (minimize acc loss)
+        Args:
+            lp_problem: An Lp problem object to add constraint to.
+        """
+        indicators = []
+        for layer in self.layer_to_sensitivity_mapping:
+            indicators.extend(list(self.layer_to_indicator_vars_mapping[layer].values()))
+        indicators_vec = np.array(indicators)
 
-    for layer in layer_to_metrics_mapping.keys():
-        # Use every bitwidth for every layer with its indicator.
-        lp_problem += lpSum([indicator * layer_to_metrics_mapping[layer][nbits]
-                             for nbits, indicator in layer_to_indicator_vars_mapping[layer].items()]) == \
-                      layer_to_objective_vars_mapping[layer]
+        for target, ru_matrix in self.candidates_ru.items():
+            # We expect 2d matrix of shape (num candidates, m). For cumulative metrics (weights, bops) m=1 - overall
+            # utilization. For max metrics (activation, total) m=num memory elements (max element depends on configuration)
+            assert ru_matrix.ndim == 2
+            if target in [RUTarget.WEIGHTS, RUTarget.BOPS]:
+                assert ru_matrix.shape[1] == 1
 
-        # Constraint of only one indicator==1
-        lp_problem += lpSum(
-            [v for v in layer_to_indicator_vars_mapping[layer].values()]) == 1
+            indicated_ru_matrix = ru_matrix.T * indicators_vec
+            # build lp sum term over all candidates
+            ru_vec = indicated_ru_matrix.sum(axis=1)
 
-    # Bound the feasible solution space with the desired resource utilization values.
-    # Creates separate constraints for weights utilization and activation utilization.
-    assert target_resource_utilization and target_resource_utilization.is_any_restricted()
-
-    indicators = []
-    for layer in layer_to_metrics_mapping.keys():
-        for _, indicator in layer_to_indicator_vars_mapping[layer].items():
-            indicators.append(indicator)
-
-    indicators_vec = np.array(indicators)
-
-    _add_ru_constraints(search_manager=search_manager,
-                        target_resource_utilization=target_resource_utilization,
-                        indicators_vec=indicators_vec,
-                        lp_problem=lp_problem)
-    return lp_problem
-
-
-def _add_ru_constraints(search_manager: MixedPrecisionSearchManager,
-                        target_resource_utilization: ResourceUtilization,
-                        indicators_vec: np.ndarray,
-                        lp_problem: LpProblem):
-    """
-    Adding targets constraints for the Lp problem for the given target resource utilization.
-    The update to the Lp problem object is done inplace.
-
-    Args:
-        search_manager:  MixedPrecisionSearchManager object to be used for resource utilization constraints formalization.
-        target_resource_utilization: Target resource utilization.
-        indicators_vec: A vector of the Lp problem's indicators.
-        lp_problem: An Lp problem object to add constraint to.
-    """
-    candidates_ru = search_manager.compute_resource_utilization_matrices()
-    min_ru = search_manager.min_ru
-    target_ru = target_resource_utilization.get_resource_utilization_dict(restricted_only=True)
-    assert candidates_ru.keys() == target_ru.keys()
-
-    for target, ru_matrix in candidates_ru.items():
-        # We expect 2d matrix of shape (num candidates, m). For cumulative metrics (weights, bops) m=1 - overall
-        # utilization. For max metrics (activation, total) m=num memory elements (max element depends on configuration)
-        assert ru_matrix.ndim == 2
-        if target in [RUTarget.WEIGHTS, RUTarget.BOPS]:
-            assert ru_matrix.shape[1] == 1
-
-        # ru values are relative to the minimal configuration, so we adjust the target ru accordingly
-        ru_constraint = target_ru[target] - min_ru[target]
-        if any(ru_constraint < 0):
-            raise ValueError(f"The model cannot be quantized to meet the specified target resource utilization "
-                             f"{target.value} with the value {target_ru[target]}.")
-
-        indicated_ru_matrix = ru_matrix.T * indicators_vec
-        # build lp sum term over all candidates
-        ru_vec = indicated_ru_matrix.sum(axis=1)
-
-        # For cumulative metrics a single constraint is added, for max metrics a separate constraint
-        # is added for each memory element (each element < target => max element < target).
-        assert len(ru_vec) == len(ru_constraint)
-        for v, c in zip(ru_vec, ru_constraint):
-            lp_problem += v <= c
+            # For cumulative metrics a single constraint is added, for max metrics a separate constraint
+            # is added for each memory element (each element < target => max element < target).
+            assert len(ru_vec) == len(self.ru_constraints[target])
+            for v, c in zip(ru_vec, self.ru_constraints[target]):
+                lp_problem += v <= c

--- a/model_compression_toolkit/core/common/mixed_precision/solution_refinement_procedure.py
+++ b/model_compression_toolkit/core/common/mixed_precision/solution_refinement_procedure.py
@@ -63,7 +63,7 @@ def greedy_solution_refinement_procedure(mp_solution: List[int],
                 # layer has max config in the given solution, nothing to optimize
                 continue
 
-            current_node = search_manager.graph.get_configurable_sorted_nodes(search_manager.fw_info)[node_idx]
+            current_node = search_manager.mp_topo_configurable_nodes[node_idx]
             node_candidates = current_node.candidates_quantization_cfg
 
             # only weights kernel attribute is quantized with weights mixed precision

--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
@@ -306,7 +306,7 @@ class QATWrappersMixedPrecisionCfgTest(MixedPrecisionActivationBaseTest):
 
         self.compare(qat_ready_model, quantization_info)
 
-    def _compare(self, qat_ready_model, quantization_info):
+    def compare(self, qat_ready_model, quantization_info):
 
         self.unit_test.assertTrue(quantization_info.mixed_precision_cfg == self.expected_mp_cfg)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
@@ -306,9 +306,9 @@ class QATWrappersMixedPrecisionCfgTest(MixedPrecisionActivationBaseTest):
 
         self.compare(qat_ready_model, quantization_info)
 
-    def compare(self, qat_ready_model, quantization_info):
+    def _compare(self, qat_ready_model, quantization_info):
 
-        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == self.expected_mp_cfg))
+        self.unit_test.assertTrue(quantization_info.mixed_precision_cfg == self.expected_mp_cfg)
 
         # check that quantizer gets multiple bits configuration
         for layer in qat_ready_model.layers:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/weights_mixed_precision_tests.py
@@ -259,7 +259,7 @@ class MixedPrecisionSearch4BitsAvgTest(MixedPrecisionBaseTest):
 
     def _compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
-        assert (quantization_info.mixed_precision_cfg == [1, 1]).all()
+        assert quantization_info.mixed_precision_cfg == [1, 1]
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
                 np.unique(conv_layers[0].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 16)
@@ -300,7 +300,7 @@ class MixedPrecisionCombinedNMSTest(MixedPrecisionBaseTest):
 
     def _compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
-        self.unit_test.assertTrue((quantization_info.mixed_precision_cfg != 0).any())
+        self.unit_test.assertTrue(any(i for i in quantization_info.mixed_precision_cfg))
 
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
@@ -325,7 +325,7 @@ class MixedPrecisionSearch2BitsAvgTest(MixedPrecisionBaseTest):
 
     def _compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
-        assert (quantization_info.mixed_precision_cfg == [2, 2]).all()
+        assert quantization_info.mixed_precision_cfg == [2, 2]
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
                 np.unique(conv_layers[0].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 4)
@@ -443,7 +443,7 @@ class MixedPrecisionActivationDisabled(MixedPrecisionBaseTest):
 
     def _compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
-        assert (quantization_info.mixed_precision_cfg == [0, 1]).all()
+        assert quantization_info.mixed_precision_cfg == [0, 1]
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
                 np.unique(conv_layers[0].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)
@@ -466,8 +466,8 @@ class MixedPrecisionSearchLastLayerDistanceTest(MixedPrecisionBaseTest):
 
     def _compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         conv_layers = get_layers_from_model_by_type(quantized_model, layers.Conv2D)
-        assert any([(quantization_info.mixed_precision_cfg == [1, 0]).all(),
-                    (quantization_info.mixed_precision_cfg == [0, 1]).all()])
+        assert any([quantization_info.mixed_precision_cfg == [1, 0],
+                    quantization_info.mixed_precision_cfg == [0, 1]])
         for i in range(32):  # quantized per channel
             self.unit_test.assertTrue(
                 np.unique(conv_layers[0].get_quantized_weights()['kernel'][:, :, :, i]).flatten().shape[0] <= 256)

--- a/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from unittest.mock import Mock
+
 import numpy as np
 import unittest
 
 import keras
 from model_compression_toolkit.core import DEFAULTCONFIG
 from model_compression_toolkit.core.common.mixed_precision.distance_weighting import MpDistanceWeighting
+from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import \
+    MixedPrecisionSearchManager
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import \
     ResourceUtilization, RUTarget
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
@@ -57,32 +61,31 @@ class MockReconstructionHelper:
 
 
 class MockMixedPrecisionSearchManager:
-    def __init__(self, layer_to_ru_mapping):
+    def __init__(self, layer_to_ru_mapping, ru_targets):
+        self.ru_targets = ru_targets
         self.layer_to_bitwidth_mapping = {0: [0, 1, 2]}
         self.layer_to_ru_mapping = layer_to_ru_mapping
-        self.compute_metric_fn = lambda x, y=None, z=None: {0: 2, 1: 1, 2: 0}[x[0]]
-        self.min_ru = {RUTarget.WEIGHTS: [1],
-                       RUTarget.ACTIVATION: [1],
-                       RUTarget.BOPS: [1]}  # minimal resource utilization in the tests layer_to_ru_mapping
+        self.min_ru = {t: np.array([1]) for t in ru_targets} # minimal resource utilization in the tests layer_to_ru_mapping
 
         self.max_ru_config = [0]
         self.config_reconstruction_helper = MockReconstructionHelper()
-        self.non_conf_ru_dict = {RUTarget.WEIGHTS: None, RUTarget.ACTIVATION: None, RUTarget.BOPS: None}
 
-    def compute_resource_utilization_matrix(self, target):
+    def build_sensitivity_mapping(self):
+        return {0: {0: 0, 1: 1, 2: 2}}
+
+    def compute_resource_utilization_matrices(self):
         # minus 1 is normalization by the minimal resource utilization (which is always 1 in this test)
-        if target == RUTarget.WEIGHTS:
-            ru_matrix = [np.flip(np.array([ru.weights_memory - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))]
-        elif target == RUTarget.ACTIVATION:
-            ru_matrix = [np.flip(np.array([ru.activation_memory - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))]
-        elif target == RUTarget.BOPS:
-            ru_matrix = [np.flip(np.array([ru.bops - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))]
-        else:
-            raise ValueError('Not supposed to get here')
-        return np.array(ru_matrix).T
-
-    def finalize_distance_metric(self, d):
-        return d
+        ru = {
+            RUTarget.WEIGHTS:
+                [np.flip(np.array([ru.weights_memory - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))],
+            RUTarget.ACTIVATION:
+                [np.flip(np.array([ru.activation_memory - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))],
+            RUTarget.BOPS:
+                [np.flip(np.array([ru.bops - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))],
+            RUTarget.TOTAL:
+                [np.flip(np.array([ru.total_memory - 1 for _, ru in self.layer_to_ru_mapping[0].items()]))]
+        }
+        return {k: np.array(v).T for k, v in ru.items() if k in self.ru_targets}
 
 
 class TestLpSearchBitwidth(unittest.TestCase):
@@ -92,7 +95,7 @@ class TestLpSearchBitwidth(unittest.TestCase):
         layer_to_ru_mapping = {0: {2: ResourceUtilization(weights_memory=1),
                                    1: ResourceUtilization(weights_memory=2),
                                    0: ResourceUtilization(weights_memory=3)}}
-        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping)
+        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping, {RUTarget.WEIGHTS})
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
                                                 target_resource_utilization=target_resource_utilization)
@@ -106,42 +109,26 @@ class TestLpSearchBitwidth(unittest.TestCase):
                                                     target_resource_utilization=target_resource_utilization)
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
-                                                target_resource_utilization=ResourceUtilization(weights_memory=np.inf))
+                                                target_resource_utilization=ResourceUtilization(weights_memory=1000))
 
         self.assertTrue(len(bit_cfg) == 1)
-        self.assertTrue(bit_cfg[0] == 0)  # ResourceUtilization is Inf so expecting for the maximal bit-width result
+        self.assertTrue(bit_cfg[0] == 0)  # expecting for the maximal bit-width result
 
         target_resource_utilization = None  # target ResourceUtilization is not defined!
         with self.assertRaises(Exception):
-            bit_cfg = mp_integer_programming_search(mock_search_manager,
-                                                    target_resource_utilization=target_resource_utilization)
+            mp_integer_programming_search(mock_search_manager,
+                                          target_resource_utilization=target_resource_utilization)
 
-    def test_search_weights_only_with_non_conf(self):
-        target_resource_utilization = ResourceUtilization(weights_memory=2+11)
-        layer_to_ru_mapping = {0: {2: ResourceUtilization(weights_memory=1),
-                                   1: ResourceUtilization(weights_memory=2),
-                                   0: ResourceUtilization(weights_memory=3)}
-                               }
-        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping)
-        mock_search_manager.non_conf_ru_dict = {RUTarget.WEIGHTS: np.array([5, 6])}
-        bit_cfg = mp_integer_programming_search(mock_search_manager,
-                                                target_resource_utilization=target_resource_utilization)
-
-        self.assertTrue(len(bit_cfg) == 1)
-        self.assertTrue(bit_cfg[0] == 1)
-
-        # make sure non_conf was taken into account and lower target has a different solution
-        target_resource_utilization = ResourceUtilization(weights_memory=2 + 10.9)
-        bit_cfg = mp_integer_programming_search(mock_search_manager,
-                                                target_resource_utilization=target_resource_utilization)
-        self.assertFalse(bit_cfg[0] == 1)
+        with self.assertRaises(Exception):
+            mp_integer_programming_search(mock_search_manager,
+                                          target_resource_utilization=ResourceUtilization(weights_memory=np.inf))
 
     def test_search_activation_only(self):
         target_resource_utilization = ResourceUtilization(activation_memory=2)
         layer_to_ru_mapping = {0: {2: ResourceUtilization(activation_memory=1),
                                    1: ResourceUtilization(activation_memory=2),
                                    0: ResourceUtilization(activation_memory=3)}}
-        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping)
+        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping, {RUTarget.ACTIVATION})
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
                                                 target_resource_utilization=target_resource_utilization)
@@ -156,17 +143,17 @@ class TestLpSearchBitwidth(unittest.TestCase):
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
                                                 target_resource_utilization=ResourceUtilization(
-                                                    activation_memory=np.inf))
+                                                    activation_memory=1000))
 
         self.assertTrue(len(bit_cfg) == 1)
-        self.assertTrue(bit_cfg[0] == 0)  # ResourceUtilization is Inf so expecting for the maximal bit-width result
+        self.assertTrue(bit_cfg[0] == 0)  # expecting for the maximal bit-width result
 
     def test_search_weights_and_activation(self):
         target_resource_utilization = ResourceUtilization(weights_memory=2, activation_memory=2)
         layer_to_ru_mapping = {0: {2: ResourceUtilization(weights_memory=1, activation_memory=1),
                                    1: ResourceUtilization(weights_memory=2, activation_memory=2),
                                    0: ResourceUtilization(weights_memory=3, activation_memory=3)}}
-        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping)
+        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping, {RUTarget.WEIGHTS, RUTarget.ACTIVATION})
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
                                                 target_resource_utilization=target_resource_utilization)
@@ -180,18 +167,18 @@ class TestLpSearchBitwidth(unittest.TestCase):
                                                     target_resource_utilization=target_resource_utilization)
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
-                                                target_resource_utilization=ResourceUtilization(weights_memory=np.inf,
-                                                                                                activation_memory=np.inf))
+                                                target_resource_utilization=ResourceUtilization(weights_memory=1000,
+                                                                                                activation_memory=1000))
 
         self.assertTrue(len(bit_cfg) == 1)
-        self.assertTrue(bit_cfg[0] == 0)  # ResourceUtilization is Inf so expecting for the maximal bit-width result
+        self.assertTrue(bit_cfg[0] == 0)  # expecting for the maximal bit-width result
 
     def test_search_total_resource_utilization(self):
         target_resource_utilization = ResourceUtilization(total_memory=4)
-        layer_to_ru_mapping = {0: {2: ResourceUtilization(weights_memory=1, activation_memory=1),
-                                   1: ResourceUtilization(weights_memory=2, activation_memory=2),
-                                   0: ResourceUtilization(weights_memory=3, activation_memory=3)}}
-        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping)
+        layer_to_ru_mapping = {0: {2: ResourceUtilization(weights_memory=1, activation_memory=1, total_memory=2),
+                                   1: ResourceUtilization(weights_memory=2, activation_memory=2, total_memory=4),
+                                   0: ResourceUtilization(weights_memory=3, activation_memory=3, total_memory=6)}}
+        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping, {RUTarget.TOTAL})
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
                                                 target_resource_utilization=target_resource_utilization)
@@ -204,7 +191,7 @@ class TestLpSearchBitwidth(unittest.TestCase):
         layer_to_ru_mapping = {0: {2: ResourceUtilization(bops=1),
                                    1: ResourceUtilization(bops=2),
                                    0: ResourceUtilization(bops=3)}}
-        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping)
+        mock_search_manager = MockMixedPrecisionSearchManager(layer_to_ru_mapping, {RUTarget.BOPS})
 
         bit_cfg = mp_integer_programming_search(mock_search_manager,
                                                 target_resource_utilization=target_resource_utilization)
@@ -272,31 +259,13 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
                                              representative_data_gen,
                                              fw_info=fw_info)
 
-        cfg = search_bit_width(graph_to_search_cfg=graph,
+        cfg = search_bit_width(graph=graph,
                                fw_info=DEFAULT_KERAS_INFO,
                                fw_impl=keras_impl,
-                               target_resource_utilization=ResourceUtilization(np.inf),
+                               target_resource_utilization=ResourceUtilization(weights_memory=100),
                                mp_config=core_config.mixed_precision_config,
                                representative_data_gen=representative_data_gen,
                                search_method=BitWidthSearchMethod.INTEGER_PROGRAMMING)
-
-        with self.assertRaises(Exception):
-            cfg = search_bit_width(graph_to_search_cfg=graph,
-                                   fw_info=DEFAULT_KERAS_INFO,
-                                   fw_impl=keras_impl,
-                                   target_resource_utilization=ResourceUtilization(np.inf),
-                                   mp_config=core_config.mixed_precision_config,
-                                   representative_data_gen=representative_data_gen,
-                                   search_method=None)
-
-        with self.assertRaises(Exception):
-            cfg = search_bit_width(graph_to_search_cfg=graph,
-                                   fw_info=DEFAULT_KERAS_INFO,
-                                   fw_impl=keras_impl,
-                                   target_resource_utilization=None,
-                                   mp_config=core_config.mixed_precision_config,
-                                   representative_data_gen=representative_data_gen,
-                                   search_method=BitWidthSearchMethod.INTEGER_PROGRAMMING)
 
     def test_mixed_precision_search_facade(self):
         core_config_avg_weights = CoreConfig(quantization_config=DEFAULTCONFIG,

--- a/tests/keras_tests/non_parallel_tests/test_tensorboard_writer.py
+++ b/tests/keras_tests/non_parallel_tests/test_tensorboard_writer.py
@@ -162,7 +162,8 @@ class TestFileLogger(unittest.TestCase):
                                           fqc=fqc,
                                           network_editor=[],
                                           quant_config=cfg,
-                                          target_resource_utilization=mct.core.ResourceUtilization(),
+                                          target_resource_utilization=mct.core.ResourceUtilization(weights_memory=73,
+                                                                                                   activation_memory=191),
                                           n_iter=1,
                                           analyze_similarity=True,
                                           mp_cfg=mp_cfg)

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_activation_test.py
@@ -72,7 +72,7 @@ class MixedPrecisionActivationBaseTest(BasePytorchTest):
         raise NotImplementedError
 
     def verify_config(self, result_config, expected_config):
-        self.unit_test.assertTrue(all(result_config == expected_config),
+        self.unit_test.assertTrue(result_config == expected_config,
                                   f"Configuration mismatch: expected {expected_config} but got {result_config}.")
 
 

--- a/tests/pytorch_tests/model_tests/feature_models/mixed_precision_weights_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/mixed_precision_weights_test.py
@@ -335,7 +335,7 @@ class MixedPrecisionWeightsConfigurableActivations(MixedPrecisionBaseTest):
         return ResourceUtilization(80)
 
     def compare(self, quantized_models, float_model, input_x=None, quantization_info=None):
-        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == self.expected_config))
+        self.unit_test.assertTrue(quantization_info.mixed_precision_cfg == self.expected_config)
 
 
 class MixedPrecisionWeightsTestNet(torch.nn.Module):

--- a/tests/pytorch_tests/model_tests/feature_models/qat_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/qat_test.py
@@ -289,7 +289,7 @@ class QuantizationAwareTrainingMixedPrecisionCfgTest(QuantizationAwareTrainingTe
                      input_x=self.representative_data_gen(),
                      quantization_info=quantization_info)
 
-        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == [1, 0, 0, 1, 0]))
+        self.unit_test.assertTrue(quantization_info.mixed_precision_cfg == [1, 0, 0, 1, 0])
 
         # check that quantizer gets multiple bits configuration
         for _, layer in qat_ready_model.named_children():
@@ -336,7 +336,7 @@ class QuantizationAwareTrainingMixedPrecisionRUCfgTest(QuantizationAwareTraining
                      quantization_info=quantization_info)
 
         # check that MP search doesn't return 8 bits configuration for all layers
-        self.unit_test.assertTrue(all(quantization_info.mixed_precision_cfg == [1, 1, 0, 0, 0]))
+        self.unit_test.assertTrue(quantization_info.mixed_precision_cfg == [1, 1, 0, 0, 0])
 
         # check that quantizer gets multiple bits configuration
         for _, layer in qat_ready_model.named_children():

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_greedy_solution_refinement.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_greedy_solution_refinement.py
@@ -25,7 +25,7 @@ import copy
 @pytest.fixture
 def search_manager():
     manager = Mock()
-    manager.graph.get_configurable_sorted_nodes = MagicMock()
+    manager.mp_topo_configurable_nodes = MagicMock()
     manager.fw_info.get_kernel_op_attributes = MagicMock()
     manager.replace_config_in_index = MagicMock(
         side_effect=lambda config, idx, candidate: (
@@ -105,7 +105,7 @@ def test_greedy_solution_refinement_procedure(
     node_mock = Mock()
     node_mock.candidates_quantization_cfg = candidate_configs(weight_bits_dict_0, act_bits_0, weight_bits_dict_1, act_bits_1)
 
-    search_manager.graph.get_configurable_sorted_nodes.return_value = [node_mock]
+    search_manager.mp_topo_configurable_nodes = [node_mock]
 
     search_manager.compute_resource_utilization_for_config = MagicMock(side_effect=lambda config: {
         0: ResourceUtilization(**alternative_candidate_resources_usage),


### PR DESCRIPTION
## Pull Request Description:
- Simplify resource utilization constraints construction - compute total weights/bops directly instead of per node and aggregating at a later stage. Use RUCalculator to compute all targets at once and use the results directly. Remove separate computation for non-configurable nodes. Remove all intermediate methods per target and the double api for conf/non-conf which are no longer needed. Remove special hacky handling of total ru metric, which is now obtained automatically by RUCalculator along with the rest.
- Convert LP solver module functions into class, remove dependency on MPSearchManager, move all code that is not related to LP to MPSearchManager.
- Move more of MP search responsibility to MPSearchManager and make it the entry point for the search. The manager precomputes all metrics (sensitivity and ru) and uses LPSolver only for building and solving LP. Move virtual graph creation and restoring final config to MPSearchManager, and only create virtual graph for BOPS if both weights and activations are configurable (previously was created in any case of BOPS).
 

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).