### PR TITLE
Node Supported Bitwidth Filtering Bugfix

### DIFF
--- a/model_compression_toolkit/core/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/set_node_quantization_config.py
@@ -119,11 +119,16 @@ def filter_node_qco_by_graph(node: BaseNode,
             _next_nodes.extend(graph.get_next_nodes(n))
         next_nodes.append(n)
 
-    if len(next_nodes):
-        next_nodes_qc_options = [_node.get_qco(fqc) for _node in next_nodes]
-        next_nodes_supported_input_bitwidth = min([max_input_activation_n_bits(op_cfg)
+    if len(next_nodes) == 0:
+        return _base_config, _node_qc_options
+    next_nodes_qc_options = [_node.get_qco(fqc) for _node in next_nodes]
+    all_next_nodes_supported_input_bitwidth = [max_input_activation_n_bits(op_cfg)
                                                    for qc_opts in next_nodes_qc_options
-                                                   for op_cfg in qc_opts.quantization_configurations])
+                                                   for op_cfg in qc_opts.quantization_configurations
+                                               if op_cfg.enable_activation_quantization or op_cfg.quantization_preserving
+                                               ]
+    if len(all_next_nodes_supported_input_bitwidth):
+        next_nodes_supported_input_bitwidth = min(all_next_nodes_supported_input_bitwidth)
 
         # Filter node's QC options that match next nodes input bit-width.
         _node_qc_options = [_option for _option in _node_qc_options

--- a/model_compression_toolkit/core/common/quantization/set_node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/set_node_quantization_config.py
@@ -210,7 +210,7 @@ def set_quantization_configs_to_node(node: BaseNode,
                 # Preserving the quantization of more than 1 previous node is ambiguous, so disable it.
                 Logger.info(f"Disabling Quantization-Preserving for node {node.name} because it has more than 1 input activations.")
                 candidate_qc.activation_quantization_cfg.quant_mode = ActivationQuantizationMode.NO_QUANT
-            elif not prev_nodes[0].is_quantization_preserving() or not prev_nodes[0].is_activation_quantization_enabled():
+            elif not prev_nodes[0].is_quantization_preserving() and not prev_nodes[0].is_activation_quantization_enabled():
                 # Preserving the quantization of an unquantized node isn't possible, so disable it.
                 Logger.info(f"Disabling Quantization-Preserving for node {node.name} because previous node activation quantization is disabled.")
                 candidate_qc.activation_quantization_cfg.quant_mode = ActivationQuantizationMode.NO_QUANT

--- a/model_compression_toolkit/core/common/substitutions/shift_negative_activation.py
+++ b/model_compression_toolkit/core/common/substitutions/shift_negative_activation.py
@@ -343,6 +343,13 @@ def shift_negative_function(graph: Graph,
     graph.set_out_stats_collector_to_node(add_node, add_node_stats_collector)
     graph.shift_stats_collector(add_node, np.array(shift_value))
 
+    set_quantization_configs_to_node(fw_info=fw_info,
+                                     node=add_node,
+                                     graph=graph,
+                                     quant_config=core_config.quantization_config,
+                                     fqc=graph.fqc,
+                                     mixed_precision_enable=core_config.is_mixed_precision_enabled)
+
     if padding is not None:
         pad_node = create_pad_node(op2d_node.name,
                                    add_node.name,
@@ -372,13 +379,6 @@ def shift_negative_function(graph: Graph,
                                               add_node_stats_collector)  # We ignore the padding effect on statistics
 
         op2d_node.input_shape = pad_node.output_shape
-
-    set_quantization_configs_to_node(fw_info=fw_info,
-                                     node=add_node,
-                                     graph=graph,
-                                     quant_config=core_config.quantization_config,
-                                     fqc=graph.fqc,
-                                     mixed_precision_enable=core_config.is_mixed_precision_enabled)
 
     original_non_linear_activation_nbits = non_linear_node_cfg_candidate.activation_n_bits
     # The non-linear node's output should be float, so we approximate it by using 16bits quantization.

--- a/tests_pytest/common_tests/unit_tests/core/graph/test_node_quantization.py
+++ b/tests_pytest/common_tests/unit_tests/core/graph/test_node_quantization.py
@@ -24,19 +24,29 @@ from model_compression_toolkit.target_platform_capabilities.schema.mct_current_s
     OpQuantizationConfig, AttributeQuantizationConfig, Signedness
 from mct_quantizers import QuantizationMethod
 
+class PreservingNode:
+    """ Only needed for repr(node) to work. """
+    pass
+
+class NoActivationQuantNode:
+    """ Only needed for repr(node) to work. """
+    pass
 
 class TestSetNodeQuantizationConfig:
 
     @staticmethod
-    def _get_op_config():
+    def _get_op_config(activation_n_bits,
+                       supported_input_activation_n_bits,
+                       enable_activation_quantization,
+                       quantization_preserving):
         aqc = AttributeQuantizationConfig()
         return OpQuantizationConfig(default_weight_attr_config=aqc,
                                     attr_weights_configs_mapping={'w': aqc},
                                     activation_quantization_method=QuantizationMethod.POWER_OF_TWO,
-                                    activation_n_bits=7,
-                                    supported_input_activation_n_bits=7,
-                                    enable_activation_quantization=False,
-                                    quantization_preserving=True,
+                                    activation_n_bits=activation_n_bits,
+                                    supported_input_activation_n_bits=supported_input_activation_n_bits,
+                                    enable_activation_quantization=enable_activation_quantization,
+                                    quantization_preserving=quantization_preserving,
                                     signedness=Signedness.AUTO)
 
     def test_activation_preserving_with_2_inputs(self, fw_info_mock):
@@ -48,9 +58,12 @@ class TestSetNodeQuantizationConfig:
         graph = Graph('g', input_nodes=[n1, n2], nodes=[n3], output_nodes=[n4],
                       edge_list=[Edge(n1, n3, 0, 0), Edge(n2, n3, 0, 0),
                                  Edge(n3, n4, 0, 0)])
-
-        fqc = Mock(filterlayer2qco={DummyLayer: QuantizationConfigOptions(quantization_configurations=[self._get_op_config()])},
-                   layer2qco={DummyLayer: QuantizationConfigOptions(quantization_configurations=[self._get_op_config()])})
+        op_config_kwargs = {"activation_n_bits": 7,
+                            "supported_input_activation_n_bits": 7,
+                            "enable_activation_quantization": False,
+                            "quantization_preserving": True}
+        fqc = Mock(filterlayer2qco={DummyLayer: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**op_config_kwargs)])},
+                   layer2qco={DummyLayer: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**op_config_kwargs)])})
         fw_info_mock = Mock(spec=FrameworkInfo, kernel_channels_mapping={DummyLayer: 0},
                             activation_quantizer_mapping={QuantizationMethod.POWER_OF_TWO: lambda x: 0},
                             get_kernel_op_attributes=lambda x: [None])
@@ -59,3 +72,51 @@ class TestSetNodeQuantizationConfig:
         assert not n3.is_quantization_preserving() and not n3.is_activation_quantization_enabled()
         assert not n4.is_quantization_preserving() and not n4.is_activation_quantization_enabled()
 
+    def test_node_quantization_by_next_nodes(self, fw_info_mock):
+        first_node = build_node('first_node')
+        preserving_node = build_node('preserving_node', layer_class=PreservingNode)
+        no_quant_node = build_node('no_enabled_quant_node', layer_class=NoActivationQuantNode)
+        graph = Graph('g', input_nodes=[first_node], nodes=[preserving_node], output_nodes=[no_quant_node],
+                      edge_list=[Edge(first_node, preserving_node, 0, 0),
+                                 Edge(preserving_node, no_quant_node, 0, 0)])
+
+        first_node_config_kwargs = {"activation_n_bits": 8,
+                                    "supported_input_activation_n_bits": [8, 16],
+                                    "enable_activation_quantization": True,
+                                    "quantization_preserving": False}
+
+        preserving_node_config_kwargs = {"activation_n_bits": 8,
+                                        "supported_input_activation_n_bits": [8],
+                                        "enable_activation_quantization": False,
+                                        "quantization_preserving": True}
+
+        no_quant_node_config_kwargs = {"activation_n_bits": 8,
+                                        "supported_input_activation_n_bits": [8],
+                                        "enable_activation_quantization": False,
+                                        "quantization_preserving": False}
+
+        fqc = Mock(
+            filterlayer2qco={
+                DummyLayer: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**first_node_config_kwargs)]),
+                PreservingNode: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**preserving_node_config_kwargs)]),
+                NoActivationQuantNode: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**no_quant_node_config_kwargs)]),
+            },
+            layer2qco={
+                DummyLayer: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**first_node_config_kwargs)]),
+                PreservingNode: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**preserving_node_config_kwargs)]),
+                NoActivationQuantNode: QuantizationConfigOptions(quantization_configurations=[self._get_op_config(**no_quant_node_config_kwargs)]),
+            }
+        )
+        fw_info_mock = Mock(spec=FrameworkInfo, kernel_channels_mapping={DummyLayer: 0},
+                            activation_quantizer_mapping={QuantizationMethod.POWER_OF_TWO: lambda x: 0},
+                            get_kernel_op_attributes=lambda x: [None])
+
+        set_quantization_configs_to_node(first_node, graph, QuantizationConfig(), fw_info_mock, fqc)
+        set_quantization_configs_to_node(preserving_node, graph, QuantizationConfig(), fw_info_mock, fqc)
+        set_quantization_configs_to_node(no_quant_node, graph, QuantizationConfig(), fw_info_mock, fqc)
+
+        # assert not first_node.is_quantization_preserving() and first_node.is_activation_quantization_enabled()
+        assert preserving_node.is_quantization_preserving() and preserving_node.is_activation_quantization_enabled()
+        assert not no_quant_node.is_quantization_preserving() and not no_quant_node.is_activation_quantization_enabled()
+
+        print("a")

--- a/tests_pytest/common_tests/unit_tests/core/graph/test_node_quantization.py
+++ b/tests_pytest/common_tests/unit_tests/core/graph/test_node_quantization.py
@@ -24,13 +24,16 @@ from model_compression_toolkit.target_platform_capabilities.schema.mct_current_s
     OpQuantizationConfig, AttributeQuantizationConfig, Signedness
 from mct_quantizers import QuantizationMethod
 
+
 class PreservingNode:
     """ Only needed for repr(node) to work. """
     pass
 
+
 class NoActivationQuantNode:
     """ Only needed for repr(node) to work. """
     pass
+
 
 class TestSetNodeQuantizationConfig:
 
@@ -80,13 +83,13 @@ class TestSetNodeQuantizationConfig:
                       edge_list=[Edge(first_node, preserving_node, 0, 0),
                                  Edge(preserving_node, no_quant_node, 0, 0)])
 
-        first_node_config_kwargs = {"activation_n_bits": 8,
+        first_node_config_kwargs = {"activation_n_bits": 16,
                                     "supported_input_activation_n_bits": [8, 16],
                                     "enable_activation_quantization": True,
                                     "quantization_preserving": False}
 
         preserving_node_config_kwargs = {"activation_n_bits": 8,
-                                        "supported_input_activation_n_bits": [8],
+                                        "supported_input_activation_n_bits": [8, 16],
                                         "enable_activation_quantization": False,
                                         "quantization_preserving": True}
 
@@ -115,8 +118,7 @@ class TestSetNodeQuantizationConfig:
         set_quantization_configs_to_node(preserving_node, graph, QuantizationConfig(), fw_info_mock, fqc)
         set_quantization_configs_to_node(no_quant_node, graph, QuantizationConfig(), fw_info_mock, fqc)
 
-        # assert not first_node.is_quantization_preserving() and first_node.is_activation_quantization_enabled()
-        assert preserving_node.is_quantization_preserving() and preserving_node.is_activation_quantization_enabled()
+        assert not first_node.is_quantization_preserving() and first_node.is_activation_quantization_enabled()
+        assert preserving_node.is_quantization_preserving() and not preserving_node.is_activation_quantization_enabled()
         assert not no_quant_node.is_quantization_preserving() and not no_quant_node.is_activation_quantization_enabled()
 
-        print("a")


### PR DESCRIPTION
## Pull Request Description:
Filter out nodes without enable quantization and not preserving

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).