### PR TITLE
Fix error message formatting in configuration validation

### DIFF
--- a/model_compression_toolkit/gptq/common/gptq_config.py
+++ b/model_compression_toolkit/gptq/common/gptq_config.py
@@ -84,7 +84,7 @@ class QFractionLinearAnnealingConfig:
             raise ValueError(f'Expected start_step >= 0. received {self.start_step}.')
         if self.end_step is not None and self.end_step <= self.start_step:
             raise ValueError('Expected start_step < end_step, '
-                             'received end_step {self.end_step} and start_step {self.start_stap}.')
+                             f'received end_step {self.end_step} and start_step {self.start_step}.')
 
 
 @dataclass


### PR DESCRIPTION
## Pull Request Description:
This small PR corrects validation error messaging in the `QFractionLinearAnnealingConfig` class. The PR fixes two issues:  
- **Missing f-string formatting**: Added proper string interpolation to display actual `end_step` and `start_step` values.  
- **Typo in error message variable**: Corrected `start_stap` to `start_step` to match the actual parameter name, preventing a runtime error.


## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).