### PR TITLE
Remove `pydantic<2.0` pin in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ matplotlib<3.10.0
 scipy
 protobuf
 mct-quantizers==1.5.2
-pydantic<2.0
+pydantic


### PR DESCRIPTION
Request to unpin this dependency as this is causing installation conflicts in the [Ultralytics package](https://github.com/ultralytics/ultralytics) when used with other export dependencies that require more recent versions of Pydantic.

I think the main changes may be needed in `model_compression_toolkit` here as this error shows when running IMX export using `model_compression_toolkit` with the latest `pydantic`:

```
# pip install ultralytics
$ yolo export format=imx model=yolov8n.pt

Downloading https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.pt to 'yolov8n.pt'...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6.25M/6.25M [00:00<00:00, 153MB/s]
Ultralytics 8.3.99 🚀 Python-3.11.10 torch-2.6.0+cpu CPU (AMD EPYC 7502 32-Core Processor)
WARNING ⚠️ IMX only supports int8 export, setting int8=True.
WARNING ⚠️ INT8 export requires a missing 'data' arg for calibration. Using default 'data=coco8.yaml'.
YOLOv8n summary (fused): 72 layers, 3,151,904 parameters, 0 gradients, 8.7 GFLOPs

PyTorch: starting from 'yolov8n.pt' with input shape (1, 3, 640, 640) BCHW and output shape(s) ((1, 8400, 4), (1, 8400, 80)) (6.2 MB)
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1743514794.166912      60 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1743514794.173526      60 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
W0000 00:00:1743514794.190136      60 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1743514794.190156      60 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1743514794.190160      60 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1743514794.190164      60 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
IMX: export failure ❌ 8.7s: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.

For further information visit https://errors.pydantic.dev/2.11/u/root-validator-pre-skip
Traceback (most recent call last):
  File "/usr/local/bin/yolo", line 10, in <module>
    sys.exit(entrypoint())
             ^^^^^^^^^^^^
  File "/ultralytics/ultralytics/cfg/__init__.py", line 987, in entrypoint
    getattr(model, mode)(**overrides)  # default args from model
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ultralytics/ultralytics/engine/model.py", line 728, in export
    return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ultralytics/ultralytics/engine/exporter.py", line 458, in __call__
    f[13], _ = self.export_imx()
               ^^^^^^^^^^^^^^^^^
  File "/ultralytics/ultralytics/engine/exporter.py", line 182, in outer_func
    raise e
  File "/ultralytics/ultralytics/engine/exporter.py", line 177, in outer_func
    f, model = inner_func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ultralytics/ultralytics/engine/exporter.py", line 1230, in export_imx
    import model_compression_toolkit as mct
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/__init__.py", line 17, in <module>
    from model_compression_toolkit import target_platform_capabilities
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/__init__.py", line 16, in <module>
    from model_compression_toolkit.target_platform_capabilities.targetplatform2framework.attribute_filter import AttributeFilter
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/targetplatform2framework/__init__.py", line 17, in <module>
    from model_compression_toolkit.target_platform_capabilities.targetplatform2framework.framework_quantization_capabilities import FrameworkQuantizationCapabilities
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/targetplatform2framework/framework_quantization_capabilities.py", line 22, in <module>
    from model_compression_toolkit.target_platform_capabilities.schema.schema_functions import \
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/schema/schema_functions.py", line 18, in <module>
    from model_compression_toolkit.target_platform_capabilities.schema.mct_current_schema import OpQuantizationConfig, \
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/schema/mct_current_schema.py", line 1, in <module>
    import model_compression_toolkit.target_platform_capabilities.schema.v1 as schema
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/schema/v1.py", line 515, in <module>
    class Fusing(TargetPlatformModelComponent):
  File "/usr/local/lib/python3.11/site-packages/model_compression_toolkit/target_platform_capabilities/schema/v1.py", line 558, in Fusing
    @root_validator(allow_reuse=True)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pydantic/deprecated/class_validators.py", line 240, in root_validator
    raise PydanticUserError(
pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.
```





## Pull Request Description:


## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).