### PR TITLE
Add a flag for TPC schema v2 for enabling quantization preserving quantizers in the output model

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/schema/v2.py
+++ b/model_compression_toolkit/target_platform_capabilities/schema/v2.py
@@ -214,6 +214,7 @@ class TargetPlatformCapabilities(BaseModel):
         add_metadata (bool): Flag to determine if metadata should be added.
         name (str): Name of the Target Platform Model.
         is_simd_padding (bool): Indicates if SIMD padding is applied.
+        insert_preserving_quantizers (bool): Whether to include quantizers for quantization preserving operations in the quantized model.
         SCHEMA_VERSION (int): Version of the schema for the Target Platform Model.
     """
     default_qco: QuantizationConfigOptions
@@ -224,7 +225,9 @@ class TargetPlatformCapabilities(BaseModel):
     tpc_platform_type: Optional[str]
     add_metadata: bool = True
     name: Optional[str] = "default_tpc"
+
     is_simd_padding: bool = False
+    insert_preserving_quantizers: bool = False
 
     SCHEMA_VERSION: int = 2
 


### PR DESCRIPTION
## Pull Request Description:

Extending TPC schema in the new schema v2 with an option to enable/disable preserving ops quantizers in the output model.
This PR does not activate the usability of this flag, since schema v2 is currently not set as active in MCT.
Any necessary test for this new functionality we'll be added once the schema is activated as current mct schema.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).