### PR TITLE
Refactor virtual config reconstruction helper, support separate configuration for activations and weights

### DIFF
--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -12,29 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import abc
 import uuid
-
-from typing import Dict, Any, Tuple
 
 from model_compression_toolkit.core import FrameworkInfo
 from model_compression_toolkit.constants import VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX, \
     VIRTUAL_WEIGHTS_SUFFIX, VIRTUAL_ACTIVATION_SUFFIX, FLOAT_BITWIDTH
 from model_compression_toolkit.core.common.framework_info import DEFAULT_KERNEL_ATTRIBUTES
-
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
-import numpy as np
-
 from model_compression_toolkit.core.common.quantization.candidate_node_quantization_config import \
     CandidateNodeQuantizationConfig
 from model_compression_toolkit.core.common.quantization.node_quantization_config import ActivationQuantizationMode
 
 
-class VirtualNode(BaseNode):
+class VirtualNode(BaseNode, abc.ABC):
     """ Base class for all virtual nodes. """
     pass
 
 
-class VirtualSplitNode(VirtualNode):
+class VirtualSplitNode(VirtualNode, abc.ABC):
     """
     A class that represents a node that was split from a kernel node (node with weights).
     """

--- a/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
+++ b/model_compression_toolkit/core/common/graph/virtual_activation_weights_node.py
@@ -19,15 +19,22 @@ from typing import Dict, Any, Tuple
 from model_compression_toolkit.core import FrameworkInfo
 from model_compression_toolkit.constants import VIRTUAL_ACTIVATION_WEIGHTS_NODE_PREFIX, \
     VIRTUAL_WEIGHTS_SUFFIX, VIRTUAL_ACTIVATION_SUFFIX, FLOAT_BITWIDTH
+from model_compression_toolkit.core.common.framework_info import DEFAULT_KERNEL_ATTRIBUTES
 
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
 import numpy as np
 
 from model_compression_toolkit.core.common.quantization.candidate_node_quantization_config import \
     CandidateNodeQuantizationConfig
+from model_compression_toolkit.core.common.quantization.node_quantization_config import ActivationQuantizationMode
 
 
-class VirtualSplitNode(BaseNode):
+class VirtualNode(BaseNode):
+    """ Base class for all virtual nodes. """
+    pass
+
+
+class VirtualSplitNode(VirtualNode):
     """
     A class that represents a node that was split from a kernel node (node with weights).
     """
@@ -73,14 +80,11 @@ class VirtualSplitWeightsNode(VirtualSplitNode):
         super().__init__(origin_node)
 
         self.name = origin_node.name + VIRTUAL_WEIGHTS_SUFFIX
-        # Virtual weights node is created only to be absorbed into virtual composed node right away.
-        # However, in some cases composition is impossible and virtual weights node can remain in the graph.
-        # In such case it messes up resource utilization computation, specifically activation cuts. In order to minimize
-        # the impact, we preserve the behavior of the original node wrt activation (shape and quantization),
-        # so that prev - virtualW cut is identical to prev-origin_node. Only the cut virtualW-virtualA will be different
-        # from the original graph, so in the worst case the utilization will be higher in virtual graph.
-        # This should guarantee that the utilization of the original graph does not exceed the requested target.
-        self.candidates_quantization_cfg = origin_node.candidates_quantization_cfg
+
+        self.candidates_quantization_cfg = origin_node.get_unique_weights_candidates(kernel_attr)
+        for c in self.candidates_quantization_cfg:
+            c.activation_quantization_cfg.quant_mode = ActivationQuantizationMode.NO_QUANT
+            c.activation_quantization_cfg.activation_n_bits = FLOAT_BITWIDTH
 
 
 class VirtualSplitActivationNode(VirtualSplitNode):
@@ -113,7 +117,7 @@ class VirtualSplitActivationNode(VirtualSplitNode):
             c.weights_quantization_cfg.weights_n_bits = FLOAT_BITWIDTH
 
 
-class VirtualActivationWeightsNode(BaseNode):
+class VirtualActivationWeightsNode(VirtualNode):
     """
     A node that represents a composition of pair of sequential activation node and weights (kernel) node.
     This structure is used for mixed-precision search with bit-operation constraint.
@@ -149,7 +153,7 @@ class VirtualActivationWeightsNode(BaseNode):
         weights = weights_node.weights.copy()
         act_node_w_rename = {}
         if act_node.weights:
-            if not fw_info.get_kernel_op_attributes(act_node)[0] is None:
+            if fw_info.get_kernel_op_attributes(act_node) != DEFAULT_KERNEL_ATTRIBUTES:
                 raise NotImplementedError(f'Node {act_node} with kernel cannot be used as activation for '
                                           f'VirtualActivationWeightsNode.')
             if act_node.has_any_configurable_weight():

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
@@ -412,10 +412,14 @@ class ConfigReconstructionHelper:
         for virtual_node, virtual_qc_ind in virtual_cfg.items():
             orig_a_node, orig_a_candidates = self._retrieve_matching_orig_a_candidates(virtual_node, virtual_qc_ind)
             if orig_a_node and (include_non_configurable or orig_a_node.has_configurable_activation()):
+                # we may have retrieved multiple candidates with different weights configs and identical activation
+                # configs, so we just take the first
                 a_cfg[orig_a_node] = orig_a_candidates[0]
 
             orig_w_node, orig_w_candidates = self._retrieve_matching_orig_w_candidates(virtual_node, virtual_qc_ind)
             if orig_w_node and (include_non_configurable or orig_w_node.has_any_configurable_weight()):
+                # we may have retrieved multiple candidates with different activation configs and identical weights
+                # configs, so we just take the first
                 w_cfg[orig_w_node] = orig_w_candidates[0]
 
         return a_cfg, w_cfg

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 
 from tqdm import tqdm
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import numpy as np
 
@@ -28,7 +28,7 @@ from model_compression_toolkit.core.common.framework_implementation import Frame
 from model_compression_toolkit.core.common.framework_info import FrameworkInfo
 from model_compression_toolkit.core.common.graph.base_graph import Graph
 from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualActivationWeightsNode, \
-    VirtualSplitWeightsNode, VirtualSplitActivationNode
+    VirtualSplitWeightsNode, VirtualSplitActivationNode, VirtualNode
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import \
     RUTarget, ResourceUtilization
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization_calculator import \
@@ -83,10 +83,9 @@ class MixedPrecisionSearchManager:
         self.min_ru_config: Dict[BaseNode, int] = self.mp_graph.get_min_candidates_config(fw_info)
         self.max_ru_config: Dict[BaseNode, int] = self.mp_graph.get_max_candidates_config(fw_info)
 
-        self.config_reconstruction_helper = ConfigReconstructionHelper(virtual_graph=self.mp_graph,
-                                                                       original_graph=self.original_graph)
+        self.config_reconstruction_helper = ConfigReconstructionHelper(self.original_graph)
         if self.using_virtual_graph:
-            real_min_ru_config: Dict[BaseNode, int] = self.config_reconstruction_helper.reconstruct_config_from_virtual_graph(self.min_ru_config)
+            real_min_ru_config = self.config_reconstruction_helper.reconstruct_full_configuration(self.min_ru_config)
             self.min_ru = self.ru_helper.compute_utilization(self.ru_targets, real_min_ru_config)
         else:
             self.min_ru = self.ru_helper.compute_utilization(self.ru_targets, self.min_ru_config)
@@ -101,7 +100,7 @@ class MixedPrecisionSearchManager:
         mp_config = self._prepare_and_run_solver()
 
         if self.using_virtual_graph:
-            mp_config = self.config_reconstruction_helper.reconstruct_config_from_virtual_graph(mp_config)
+            mp_config = self.config_reconstruction_helper.reconstruct_full_configuration(mp_config)
 
         return mp_config
 
@@ -112,9 +111,9 @@ class MixedPrecisionSearchManager:
         Returns:
             Mapping from nodes to indices of the selected bit-widths candidate.
         """
-        layers_candidates_sensitivity: Dict[BaseNode, List[float]] = self._build_sensitivity_mapping()
         candidates_ru = self._compute_relative_ru_matrices()
         rel_target_ru = self._get_relative_ru_constraint_per_mem_element()
+        layers_candidates_sensitivity: Dict[BaseNode, List[float]] = self._build_sensitivity_mapping()
         solver = MixedPrecisionIntegerLPSolver(layers_candidates_sensitivity, candidates_ru, rel_target_ru)
         mp_config = solver.run()
         return mp_config
@@ -171,8 +170,7 @@ class MixedPrecisionSearchManager:
                                                              topo_cfg(baseline_cfg) if baseline_cfg else None)
 
         if self.using_virtual_graph:
-            origin_max_config = self.config_reconstruction_helper.reconstruct_config_from_virtual_graph(
-                self.max_ru_config)
+            origin_max_config = self.config_reconstruction_helper.reconstruct_full_configuration(self.max_ru_config)
             max_config_value = compute_metric(origin_max_config)
         else:
             max_config_value = compute_metric(self.max_ru_config)
@@ -192,22 +190,12 @@ class MixedPrecisionSearchManager:
                 # Build a distance matrix using the function we got from the framework implementation.
                 if self.using_virtual_graph:
                     # Reconstructing original graph's configuration from virtual graph's configuration
-                    origin_mp_model_configuration = \
-                        self.config_reconstruction_helper.reconstruct_config_from_virtual_graph(
-                            mp_model_configuration,
-                            changed_virtual_nodes_idx=[node_idx],
-                            original_base_config=origin_max_config)
-                    origin_changed_nodes_indices = [i for i, (n, c) in enumerate(origin_max_config.items()) if
-                                                    c != origin_mp_model_configuration[n]]
-                    metric_value = compute_metric(
-                        origin_mp_model_configuration,
-                        origin_changed_nodes_indices,
-                        origin_max_config)
+                    orig_mp_config = self.config_reconstruction_helper.reconstruct_full_configuration(mp_model_configuration)
+                    changed_nodes = [orig_sorted_nodes.index(n) for n, ind in orig_mp_config.items()
+                                     if origin_max_config[n] != ind]
+                    metric_value = compute_metric(orig_mp_config, changed_nodes, origin_max_config)
                 else:
-                    metric_value = compute_metric(
-                        mp_model_configuration,
-                        [node_idx],
-                        self.max_ru_config)
+                    metric_value = compute_metric(mp_model_configuration, [node_idx], self.max_ru_config)
                 metric_value = max(metric_value, max_config_value + eps)
                 layer_to_metrics_mapping[node].append(metric_value)
 
@@ -256,7 +244,7 @@ class MixedPrecisionSearchManager:
                 else:
                     cfg = self.min_ru_config.copy()
                     cfg[node] = candidate_idx
-                    real_cfg = self.config_reconstruction_helper.reconstruct_config_from_virtual_graph(cfg)
+                    real_cfg = self.config_reconstruction_helper.reconstruct_full_configuration(cfg)
                     candidate_rus = self.ru_helper.compute_utilization(self.ru_targets, real_cfg)
 
                 for target, ru in candidate_rus.items():
@@ -326,353 +314,188 @@ class MixedPrecisionSearchManager:
 
 
 class ConfigReconstructionHelper:
-    """
-    A class to help reconstruct an original mixed-precision configuration from a virtual one,
-    when running mixed-precision search with BOPS utilization.
-    It provides a reconstruct_config_from_virtual_graph which allows to translate a bit-width config of a virtual graph
-    to a config of the original configurable nodes.
-    """
+    def __init__(self, original_graph):
+        # mapping in order to return the actual node objects from the original graph
+        self.orig_nodes = {n.name: n for n in original_graph.nodes}
 
-    def __init__(self, virtual_graph: Graph, original_graph: Graph):
+    def reconstruct_full_configuration(self,
+                                       virtual_cfg: Dict[BaseNode, int],
+                                       include_non_configurable: bool = False) -> Dict[BaseNode, int]:
         """
-        Init a ConfigReconstructionHelper object.
-        It holds a dictionary variable named origin_node_idx_to_cfg which holds the mapping from an original graph's
-        configurable node to its actual bit-width index (this data structure is being cleared
-        after every reconstruction call).
+        Convert a configuration of a virtual graph into the corresponding configuration of the original graph.
+        Note that a configurable VirtualActivationWeightsNode might comprise one configurable and one non-configurable
+        original nodes.
 
         Args:
-            virtual_graph: The virtual graph.
-            original_graph: The original graph.
+            virtual_cfg: a mapping from nodes in the virtual graph to selected candidate index. Should contain all
+                configurable nodes of the virtual graph, and only configurable nodes.
+            include_non_configurable: whether to return configs for non-configurable original nodes.
+
+        Returns:
+            A mapping from configurable nodes in the original graph to their candidate indices.
         """
+        # Original candidate of a node that has been split might be determined by two different virtual nodes, one
+        # determines activation and one - weights. First, for each virtual node we collect the original
+        # activation / weights nodes, with all original candidates that match the virtual candidate
+        # activation / weights config. If both activation and weights of the original node are determined by virtual
+        # candidates, we look for a common candidate.
+        orig_nodes_a_candidates = {}
+        orig_nodes_w_candidates = {}
+        for virtual_node, virtual_qc_ind in virtual_cfg.items():
+            assert virtual_node.has_configurable_activation() or virtual_node.has_any_configurable_weight()
+            orig_a_node, orig_a_candidates = self._retrieve_matching_orig_a_candidates(virtual_node, virtual_qc_ind)
+            if orig_a_node and (include_non_configurable or orig_a_node.has_configurable_activation()):
+                assert orig_a_node not in orig_nodes_a_candidates
+                orig_nodes_a_candidates[orig_a_node] = orig_a_candidates
+            orig_w_node, orig_w_candidates = self._retrieve_matching_orig_w_candidates(virtual_node, virtual_qc_ind)
+            if orig_w_node and (include_non_configurable or orig_w_node.has_any_configurable_weight()):
+                assert orig_w_node not in orig_nodes_w_candidates
+                orig_nodes_w_candidates[orig_w_node] = orig_w_candidates
 
-        self.virtual_graph = virtual_graph
-        self.original_graph = original_graph
-        self.fw_info = original_graph.fw_info
+        orig_cfg = {}
+        common_orig_nodes = set(orig_nodes_a_candidates.keys()).intersection(set(orig_nodes_w_candidates))
+        for orig_node in common_orig_nodes:
+            a_candidates = orig_nodes_a_candidates[orig_node]
+            w_candidates = orig_nodes_w_candidates[orig_node]
+            # find the common candidate
+            common_candidates = set(a_candidates).intersection(set(w_candidates))
+            if len(common_candidates) != 1:
+                raise ValueError(f'Expected to find exactly one candidate with the required activation and weights '
+                                 f'quantization configuration for node {orig_node}. Found {len(common_candidates)}')
+            # in theory it's possible that original non-configurable node gets split and each part is combined
+            # with a configurable part of another node and we end up here
+            if orig_node.has_configurable_activation() or orig_node.has_any_configurable_weight():
+                orig_cfg[orig_node] = common_candidates.pop()
+            del orig_nodes_a_candidates[orig_node]
+            del orig_nodes_w_candidates[orig_node]
 
-        self.virtual_sorted_nodes_names = self.virtual_graph.get_configurable_sorted_nodes_names(self.fw_info)
-        self.origin_sorted_conf_nodes = self.original_graph.get_configurable_sorted_nodes(self.fw_info)
-        self.origin_sorted_conf_nodes_names = [n.name for n in self.origin_sorted_conf_nodes]
+        # remaining a nodes
+        for orig_node, a_candidates in orig_nodes_a_candidates.items():
+            assert not orig_node.has_any_configurable_weight()  # if it had we should have caught it above
+            assert len(a_candidates) == 1
+            assert orig_node not in orig_cfg
+            if include_non_configurable or orig_node.has_configurable_activation():
+                orig_cfg[orig_node] = a_candidates[0]
 
-        self.origin_node_idx_to_cfg = {}
+        # remaining w nodes
+        for orig_node, w_candidates in orig_nodes_w_candidates.items():
+            assert not orig_node.has_configurable_activation()  # if it had we should have caught it above
+            assert len(w_candidates) == 1
+            assert orig_node not in orig_cfg
+            if include_non_configurable or orig_node.has_any_configurable_weight():
+                orig_cfg[orig_node] = w_candidates[0]
 
-    def _clear_reconstruction_dict(self):
+        return orig_cfg
+
+    def reconstruct_separate_aw_configs(self, virtual_cfg: Dict[BaseNode, int], include_non_configurable: bool) \
+            -> Tuple[Dict[BaseNode, int], Dict[BaseNode, int]]:
         """
-        Clears the origin_node_idx_to_cfg data structure.
-        """
-
-        self.origin_node_idx_to_cfg = {}
-
-    def reconstruct_config_from_virtual_graph(self,
-                                              virtual_mp_cfg: Dict[BaseNode, int],
-                                              changed_virtual_nodes_idx: List[int] = None,
-                                              original_base_config: Dict[BaseNode, int] = None) -> Dict[BaseNode, int]:
-        """
-        Reconstructs the original config for a given virtual graph mixed-precision config.
-        It iterates over all virtual configurable node (that has some chosen bit-width virtual candidate)
-        and translates its chosen candidate to a candidate index of configurable nodes in the original graph.
-        The translation is based of the virtual node's type. Note that if the node is a split activation node
-        for instance, then we need to find its matching weights node in order to construct the original linear node's
-        chosen config.
+        Retrieves original activation and weights nodes and corresponding candidates for a given configuration of the
+        virtual graph. Only returns configuration specified by the virtual config, per configurable target (activation
+        or weights). For example, if 'virtual_cfg' contains a single VirtualActivationWeightsNode, the returned
+        configuration will contain only activation config for the original activation node, and only weights config
+        for the original weights node).
+        In practice, we return candidate index in both cases, instead of actual activation or weights config, since
+        sensitivity evaluator heavily depends on it, so we must ignore activation config in weights candidate and vice
+        versa. This is bad!!! TODO
 
         Args:
-            virtual_mp_cfg: A mixed-precision configuration (list of candidates indices) of the virtual graph.
-            changed_virtual_nodes_idx: Provide an optional list of virtual nodes indices for which the
-                config reconstruction will be computed.
-            original_base_config: If changed_virtual_nodes_idx is provided, need to provide a base config from which the
-                bit-width for all un-changed original nodes will be taken.
+            virtual_cfg: a mapping from nodes in the virtual graph to selected candidate index.
+            include_non_configurable: whether to return configs for non-configurable target (i.e. activation config
+              for non-configurable activation, and weights config for non-configurable weight).
 
-        Returns: A mixed-precision configuration (list of candidates indices) of the original graph.
-
+        Returns:
+            Configuration for original activation nodes and a separate configuration for original weights nodes.
         """
+        a_cfg = {}
+        w_cfg = {}
+        for virtual_node, virtual_qc_ind in virtual_cfg.items():
+            orig_a_node, orig_a_candidates = self._retrieve_matching_orig_a_candidates(virtual_node, virtual_qc_ind)
+            if orig_a_node and (include_non_configurable or orig_a_node.has_configurable_activation()):
+                a_cfg[orig_a_node] = orig_a_candidates[0]
 
-        if changed_virtual_nodes_idx is not None:
-            if original_base_config is None:
-                Logger.critical("To run config reconstruction for a partial set of nodes, a base original config must be provided.")  # pragma: no cover
+            orig_w_node, orig_w_candidates = self._retrieve_matching_orig_w_candidates(virtual_node, virtual_qc_ind)
+            if orig_w_node and (include_non_configurable or orig_w_node.has_any_configurable_weight()):
+                w_cfg[orig_w_node] = orig_w_candidates[0]
 
-            updated_virtual_nodes = \
-                [(idx, self.virtual_graph.get_configurable_sorted_nodes(self.fw_info)[idx]) for idx in changed_virtual_nodes_idx]
-            # Iterating only over the virtual nodes that have updated config
-            for virtual_node_idx, n in updated_virtual_nodes:
-                self.reconstruct_node_config(n, list(virtual_mp_cfg.values()), virtual_node_idx)
-            # Updating reconstructed config for all other nodes based on provided base_config
-            original_sorted_conf_nodes = self.original_graph.get_configurable_sorted_nodes(self.fw_info)
-            for i, (n, qc_ind) in enumerate(original_base_config.items()):
-                if i not in list(self.origin_node_idx_to_cfg.keys()):
-                    self.update_config_at_original_idx(n=n, origin_cfg_idx=qc_ind)
+        return a_cfg, w_cfg
+
+    def _retrieve_matching_orig_a_candidates(self,
+                                             virtual_node: BaseNode,
+                                             virtual_qc_ind: int) -> Tuple[Optional[BaseNode], Optional[List[int]]]:
+        """
+        Retrieve the original activation node and all its candidates matching activation quantization config of the
+        given virtual candidate (candidate of a node in the virtual graph).
+        Note that we do simple matching, without any filtering, so disabled activation quantization will be also matched.
+
+        Args:
+            virtual_node: node in the virtual graph (can be virtual or regular).
+            virtual_qc_ind: candidate index of the virtual node.
+
+        Returns:
+            The original activation node (actual object from the original graph) and a list of its matching candidates.
+        """
+        if not isinstance(virtual_node, VirtualNode):
+            return self.orig_nodes[virtual_node.name], [virtual_qc_ind]
+        if isinstance(virtual_node, VirtualSplitWeightsNode):
+            return None, None
+        if isinstance(virtual_node, VirtualActivationWeightsNode):
+            orig_a_node = virtual_node.original_activation_node
+            if isinstance(orig_a_node, VirtualSplitActivationNode):
+                orig_a_node = orig_a_node.origin_node
         else:
-            # Reconstruct entire config
-            for virtual_node_idx, n in enumerate(self.virtual_graph.get_configurable_sorted_nodes(self.fw_info)):
-                self.reconstruct_node_config(n, list(virtual_mp_cfg.values()), virtual_node_idx)
+            assert isinstance(virtual_node, VirtualSplitActivationNode)
+            orig_a_node = virtual_node.origin_node
 
-        res_config = [self.origin_node_idx_to_cfg[key] for key in sorted(self.origin_node_idx_to_cfg.keys())]
-        self._clear_reconstruction_dict()
-        assert len(res_config) == len(self.origin_sorted_conf_nodes)
-        return {n: candidate_idx for n, candidate_idx in zip(self.origin_sorted_conf_nodes, res_config)}
+        virtual_qc = virtual_node.candidates_quantization_cfg[virtual_qc_ind]
+        matching_orig_a_cfgs = [i for i, orig_qc in enumerate(orig_a_node.candidates_quantization_cfg)
+                                if orig_qc.activation_quantization_cfg == virtual_qc.activation_quantization_cfg]
+        if not matching_orig_a_cfgs:    # pragma: no cover
+            raise ValueError(f'Could not find matching activation quantization config in the original node '
+                             f'{orig_a_node} for candidate {virtual_qc_ind} of the virtual node {virtual_node}')
+        return self.orig_nodes[orig_a_node.name], matching_orig_a_cfgs
 
-    def reconstruct_node_config(self,
-                                n: BaseNode,
-                                virtual_mp_cfg: List[int],
-                                virtual_node_idx: int):
+    def _retrieve_matching_orig_w_candidates(self,
+                                             virtual_node: BaseNode,
+                                             virtual_qc_ind: int) -> Tuple[Optional[BaseNode], Optional[List[int]]]:
         """
-        Reconstructs the original configuration for a single node. Updates the mapping inplace.
+        Retrieve the original weights node and all its candidates matching weights quantization config of the
+        given virtual candidate (candidate of a node in the virtual graph).
 
         Args:
-            n: The node to reconstruct the configuration for.
-            virtual_mp_cfg: A mixed-precision configuration (list of candidates indices) of the virtual graph.
-            virtual_node_idx: The index of the virtual node in the virtual mixed-precision configuration.
+            virtual_node: node in the virtual graph (can be virtual or regular).
+            virtual_qc_ind: candidate index of the virtual node.
+
+        Returns:
+            The original weights node (actual object from the original graph) and a list of all its matching candidates.
         """
+        if not isinstance(virtual_node, VirtualNode):
+            if virtual_node.weights:
+                return self.orig_nodes[virtual_node.name], [virtual_qc_ind]
+            return None, None
+        if isinstance(virtual_node, VirtualSplitActivationNode):
+            return None, None
 
-        virtual_cfg_idx = virtual_mp_cfg[virtual_node_idx]
-
-        if isinstance(n, VirtualActivationWeightsNode):
-            weights_node = n.original_weights_node
-            if isinstance(weights_node, VirtualSplitWeightsNode):
-                self.get_activation_for_split_weights(weights_node, n, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                Logger.critical(f"Virtual graph construction error: Expected all weights nodes to be split into weights and activation nodes. Found node '{n.name}' not split as expected. Every weights node should correspond to a VirtualSplitWeightsNode type.")  # pragma: no cover
-
-            activation_node = n.original_activation_node
-            if isinstance(activation_node, VirtualSplitActivationNode):
-                self.get_weights_for_split_activation(activation_node, n, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                if activation_node.name in self.origin_sorted_conf_nodes_names:
-                    # It is possible that the original activation node is not configurable,
-                    # in this case we don't need to retrieve its bit-width config
-                    self.retrieve_activation_only_config(activation_node, n, virtual_cfg_idx)
-        elif isinstance(n, VirtualSplitWeightsNode):
-            # If the node's predecessor have multiple outgoing edges then it is possible that this weights
-            # node is not composed with an activation, but otherwise there is something wrong, and we need
-            # to raise an exception
-            predecessor = self.virtual_graph.get_prev_nodes(n)
-            assert len(predecessor) == 1  # Sanity check
-            predecessor = predecessor[0]
-            if len(self.virtual_graph.out_edges(predecessor)) > 1:
-                # It's ok, need to find the node's configuration
-                self.get_activation_for_split_weights(n, n, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                Logger.critical(f"Virtual graph configuration error: Expected the predecessor of node '{n.name}' to have multiple outputs when not composed with an activation node.")  # pragma: no cover
-        elif isinstance(n, VirtualSplitActivationNode):
-            self.get_weights_for_split_activation(n, n, virtual_cfg_idx, virtual_mp_cfg)
+        if isinstance(virtual_node, VirtualActivationWeightsNode):
+            assert isinstance(virtual_node.original_weights_node, VirtualSplitWeightsNode)
+            orig_w_node = virtual_node.original_weights_node.origin_node
         else:
-            # Node didn't change in virtual graph - candidates list is similar to original
-            if n.name not in self.origin_sorted_conf_nodes_names:
-                Logger.critical(f"Configuration mismatch: Node '{n.name}' is configurable in the virtual graph but not in the original graph. Verify node configurations.")  # pragma: no cover
-            origin_idx = self.origin_sorted_conf_nodes_names.index(n.name)
-            self.origin_node_idx_to_cfg[origin_idx] = virtual_cfg_idx
+            assert isinstance(virtual_node, VirtualSplitWeightsNode)
+            orig_w_node = virtual_node.origin_node
 
-    def retrieve_weights_only_config(self, weights_node: BaseNode, virtual_node: BaseNode, virtual_cfg_idx: int):
-        """
-        Retrieves the configuration of an original weights configurable node based on a
-        virtual weights configurable node's chosen config idx, and updates (inplace) the origin_cfg_idx mapping dict.
-        If the original node is not configurable, nothing will be updated.
+        virtual_qc = virtual_node.candidates_quantization_cfg[virtual_qc_ind]
 
-        Args:
-            weights_node: The original weights (possibly configurable) node.
-            virtual_node: The virtual weights configurable node.
-            virtual_cfg_idx: The virtual node's chosen config index.
-        """
+        # Matching candidate is a candidate with matching configs for configurable weights. We cannot compare the entire
+        # weights config since the virtual node may contain additional non-configurable weights from the activation node
+        orig_configurable_attrs = [attr for attr in orig_w_node.weights if virtual_node.is_configurable_weight(attr)]
+        assert all(virtual_node.is_configurable_weight(attr) for attr in orig_configurable_attrs)
 
-        if weights_node.name in self.origin_sorted_conf_nodes_names:
-            # It is possible that the original weights node is not configurable,
-            # in this case we don't need to retrieve its bit-width config
-            kernel_attr = self.fw_info.get_kernel_op_attributes(weights_node.type)[0]
-            weights_bitwidth = (virtual_node.candidates_quantization_cfg[virtual_cfg_idx].weights_quantization_cfg
-                                .get_attr_config(kernel_attr).weights_n_bits)
-            origin_cfg_idx = [i for i, c in
-                              enumerate(weights_node.candidates_quantization_cfg) if
-                              c.weights_quantization_cfg.get_attr_config(kernel_attr).weights_n_bits == weights_bitwidth]
-
-            self.update_config_at_original_idx(weights_node, origin_cfg_idx[0])
-
-    def retrieve_activation_only_config(self, activation_node: BaseNode, virtual_node: BaseNode, virtual_cfg_idx: int):
-        """
-        Retrieves the configuration of an original activation configurable node based on a
-        virtual activation configurable node's chosen config idx, and updates (inplace) the origin_cfg_idx mapping dict.
-        If the original node is not configurable, nothing will be updated.
-
-        Args:
-            activation_node: The original activation (possibly configurable) node.
-            virtual_node: The virtual activation configurable node.
-            virtual_cfg_idx: The virtual node's chosen config index.
-        """
-
-        if activation_node.name in self.origin_sorted_conf_nodes_names:
-            # It is possible that the original activation node is not configurable,
-            # in this case we don't need to retrieve its bit-width config
-            activation_bitwidth = virtual_node.candidates_quantization_cfg[
-                virtual_cfg_idx].activation_quantization_cfg.activation_n_bits
-            origin_cfg_idx = [i for i, c in
-                              enumerate(activation_node.candidates_quantization_cfg) if
-                              c.activation_quantization_cfg.activation_n_bits == activation_bitwidth]
-
-            self.update_config_at_original_idx(activation_node, origin_cfg_idx[0])
-
-    def retrieve_activation_weights_config(self,
-                                           activation_node: BaseNode,
-                                           weights_node: BaseNode,
-                                           virtual_node: BaseNode,
-                                           virtual_cfg_idx: int,
-                                           virtual_mp_cfg: List[int]):
-        """
-        Retrieves the configuration of an original weights and activation (possibly) configurable node based on a given
-        virtual split weights node and a virtual split activation node which represents its matching in the original graph.
-        it updates (inplace) the origin_cfg_idx mapping dict.
-
-        Args:
-            activation_node: The virtual node that contains the activation that matches the weights node in the original graph.
-            weights_node: The virtual node that contains the weights representation of an original node.
-            virtual_node: The virtual node that contains the virtual weights node (either a composed node or a split weights node).
-            virtual_cfg_idx: The virtual node's chosen config index.
-            virtual_mp_cfg: The virtual graph's chosen mp config.
-        """
-
-        activation_bitwidth = activation_node.candidates_quantization_cfg[virtual_mp_cfg[
-            self.virtual_sorted_nodes_names.index(activation_node.name)]].activation_quantization_cfg.activation_n_bits
-
-        kernel_attr = self.fw_info.get_kernel_op_attributes(weights_node.type)[0]
-
-        weights_bitwidth = (virtual_node.candidates_quantization_cfg[virtual_cfg_idx].weights_quantization_cfg
-                            .get_attr_config(kernel_attr).weights_n_bits)
-
-        origin_cfg_idx = [i for i, c in
-                          enumerate(weights_node.origin_node.candidates_quantization_cfg) if
-                          c.weights_quantization_cfg.get_attr_config(kernel_attr).weights_n_bits == weights_bitwidth and
-                          c.activation_quantization_cfg.activation_n_bits == activation_bitwidth]
-
-        self.update_config_at_original_idx(weights_node.origin_node, origin_cfg_idx[0])
-
-    def retrieve_weights_activation_config(self,
-                                           activation_node: BaseNode,
-                                           weights_node: BaseNode,
-                                           virtual_node: BaseNode,
-                                           virtual_cfg_idx: int,
-                                           virtual_mp_cfg: List[int]):
-        """
-        Retrieves the configuration of an original weights and activation (possibly) configurable node based on a given
-        virtual split activation node and a virtual split weights node which represents its matching in the original graph.
-        it updates (inplace) the origin_cfg_idx mapping dict.
-
-        Args:
-            activation_node: The virtual node that contains the activation representation of an original node.
-            weights_node: The virtual node that contains the weights that matches the activation node in the original graph.
-            virtual_node: The virtual node that contains the virtual activation node (either a composed node or a split activation node).
-            virtual_cfg_idx: The virtual node's chosen config index.
-            virtual_mp_cfg: The virtual graph's chosen mp config.
-        """
-
-        kernel_attr = self.fw_info.get_kernel_op_attributes(weights_node.type)[0]
-
-        weights_bitwidth = (weights_node.candidates_quantization_cfg[virtual_mp_cfg[
-            self.virtual_sorted_nodes_names.index(weights_node.name)]]
-                            .weights_quantization_cfg.get_attr_config(kernel_attr).weights_n_bits)
-
-        activation_bitwidth = virtual_node.candidates_quantization_cfg[
-            virtual_cfg_idx].activation_quantization_cfg.activation_n_bits
-
-        origin_cfg_idx = [i for i, c in enumerate(activation_node.origin_node.candidates_quantization_cfg) if
-                          c.weights_quantization_cfg.get_attr_config(kernel_attr).weights_n_bits == weights_bitwidth and
-                          c.activation_quantization_cfg.activation_n_bits == activation_bitwidth]
-
-        self.update_config_at_original_idx(activation_node.origin_node, origin_cfg_idx[0])
-
-    def get_activation_for_split_weights(self,
-                                         weights_node: BaseNode,
-                                         virtual_node: BaseNode,
-                                         virtual_cfg_idx: int,
-                                         virtual_mp_cfg: List[int]):
-        """
-        Finds the matching activation node in the virtual graph for a given split weights node,
-        and calls the relevant method for updating the configuration mapping.
-
-        Args:
-            weights_node: A virtual weights node.
-            virtual_node: A virtual node that contains the virtual weights node (either a composed node or a split weights node).
-            virtual_cfg_idx: The virtual node's chosen config index.
-            virtual_mp_cfg: The virtual graph's chosen mp config.
-
-        """
-
-        # This is a weights node that was split, means it has an activation node that should follow it,
-        # and we need its configuration in order to reconstruct the original node's configuration.
-        matching_activation_node = self.virtual_graph.get_next_nodes(virtual_node)
-        assert len(matching_activation_node) == 1
-        activation_node = matching_activation_node[0]
-
-        if isinstance(activation_node, VirtualActivationWeightsNode):
-            if activation_node.original_activation_node.is_activation_quantization_enabled() and not \
-                    activation_node.original_activation_node.is_all_activation_candidates_equal():
-                assert activation_node.name in self.virtual_sorted_nodes_names  # Sanity check
-                # The original node is both weights and activation configurable
-                self.retrieve_activation_weights_config(activation_node, weights_node, virtual_node, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                # weights_node here is a split weights node therefore must have 'origin_node'
-                self.retrieve_weights_only_config(weights_node.origin_node, virtual_node, virtual_cfg_idx)
-        else:
-            assert isinstance(activation_node, VirtualSplitActivationNode)  # Sanity check
-            if activation_node.name in self.virtual_sorted_nodes_names:
-                self.retrieve_activation_weights_config(activation_node, weights_node, virtual_node, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                # The original node is only weights configurable
-                # weights_node here is a split weights node therefore must have 'origin_node'
-                self.retrieve_weights_only_config(weights_node.origin_node, virtual_node, virtual_cfg_idx)
-
-    def get_weights_for_split_activation(self,
-                                         activation_node: BaseNode,
-                                         virtual_node: BaseNode,
-                                         virtual_cfg_idx: int,
-                                         virtual_mp_cfg: List[int]):
-        """
-        Finds the matching weights node in the virtual graph for a given split activation node,
-        and calls the relevant method for updating the configuration mapping.
-
-        Args:
-            activation_node: A virtual activation node.
-            virtual_node: A virtual node that contains the virtual activation node (either a composed node or a split activation node).
-            virtual_cfg_idx: The virtual node's chosen config index.
-            virtual_mp_cfg: The virtual graph's chosen mp config.
-
-        """
-
-        # This is an activation node that was split, means it has a weights node that should come before it,
-        # and we need its configuration in order to reconstruct the original node's configuration.
-        matching_weights_node = self.virtual_graph.get_prev_nodes(virtual_node)
-        assert len(matching_weights_node) == 1
-        weights_node = matching_weights_node[0]
-
-        if isinstance(weights_node, VirtualActivationWeightsNode):
-            kernel_attr = self.fw_info.get_kernel_op_attributes(weights_node.type)[0]
-            if weights_node.original_weights_node.is_weights_quantization_enabled(kernel_attr) and not \
-                    weights_node.original_weights_node.is_all_weights_candidates_equal(kernel_attr):
-                assert weights_node.name in self.virtual_sorted_nodes_names  # Sanity check
-                # The original node is both weights and activation configurable
-                self.retrieve_weights_activation_config(activation_node, weights_node, virtual_node, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                # The original node is only activation configurable
-                # activation_node here is a split activation node therefore must have 'origin_node'
-                self.retrieve_activation_only_config(activation_node.origin_node, virtual_node, virtual_cfg_idx)
-        else:
-            # If the node's predecessor e multiple outgoing edges than it is possible that this weights
-            # node is not composed with an activation, but otherwise this is something wrong and we need
-            # to raise an exception
-            predecessor = self.virtual_graph.get_prev_nodes(weights_node)
-            assert len(predecessor) == 1  # Sanity check
-            predecessor = predecessor[0]
-            if len(self.virtual_graph.out_edges(predecessor)) > 1:
-                # It's ok, need to find the node's configuration
-                self.retrieve_weights_activation_config(activation_node, weights_node, virtual_node, virtual_cfg_idx, virtual_mp_cfg)
-            else:
-                Logger.critical(f"Virtual graph configuration error: Expected the predecessor of node '{weights_node.name}' to have multiple outputs when not composed with an activation node.")  # pragma: no cover
-
-    def update_config_at_original_idx(self, n: BaseNode, origin_cfg_idx: int):
-        """
-        Updates (inplace) the origin_node_idx_to_cfg mapping wit hthe given index for a given original node index
-        (in the original graph's sorted configurable nodes list).
-
-        Args:
-            n: An original graph's node
-            origin_cfg_idx: A candidate index.
-
-        """
-
-        origin_idx = self.origin_sorted_conf_nodes_names.index(n.name)
-        self.origin_node_idx_to_cfg[origin_idx] = origin_cfg_idx
+        def get_configurable_attrs_cfgs(qc):
+            return {attr: qc.weights_quantization_cfg.get_attr_config(attr) for attr in orig_configurable_attrs}
+        virtual_cfg = get_configurable_attrs_cfgs(virtual_qc)
+        matching_orig_w_cfgs = [i for i, orig_qc in enumerate(orig_w_node.candidates_quantization_cfg)
+                                if get_configurable_attrs_cfgs(orig_qc) == virtual_cfg]
+        if not matching_orig_w_cfgs:    # pragma: no cover
+            raise ValueError(f'Could not find matching weights quantization config in the original node '
+                             f'{orig_w_node} for candidate {virtual_qc_ind} of the virtual node {virtual_node}')
+        return self.orig_nodes[orig_w_node.name], matching_orig_w_cfgs

--- a/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization_calculator.py
+++ b/model_compression_toolkit/core/common/mixed_precision/resource_utilization_tools/resource_utilization_calculator.py
@@ -29,7 +29,7 @@ from model_compression_toolkit.core.common.graph.memory_graph.compute_graph_max_
 from model_compression_toolkit.core.common.graph.memory_graph.cut import Cut
 from model_compression_toolkit.core.common.graph.memory_graph.memory_graph import MemoryGraph
 from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualActivationWeightsNode, \
-    VirtualSplitWeightsNode
+    VirtualSplitWeightsNode, VirtualNode
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import \
     RUTarget, ResourceUtilization
 from model_compression_toolkit.core.common.quantization.node_quantization_config import NodeWeightsQuantizationConfig, \
@@ -531,6 +531,7 @@ class ResourceUtilizationCalculator:
         Returns:
             Node's BOPS count.
         """
+        assert not isinstance(n, VirtualNode), 'Use original graph to compute BOPS.'
         if target_criterion is None:
             target_criterion = TargetInclusionCriterion.Any
         if target_criterion not in [TargetInclusionCriterion.AnyQuantized, TargetInclusionCriterion.Any]:
@@ -538,20 +539,6 @@ class ResourceUtilizationCalculator:
 
         self._validate_custom_qcs(act_qcs, bitwidth_mode)
         self._validate_custom_qcs(w_qc, bitwidth_mode)
-
-        if isinstance(n, VirtualSplitWeightsNode):
-            # Virtual weights node can only be present if it couldn't be merged into VirtualActivationWeightsNode.
-            # This means that during MP search we cannot compute bops for all A/W nbits combinations. To prevent
-            # inconsistencies we ignore such nodes for bops computation.
-            return 0
-
-        # Fetch the original weights node for mac computation (VirtualActivationWeightsNode input/output shapes are
-        # based on the activation original node, not weights original node)
-        orig_w_node = n
-        if isinstance(n, VirtualActivationWeightsNode):
-            orig_w_node = n.original_weights_node
-            if isinstance(orig_w_node, VirtualSplitWeightsNode):
-                orig_w_node = orig_w_node.origin_node
 
         # check if the node has kernel
         kernel_attrs = self.fw_info.get_kernel_op_attributes(n.type)
@@ -561,21 +548,13 @@ class ResourceUtilizationCalculator:
             return 0
 
         kernel_attr = kernel_attrs[0]
-        node_mac = self.fw_impl.get_node_mac_operations(orig_w_node, self.fw_info)
+        node_mac = self.fw_impl.get_node_mac_operations(n, self.fw_info)
         if node_mac == 0:
             return node_mac
 
-        # find the activation node from which to get quantization info and for which to look in custom configuration
-        if isinstance(n, VirtualActivationWeightsNode):
-            # we don't need the original node (and cannot use it for custom configuration anyway)
-            a_node = n
-        else:
-            # if we are running on the original (non-virtual) graph, we only compute bops if it would be computed in an
-            # equivalent virtual graph for consistency.
-            a_node = get_input_activation_if_composable(self.graph, n, warn=False)
-            if a_node is None:
-                return 0
-
+        prev_nodes = self.graph.get_prev_nodes(n)
+        assert len(prev_nodes) == 1, f'Weights node is expected to have exactly one input, {n} has {len(prev_nodes)}'
+        a_node = prev_nodes[0]
         if (target_criterion == TargetInclusionCriterion.AnyQuantized and
                 not (a_node.is_activation_quantization_enabled() or n.is_weights_quantization_enabled(kernel_attr))):
             return 0

--- a/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_bops_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/mixed_precision_bops_test.py
@@ -178,7 +178,7 @@ class MixedPrecisionBopsMultipleOutEdgesTest(BaseMixedPrecisionBopsTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def get_resource_utilization(self):
-        return ResourceUtilization(bops=1)  # No layers with BOPs count
+        return ResourceUtilization(bops=(16*3*3*13*13)*8*8*2)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # Verify that all layers got 8 bits (so checking candidate index is 0)

--- a/tests/keras_tests/function_tests/test_weights_activation_split_substitution.py
+++ b/tests/keras_tests/function_tests/test_weights_activation_split_substitution.py
@@ -170,7 +170,9 @@ class TestWeightsActivationSplit(unittest.TestCase):
 
         for n in split_graph.get_topo_sorted_nodes():
             if isinstance(n, VirtualSplitWeightsNode):
-                self.assertEqual(n.candidates_quantization_cfg, n.origin_node.candidates_quantization_cfg)
+                self.assertTrue(len(n.candidates_quantization_cfg) == 3)
+                self.assertFalse(any(c.activation_quantization_cfg.enable_activation_quantization
+                                     for c in n.candidates_quantization_cfg))
             if isinstance(n, VirtualSplitActivationNode):
                 self.assertTrue(len(n.candidates_quantization_cfg) == 3,
                                 "The activation split node should have only activation configurable candidates.")

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/resource_utilization_tools/test_resource_utilization_calculator.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/resource_utilization_tools/test_resource_utilization_calculator.py
@@ -1116,59 +1116,6 @@ class TestBOPSAndVirtualGraph:
         ru_calc = ResourceUtilizationCalculator(graph, fw_impl_mock, fw_info_mock)
         assert ru_calc.compute_node_bops(n2, TIC.Any, BM.QCustom) == 42 * 7 * 6
 
-    def test_compute_virtual_aw_node_bops_fully_quantized(self, fw_impl_mock, fw_info_mock):
-        # all quantized
-        g, _, a1w2, a2, a2w3, w3, a3 = self._build_virtual_node_graph(fw_impl_mock, fw_info_mock,
-                                                                  quantize_a1=True, quantize_w1=True,
-                                                                  quantize_a2=True, quantize_w2=True)
-        ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-
-        assert ru_calc.compute_node_bops(a1w2, TIC.AnyQuantized, BM.Float) == 42 * 32 * 32
-        assert ru_calc.compute_node_bops(a1w2, TIC.AnyQuantized, BM.QMinBit) == 42 * 4 * 6
-        assert ru_calc.compute_node_bops(a1w2, TIC.AnyQuantized, BM.QMaxBit) == 42 * 16 * 16
-
-        assert ru_calc.compute_node_bops(a2w3, TIC.AnyQuantized, BM.Float) == 142 * 32 * 32
-        assert ru_calc.compute_node_bops(a2w3, TIC.AnyQuantized, BM.QMinBit) == 142 * 2 * 2
-        assert ru_calc.compute_node_bops(a2w3, TIC.AnyQuantized, BM.QMaxBit) == 142 * 5 * 6
-
-        assert ru_calc.compute_node_bops(a2, TIC.AnyQuantized, BM.Float) == 0
-
-    def test_compute_virtual_aw_node_bops_half_quantized(self, fw_impl_mock, fw_info_mock):
-        g, _, a1w2, a2, a2w3, w3, a3 = self._build_virtual_node_graph(fw_impl_mock, fw_info_mock,
-                                                                   quantize_a1=True, quantize_w1=False,
-                                                                   quantize_a2=False, quantize_w2=True)
-        ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-        assert ru_calc.compute_node_bops(a1w2, TIC.AnyQuantized, BM.QMaxBit) == 42 * 16 * 32
-        assert ru_calc.compute_node_bops(a2w3, TIC.AnyQuantized, BM.QMaxBit) == 142 * 32 * 6
-
-    def test_compute_virtual_aw_node_bops_unquantized(self, fw_impl_mock, fw_info_mock):
-        g, _, a1w2, a2, a2w3, w3, a3 = self._build_virtual_node_graph(fw_impl_mock, fw_info_mock,
-                                                                   quantize_a1=False, quantize_w1=False,
-                                                                   quantize_a2=False, quantize_w2=False)
-        ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-        assert ru_calc.compute_node_bops(a1w2, TIC.AnyQuantized, BM.QMaxBit) == 0
-        assert ru_calc.compute_node_bops(a2w3, TIC.AnyQuantized, BM.QMaxBit) == 0
-
-        assert ru_calc.compute_node_bops(a1w2, TIC.Any, BM.QMaxBit) == 42 * 32 * 32
-        assert ru_calc.compute_node_bops(a2w3, TIC.Any, BM.QMaxBit) == 142 * 32 * 32
-
-    def test_compute_virtual_aw_node_bops_custom(self, fw_impl_mock, fw_info_mock):
-        g, _, a1w2, a2, a2w3, w3, a3 = self._build_virtual_node_graph(fw_impl_mock, fw_info_mock,
-                                                                   quantize_a1=False, quantize_w1=False,
-                                                                   quantize_a2=True, quantize_w2=True)
-        custom_qc_a1w2 = build_qc(5, w_attr={'foo': (6, True)})
-        custom_qc_a2w3 = build_qc(7, w_attr={'bar': (3, True)})
-        a_cfg = {a1w2.name: custom_qc_a1w2.activation_quantization_cfg,
-                 a2w3.name: custom_qc_a2w3.activation_quantization_cfg}
-        w_a1w2 = custom_qc_a1w2.weights_quantization_cfg
-        w_a2w3 = custom_qc_a2w3.weights_quantization_cfg
-
-        ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-        assert ru_calc.compute_node_bops(a1w2, TIC.Any, BM.QCustom, act_qcs=a_cfg, w_qc=w_a1w2) == 42 * 5 * 6
-        assert ru_calc.compute_node_bops(a1w2, TIC.AnyQuantized, BM.QCustom, act_qcs=a_cfg, w_qc=w_a1w2) == 0
-
-        assert ru_calc.compute_node_bops(a2w3, TIC.AnyQuantized, BM.QCustom, act_qcs=a_cfg, w_qc=w_a2w3) == 142 * 7 * 3
-
     @pytest.mark.parametrize('bm', set(BitwidthMode) - {BM.QCustom})
     def test_node_bops_unexpected_custom_qcs(self, graph_mock, fw_impl_mock, fw_info_mock, bm):
         ru_calc = ResourceUtilizationCalculator(graph_mock, fw_impl_mock, fw_info_mock)
@@ -1226,36 +1173,6 @@ class TestBOPSAndVirtualGraph:
         assert detailed == {'n2': 42 * 32 * 7,
                             'n3': 630 * 7 * 5}
 
-    def test_compute_virtual_graph_resources(self, fw_impl_mock, fw_info_mock):
-        g, _, a1w2, a2, a2w3, w3, a3 = self._build_virtual_node_graph(fw_impl_mock, fw_info_mock, True, True, True, True)
-        ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-        ru, detailed = ru_calc.compute_resource_utilization(TIC.Any, BM.QMaxBit, return_detailed=True)
-        assert (sorted(list(detailed[RUTarget.ACTIVATION].values())) ==
-                sorted([24, 24 + 50*2, 50*2+88*5/8, 88*5/8 + 28*7/8, 28*7/8])), detailed[RUTarget.ACTIVATION]
-        assert detailed[RUTarget.WEIGHTS] == {a1w2.name: 42*2, a2w3.name: 142*6/8}
-        assert detailed[RUTarget.BOPS] == {a1w2.name: 42*16*16, a2w3.name: 142*5*6}
-        assert ru == ResourceUtilization(weights_memory=84 + 142*6/8,
-                                         activation_memory=155,
-                                         total_memory=155 + (84 + 142*6/8),
-                                         bops=42*256+142*30)
-
-    def test_virtual_graph_with_virtual_weight(self, fw_impl_mock, fw_info_mock):
-        # virtual weight node wasn't merged into virtual composed node
-        _, n_in, a1w2, a2, a2w3, w3, a3 = self._build_virtual_node_graph(fw_impl_mock, fw_info_mock, True, True, True, True)
-        g = Graph('g', nodes=[w3], input_nodes=[n_in], output_nodes=[a3],
-                  edge_list=[Edge(n_in, w3, 0, 0), Edge(w3, a3, 0, 0)])
-        ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-        ru, detailed = ru_calc.compute_resource_utilization(TIC.Any, BM.QMaxBit, return_detailed=True)
-        assert list(detailed[RUTarget.WEIGHTS].values()) == [142 * 6 / 8]
-        assert detailed[RUTarget.BOPS] == {}
-        # the extra cut that is created by virtual weight node. The rest of the cuts must be correct.
-        wa_cut = 2*28*7/8
-        assert sorted(list(detailed[RUTarget.ACTIVATION].values())) == sorted([24, 24+28*7/8, 28*7/8, wa_cut])
-        assert ru == ResourceUtilization(weights_memory=142 * 6 / 8,
-                                         activation_memory=wa_cut,
-                                         total_memory=wa_cut + (142 * 6 / 8),
-                                         bops=0)
-
     def test_multi_output_input_activation(self, fw_impl_mock, fw_info_mock):
         """ No bops should be calculated for weight node if its input activation has multiple outputs. """
         n_in = build_node('in', qcs=[build_qc()], output_shape=(None, 2, 3, 4))
@@ -1277,7 +1194,7 @@ class TestBOPSAndVirtualGraph:
         fw_impl_mock.get_node_mac_operations = lambda n, fw_info: {n2: 42}.get(n, 0)
 
         ru_calc = ResourceUtilizationCalculator(g, fw_impl_mock, fw_info_mock)
-        assert ru_calc.compute_bops(TIC.Any, BM.Float) == (0, {})
+        assert ru_calc.compute_bops(TIC.Any, BM.QMaxBit) == (42*8*16, {'n2': 42*8*16})
 
     def _build_regular_node_graph(self, enable_aq, enable_wq):
         n1 = build_node('n1', qcs=[build_qc(16, enable_aq), build_qc(7, enable_aq)], output_shape=(None, 5, 10))
@@ -1292,48 +1209,3 @@ class TestBOPSAndVirtualGraph:
         graph = Graph('g', input_nodes=[n1], nodes=[n2], output_nodes=[n3],
                       edge_list=[Edge(n1, n2, 0, 0), Edge(n2, n3, 0, 0)])
         return graph, n1, n2, n3
-
-    def _build_virtual_node_graph(self, fw_impl_mock, fw_info_mock, quantize_w1, quantize_w2, quantize_a1, quantize_a2):
-
-        class BOPNode2:
-            pass
-
-        class ActType:
-            pass
-
-        # define original nodes
-        n_in = build_node('in', qcs=[build_qc()], output_shape=(None, 2, 3, 4))
-        n1 = build_node('n1', qcs=[build_qc(16, quantize_a1),
-                                   build_qc(4, quantize_a1)], output_shape=(None, 5, 10))
-        n2 = build_node('n2', layer_class=BOPNode, output_shape=(None, 2, 44),
-                        canonical_weights={'foo': np.zeros((3, 14))},
-                        qcs=[
-                            build_qc(2, quantize_a2, w_attr={'foo': (16, quantize_w1)}),
-                            build_qc(3, quantize_a2, w_attr={'foo': (10, quantize_w1)}),
-                            build_qc(4, quantize_a2, w_attr={'foo': (7, quantize_w1)}),
-                            build_qc(5, quantize_a2, w_attr={'foo': (6, quantize_w1)}),
-                        ])
-        n3 = build_node('n3', layer_class=BOPNode2, output_shape=(None, 28),
-                        canonical_weights={'bar': np.zeros((2, 71))},
-                        qcs=[
-                            build_qc(4, w_attr={'bar': (6, quantize_w2)}),
-                            build_qc(5, w_attr={'bar': (5, quantize_w2)}),
-                            build_qc(6, w_attr={'bar': (4, quantize_w2)}),
-                            build_qc(7, w_attr={'bar': (2, quantize_w2)})
-                        ])
-
-        def get_kernel_attr(node_type):
-            return {BOPNode: ['foo'], BOPNode2: ['bar']}.get(node_type, [])
-        fw_info_mock.get_kernel_op_attributes = get_kernel_attr
-        fw_impl_mock.get_node_mac_operations = lambda n, fw_info: {n2: 42, n3: 142}.get(n, 0)
-
-        # virtual aw node made of original nodes
-        a1w2 = VirtualActivationWeightsNode(act_node=n1, weights_node=n2, fw_info=fw_info_mock)
-        a2 = VirtualSplitActivationNode(n2, ActType, {})
-        w3 = VirtualSplitWeightsNode(n3, 'bar')
-        # virtual aw node made of virtual split a, w nodes
-        a2w3 = VirtualActivationWeightsNode(act_node=a2, weights_node=w3, fw_info=fw_info_mock)
-        a3 = VirtualSplitActivationNode(n3, ActType, {})
-        g = Graph('g', nodes=[a1w2, a2w3, a3], input_nodes=[n_in], output_nodes=[w3],
-                  edge_list=[Edge(n_in, a1w2, 0, 0), Edge(a1w2, a2w3, 0, 0), Edge(a2w3, a3, 0, 0)])
-        return g, n_in, a1w2, a2, a2w3, w3, a3

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Optional
+
+import copy
+
 import pytest
 from unittest.mock import Mock
 
@@ -21,6 +25,8 @@ from model_compression_toolkit.core import ResourceUtilization
 from model_compression_toolkit.core.common import Graph
 from model_compression_toolkit.core.common.framework_info import DEFAULT_KERNEL_ATTRIBUTES
 from model_compression_toolkit.core.common.graph.edge import Edge
+from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualActivationWeightsNode, \
+    VirtualSplitActivationNode, VirtualSplitWeightsNode
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_ru_helper import MixedPrecisionRUHelper
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import \
     MixedPrecisionSearchManager, ConfigReconstructionHelper
@@ -245,7 +251,7 @@ class TestMixedPrecisionSearchManager:
                                  'mixed_precision_search_manager.copy.deepcopy')
         mocker.patch.object(MixedPrecisionRUHelper, 'compute_utilization')
 
-        recon_cfg_mock = mocker.patch.object(ConfigReconstructionHelper, 'reconstruct_config_from_virtual_graph')
+        recon_cfg_mock = mocker.patch.object(ConfigReconstructionHelper, 'reconstruct_full_configuration')
         mocker.patch.object(MixedPrecisionSearchManager, '_prepare_and_run_solver')
 
         virt_sub_mock = Mock()
@@ -289,3 +295,367 @@ class TestMixedPrecisionSearchManager:
         res = mgr.search()
         assert res == exp_cfg
         return res, mgr
+
+
+class TestConfigHelper:
+    class AWLayer:
+        pass
+
+    class ALayer:
+        pass
+
+    class VALayer:
+        pass
+
+    kernel_attr = 'im_kernel'
+
+    @pytest.fixture(autouse=True)
+    def fw_info_mock(self, fw_info_mock):
+        self.fw_info_mock = fw_info_mock
+        self.fw_info_mock.get_kernel_op_attributes = \
+            lambda nt: [self.kernel_attr] if nt == self.AWLayer else DEFAULT_KERNEL_ATTRIBUTES
+
+    @staticmethod
+    def build_aw_node(abits, wbits, name='aw', layer_cls=AWLayer, w_attr=kernel_attr):
+        qcs = []
+        for abit in abits:
+            for wbit in wbits:
+                qcs.append(build_nbits_qc(abit, True, w_attr={w_attr: (wbit, True)}))
+        return build_node(name, layer_class=layer_cls, canonical_weights={w_attr: np.ones(50)}, qcs=qcs)
+
+    @staticmethod
+    def build_a_node(abits, name='a', layer_cls=ALayer):
+        return build_node(name, layer_class=layer_cls, qcs=[build_nbits_qc(abit) for abit in abits])
+
+    @pytest.mark.parametrize('n, ind', [
+        (build_a_node(abits=(5, 3, 7)), 1),
+        (build_aw_node(abits=(4, 8, 16), wbits=(2, 6, 10)), 8),
+        (build_aw_node(abits=(4, 8, 16), wbits=(2, 6, 10)), 5),
+        (build_aw_node(abits=(5,), wbits=(2, 4, 8)), 2),
+    ])
+    def test_retrieve_a_candidates_regular_node(self, graph_mock, n, ind):
+        graph_mock.nodes = [n]
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_n, ret_inds = helper._retrieve_matching_orig_a_candidates(copy.deepcopy(n), ind)
+        assert ret_n is n
+        assert ret_inds == [ind]
+
+    @pytest.mark.parametrize('abits, wbits, vind', [
+        ((4, 8, 16), (2, 6, 10, 12), 0),
+        ((4, 8, 16), (2, 6, 10, 12), 2),
+        ((4,), (2, 6, 10), 0)
+    ])
+    def test_retrieve_a_candidates_virt_split_node(self, graph_mock, abits, wbits, vind):
+        orig_n = self.build_aw_node(abits=abits, wbits=wbits)
+        graph_mock.nodes = [orig_n]
+        helper = ConfigReconstructionHelper(graph_mock)
+        van = VirtualSplitActivationNode(copy.deepcopy(orig_n), self.VALayer, {})
+        ret_n, ret_inds = helper._retrieve_matching_orig_a_candidates(van, vind)
+        assert ret_n is orig_n
+        assert len(ret_inds) == len(wbits)
+        self._validate_activation(orig_n, ret_inds, van, vind)
+
+        vwn = VirtualSplitWeightsNode(orig_n, self.kernel_attr)
+        assert helper._retrieve_matching_orig_a_candidates(vwn, vind) == (None, None)
+
+    @pytest.mark.parametrize('orig_a_n, build_va, orig_w_n, v_ind', [
+        (build_a_node(abits=(2, 4, 8)), False, build_aw_node(abits=(5, 7, 3), wbits=(3, 6)), 5),
+        (build_a_node(abits=(2,)), False, build_aw_node(abits=(5, 7), wbits=(3, 4, 6)), 2),
+        (build_aw_node(abits=(2, 4, 6), wbits=(3, 5, 7, 9)), True, build_aw_node(abits=(8, 10), wbits=(11, 12)), 5),
+        (build_aw_node(abits=(2, 4, 6), wbits=(3, 5, 7, 9)), True, build_aw_node(abits=(8, 10), wbits=(11, 12)), 3),
+        (build_aw_node(abits=(2,), wbits=(3,)), True, build_aw_node(abits=(8,), wbits=(11,)), 0)
+    ])
+    def test_retrieve_a_candidates_virt_aw_node(self, graph_mock, orig_a_n, build_va, orig_w_n, v_ind):
+        graph_mock.nodes = [orig_a_n]
+        a_n = copy.deepcopy(orig_a_n)
+        if build_va:
+            a_n = VirtualSplitActivationNode(a_n, self.VALayer, {})
+        vaw_n = VirtualActivationWeightsNode(act_node=a_n,
+                                             weights_node=VirtualSplitWeightsNode(orig_w_n, self.kernel_attr),
+                                             fw_info=self.fw_info_mock)
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_n, ret_inds = helper._retrieve_matching_orig_a_candidates(vaw_n, v_ind)
+        assert ret_n is orig_a_n
+        self._validate_activation(orig_a_n, ret_inds, vaw_n, v_ind)
+
+    @pytest.mark.parametrize('n, ind', [
+        (build_aw_node(abits=(4, 8, 16), wbits=(2, 6, 10)), 8),
+        (build_aw_node(abits=(4, 8, 16), wbits=(2, 6, 10)), 1),
+        (build_aw_node(abits=(5,), wbits=(2, 4, 8)), 1),
+        (build_aw_node(abits=(4, 8, 16), wbits=(5,)), 2),
+        (build_a_node(abits=(5, 3, 7)), 0)
+    ])
+    def test_retrieve_w_candidates_regular_node(self, graph_mock, n, ind):
+        graph_mock.nodes = [n]
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_n, ret_inds = helper._retrieve_matching_orig_w_candidates(copy.deepcopy(n), ind)
+        assert ret_n is n
+        assert ret_inds == [ind]
+
+    def test_retrieve_w_candidates_activation_node(self, graph_mock):
+        n = self.build_a_node(abits=(5, 3, 7))
+        graph_mock.nodes = [n]
+        helper = ConfigReconstructionHelper(graph_mock)
+        assert helper._retrieve_matching_orig_w_candidates(n, 0) == (None, None)
+
+    @pytest.mark.parametrize('abits, wbits, vind', [
+        ((4, 8, 16), (2, 6, 10, 12), 0),
+        ((4, 8, 16), (2, 6, 10, 12), 2),
+        ((4,), (2, 6, 10), 0),
+        ((2, 6, 10), (4,), 0)
+    ])
+    def test_retrieve_w_candidates_virt_split_node(self, graph_mock, abits, wbits, vind):
+        orig_n = self.build_aw_node(abits=abits, wbits=wbits)
+        graph_mock.nodes = [orig_n]
+        vw_n = VirtualSplitWeightsNode(copy.deepcopy(orig_n), self.kernel_attr)
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_n, ret_inds = helper._retrieve_matching_orig_w_candidates(vw_n, vind)
+        assert ret_n is orig_n
+        self._validate_weights(orig_n, ret_inds, vw_n, vind)
+
+        va_n = VirtualSplitActivationNode(copy.deepcopy(orig_n), self.VALayer, {})
+        assert helper._retrieve_matching_orig_w_candidates(va_n, vind) == (None, None)
+
+    @pytest.mark.parametrize('orig_a_n, build_va, orig_w_n, v_ind', [
+        (build_a_node(abits=(2, 4, 8, 16)), False, build_aw_node(abits=(5, 7), wbits=(3, 6, 9)), 11),
+        (build_a_node(abits=(2, 4, 8, 16)), True, build_aw_node(abits=(5, 7), wbits=(3, 6, 9)), 7),
+        (build_a_node(abits=(2, 4, 8, 16)), True, build_aw_node(abits=(5, 7), wbits=(3,)), 2),
+        (build_a_node(abits=(2,)), False, build_aw_node(abits=(5, 7), wbits=(3, 4, 6)), 2),
+        (build_a_node(abits=(2,)), True, build_aw_node(abits=(8,), wbits=(11,)), 0)
+    ])
+    def test_retrieve_w_candidates_virt_aw_node(self, graph_mock, orig_a_n, build_va, orig_w_n, v_ind):
+        graph_mock.nodes = [orig_a_n]
+        a_n = copy.deepcopy(orig_a_n)
+        if build_va:
+            a_n = VirtualSplitActivationNode(a_n, self.VALayer, {})
+        vaw_n = VirtualActivationWeightsNode(act_node=a_n,
+                                             weights_node=VirtualSplitWeightsNode(orig_w_n, self.kernel_attr),
+                                             fw_info=self.fw_info_mock)
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_n, ret_inds = helper._retrieve_matching_orig_a_candidates(vaw_n, v_ind)
+        assert ret_n is orig_a_n
+        self._validate_activation(orig_a_n, ret_inds, vaw_n, v_ind)
+
+    @pytest.mark.parametrize('build_va, v_ind', [(False, 5)]) #[(True, 8), (False, 5)])
+    def test_retrieve_w_candidates_virt_aw_node_multiple_weights(self, graph_mock, build_va, v_ind):
+        """ A node contains non-kernel non-configurable weights, w node contains additional non-configurable weight,
+            some of weight attrs are identical. Configs should be retrieved by configurable weight of w_node. """
+        orig_a_node = build_node(
+            'a', layer_class=self.ALayer,
+            canonical_weights={'foo': np.ones(2), 'bar': np.ones(3), 1: np.ones(4)},
+            qcs=[build_nbits_qc(ab, True, w_attr={'foo': (4, True), 'bar': (5, True)},
+                                pos_attr=(6, True, [1])) for ab in (2, 3, 7)]
+        )
+        orig_w_node = build_node(
+            'a', layer_class=self.AWLayer,
+            canonical_weights={'bar': np.ones(2), self.kernel_attr: np.ones(3), 1: np.ones(4)},
+            qcs=[build_nbits_qc(ab, True, w_attr={'bar': (4, True), self.kernel_attr: (wb, True)},
+                                pos_attr=(6, True, [1])) for ab in (2, 3) for wb in (9, 10, 11)]
+        )
+        graph_mock.nodes = [orig_a_node, orig_w_node]
+        a_node = copy.deepcopy(orig_a_node)
+        if build_va:
+            a_node = VirtualSplitActivationNode(a_node, self.ALayer, {})
+        vaw = VirtualActivationWeightsNode(act_node=a_node,
+                                           weights_node=VirtualSplitWeightsNode(copy.deepcopy(orig_w_node), self.kernel_attr),
+                                           fw_info=self.fw_info_mock)
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_n, ret_inds = helper._retrieve_matching_orig_w_candidates(vaw, v_ind)
+        assert ret_n is orig_w_node
+        self._validate_weights(orig_w_node, ret_inds, vaw, v_ind, attrs=[self.kernel_attr])
+
+    def test_reconstruct_separate_aw_configs_regular_nodes(self, graph_mock):
+        mpa = self.build_a_node(name='mpa', abits=(4, 8, 16))
+        mpa_mpw = self.build_aw_node(name='mpa_mpw', abits=(2, 3, 4), wbits=(5, 6))
+        spa_mpw = self.build_aw_node(name='spa_mpw', abits=(2,), wbits=(5, 6, 7))
+        mpa_spw = self.build_aw_node(name='mpa_spw', abits=(2, 3, 4), wbits=(5,))
+        graph_mock.nodes = [mpa, mpa_mpw, spa_mpw, mpa_spw]
+
+        helper = ConfigReconstructionHelper(graph_mock)
+        v_cfg = {mpa: 1, mpa_mpw: 4, spa_mpw: 2, mpa_spw: 1}
+        a_cfg, w_cfg = helper.reconstruct_separate_aw_configs(v_cfg, include_non_configurable=False)
+        assert a_cfg == {n: v_cfg[n] for n in (mpa, mpa_mpw, mpa_spw)}
+        assert w_cfg == {n: v_cfg[n] for n in (mpa_mpw, spa_mpw)}
+
+        a_cfg, w_cfg = helper.reconstruct_separate_aw_configs(v_cfg, include_non_configurable=True)
+        assert a_cfg == {n: v_cfg[n] for n in (mpa, mpa_mpw, spa_mpw, mpa_spw)}
+        assert w_cfg == {n: v_cfg[n] for n in (mpa_mpw, spa_mpw, mpa_spw)}
+
+    @pytest.mark.parametrize('incl_non_conf', [True, False])
+    def test_reconstruct_separate_aw_configs_virtual_nodes(self, graph_mock, incl_non_conf):
+        spa = self.build_a_node(name='spa', abits=(4,))
+        mpa_mpw = self.build_aw_node(name='mpa_mpw', abits=(2, 3, 4), wbits=(5, 6, 7))
+        mpa_spw = self.build_aw_node(name='mpa_spw', abits=(7, 8, 9), wbits=(5,))
+        mpa_mpw2 = self.build_aw_node(name='mpa_mpw2', abits=(6, 7), wbits=(3, 4, 5))
+        graph_mock.nodes = [spa, mpa_mpw, mpa_spw, mpa_mpw2]
+        vaw1 = VirtualActivationWeightsNode(copy.deepcopy(spa),
+                                            VirtualSplitWeightsNode(copy.deepcopy(mpa_mpw), self.kernel_attr),
+                                            self.fw_info_mock)
+        va1 = VirtualSplitActivationNode(copy.deepcopy(mpa_spw), self.ALayer, {})
+        vw = VirtualSplitWeightsNode(copy.deepcopy(mpa_mpw2), self.kernel_attr)
+        vaw2 = VirtualActivationWeightsNode(VirtualSplitActivationNode(copy.deepcopy(mpa_mpw2), self.ALayer, {}),
+                                            VirtualSplitWeightsNode(copy.deepcopy(mpa_spw), self.kernel_attr),
+                                            self.fw_info_mock)
+
+        v_cfg = {vaw1: 2, va1: 1, vw: 2, vaw2: 1}
+
+        def validate_activation(n, vn, ret_cfg):
+            assert self._get_activation_cfg(n, ret_cfg[n]) == self._get_activation_cfg(vn, v_cfg[vn])
+
+        def validate_weights(n, vn, ret_cfg):
+            assert self._get_weights_cfg(n, ret_cfg[n]) == self._get_weights_cfg(vn, v_cfg[vn])
+
+        helper = ConfigReconstructionHelper(graph_mock)
+        a_cfg, w_cfg = helper.reconstruct_separate_aw_configs(v_cfg, include_non_configurable=incl_non_conf)
+        if incl_non_conf:
+            assert set(a_cfg.keys()) == {spa, mpa_spw, mpa_mpw2}
+            assert set(w_cfg.keys()) == {mpa_spw, mpa_mpw, mpa_mpw2}
+        else:
+            assert set(a_cfg.keys()) == {mpa_spw, mpa_mpw2}
+            assert set(w_cfg.keys()) == {mpa_mpw, mpa_mpw2}
+        validate_activation(mpa_spw, va1, a_cfg)
+        validate_activation(mpa_mpw2, vaw2, a_cfg)
+        validate_weights(mpa_mpw, vaw1, w_cfg)
+        validate_weights(mpa_mpw2, vw, w_cfg)
+
+    @pytest.mark.parametrize('incl_non_conf', [True, False])
+    def test_reconstruct_full_configuration(self, graph_mock, incl_non_conf):
+        # orig nodes for virtual nodes
+        spa = self.build_a_node(name='spa', abits=(4,))
+        mpa_mpw = self.build_aw_node(name='mpa_mpw', abits=(2, 3, 4), wbits=(5, 6, 7))
+        mpa_spw = self.build_aw_node(name='mpa_spw', abits=(7, 8, 9), wbits=(5,))
+        spa_mpw = self.build_aw_node(name='spa_mpw', abits=(6,), wbits=(3, 4, 5))
+        # orig nodes as is
+        mpa_mpw2 = self.build_aw_node(name='mpa_mpw2', abits=(4, 5, 6), wbits=(2, 6, 8))
+        mpa_spw2 = self.build_aw_node(name='mpa_spw2', abits=(4, 5, 6), wbits=(3,))
+        spa_mpw2 = self.build_aw_node(name='spa_spw2', abits=(5,), wbits=(2, 6, 8))
+
+        graph_mock.nodes = [spa, mpa_mpw, mpa_spw, spa_mpw, mpa_mpw2, mpa_spw2, spa_mpw2]
+        vaw1 = VirtualActivationWeightsNode(copy.deepcopy(spa),
+                                            VirtualSplitWeightsNode(copy.deepcopy(mpa_mpw), self.kernel_attr),
+                                            self.fw_info_mock)
+        vaw2 = VirtualActivationWeightsNode(VirtualSplitActivationNode(copy.deepcopy(mpa_mpw), self.ALayer, {}),
+                                            VirtualSplitWeightsNode(copy.deepcopy(mpa_spw), self.kernel_attr),
+                                            self.fw_info_mock)
+        va = VirtualSplitActivationNode(copy.deepcopy(mpa_spw), self.ALayer, {})
+        vw = VirtualSplitWeightsNode(copy.deepcopy(spa_mpw), self.kernel_attr)
+
+        v_cfg = {vaw1: 2, vaw2: 1, va: 2, vw: 2, mpa_mpw2: 7, mpa_spw2: 1, spa_mpw2: 2}
+
+        def validate_activation(n, vn, ret_cfg):
+            assert self._get_activation_cfg(n, ret_cfg[n]) == self._get_activation_cfg(vn, v_cfg[vn]), n
+
+        def validate_weights(n, vn, ret_cfg):
+            assert self._get_weights_cfg(n, ret_cfg[n]) == self._get_weights_cfg(vn, v_cfg[vn]), n
+
+        helper = ConfigReconstructionHelper(graph_mock)
+        ret_cfg = helper.reconstruct_full_configuration(v_cfg, include_non_configurable=incl_non_conf)
+
+        exp_keys = {mpa_mpw, mpa_spw, spa_mpw, mpa_mpw2, spa_mpw2, mpa_spw2}
+        if incl_non_conf:
+            exp_keys.add(spa)
+            assert ret_cfg[spa] == 0
+        assert set(ret_cfg.keys()) == exp_keys
+        validate_activation(mpa_mpw, vaw2, ret_cfg)
+        validate_weights(mpa_mpw, vaw1, ret_cfg)
+        validate_activation(mpa_spw, va, ret_cfg)
+        validate_weights(spa_mpw, vw, ret_cfg)
+        for n in (mpa_mpw2, spa_mpw2, mpa_spw2):
+            assert v_cfg[n] == ret_cfg[n], n
+
+    def _validate_activation(self, orig_n, ret_inds, vn, vind):
+        """ Validates that all returned candidate indices of the original node match activation config of the virtual
+            candidate, and all matching indices have been retrieved. """
+        for i, _ in enumerate(orig_n.candidates_quantization_cfg):
+            if i in ret_inds:
+                assert self._get_activation_cfg(orig_n, i) == self._get_activation_cfg(vn, vind)
+            else:
+                assert (self._get_activation_cfg(orig_n, i).activation_n_bits !=
+                        self._get_activation_cfg(vn, vind).activation_n_bits)
+
+    def _validate_weights(self, orig_n, ret_inds, vn, vind, attrs=None):
+        """ Validates that all returned candidate indices of the original node match eights config of the virtual
+            candidate, and all matching indices have been retrieved. """
+        for i, _ in enumerate(orig_n.candidates_quantization_cfg):
+            orig_cfg = self._get_weights_cfg(orig_n, i)
+            v_cfg = self._get_weights_cfg(vn, vind)
+            if i in ret_inds:
+                if attrs:
+                    assert all(orig_cfg.get_attr_config(attr) == v_cfg.get_attr_config(attr) for attr in attrs)
+                else:
+                    assert orig_cfg == v_cfg
+            else:
+                attrs = attrs or orig_n.weights.keys()
+                assert any(orig_cfg.get_attr_config(attr).weights_n_bits != v_cfg.get_attr_config(attr).weights_n_bits
+                           for attr in attrs)
+
+    @staticmethod
+    def _get_activation_cfg(n, ind):
+        return n.candidates_quantization_cfg[ind].activation_quantization_cfg
+
+    @staticmethod
+    def _get_weights_cfg(n, ind):
+        return n.candidates_quantization_cfg[ind].weights_quantization_cfg
+
+    # def test_config(self, graph_mock, fw_info_mock):
+    #     mpa_mpw = self.build_aw_node('mpa_mpw', abits=(4, 8, 16), wbits=(2, 6, 10))
+    #     mpa_spw = self.build_aw_node('mpa_spw', abits=(5, 7, 10), wbits=(2,))
+    #     spa_mpw = self.build_aw_node('spa_mpw', abits=(3,), wbits=(2, 4, 8))
+    #     spa_spw = self.build_aw_node('spa_spw', abits=(3,), wbits=(8,))
+    #     mpa = self.build_a_node('mpa', abits=(2, 4, 8))
+    #     spa = self.build_a_node('spa', abits=(5,))
+    #     graph_mock.nodes = [mpa_mpw, mpa_spw, spa_mpw, spa_spw, mpa, spa]
+    #     fw_info_mock.get_kernel_op_attributes = lambda nt: 'w' if DummyLayer1 else DEFAULT_KERNEL_ATTRIBUTES
+    #
+    #
+    #
+    #     helper = ConfigReconstructionHelper(graph_mock)
+    #
+    #
+    #     # mp virt a, mp virt w
+    #     va = VirtualSplitActivationNode(mpa_mpw, ALayer, {})
+    #
+    #     ret_cfg = helper.reconstruct_configuration({va: 2})
+    #     assert len(ret_cfg) == 1 and mpa_mpw in ret_cfg
+    #     assert get_activation_cfg(mpa_mpw, ret_cfg[mpa_mpw]) == get_activation_cfg(va, 2)
+    #
+    #     vaw = VirtualActivationWeightsNode(va, VirtualSplitWeightsNode(mpa_mpw), fw_info_mock)
+    #     ret_cfg = helper.reconstruct_configuration({va2: 2})
+    #     assert len(ret_cfg) == 1 and mpa_mpw in ret_cfg
+    #     assert get_activation_cfg(mpa_mpw, ret_cfg[mpa_mpw]) == get_activation_cfg(va, 2)
+    #
+    #     assert len(ret_cfg) == 1 and mpa in ret_cfg
+    #     assert get_activation_cfg(mpa, ret_cfg[mpa]) == get_activation_cfg(va1, 2)
+    #
+    #     # va2 = VirtualSplitActivationNode(mpa_mpw, ALayer, {})
+    #     # vaw1 = VirtualActivationWeightsNode(spa, VirtualSplitWeightsNode(spa_mpw), fw_info_mock)
+    #     # vaw2 = VirtualActivationWeightsNode(va1, VirtualSplitWeightsNode(mpa_mpw), fw_info_mock)
+    #     #
+    #     #
+    #     # virtual_cfg = {va1: 2, va2: 1, vaw1: 1, vaw2: 7}
+    #     # ret_cfg = helper.reconstruct_configuration(virtual_cfg)
+        # assert set(ret_cfg.keys()) == {mpa, va1, spa_mpw, mpa_mpw}
+        # assert get_activation_cfg(mpa, ret_cfg[mpa]) == get_activation_cfg(va1, virtual_cfg[va1])
+        #
+        #
+        #
+        #
+        # # va2 = VirtualSplitActivationNode(spa, ALayer, {})
+        # # vw1 = VirtualSplitWeightsNode(spa_mpw)
+        # # vw1 = VirtualSplitWeightsNode(mpa_spw)
+        # # vaw3 = VirtualActivationWeightsNode(mpa, VirtualSplitWeightsNode(mpa_spw), fw_info_mock)
+        # # vaw4 = VirtualActivationWeightsNode(spa, VirtualSplitWeightsNode(spa_spw), fw_info_mock)
+        # #
+        # # vaw7 = VirtualActivationWeightsNode(va2, VirtualSplitWeightsNode(spa_spw), fw_info_mock)
+
+
+
+
+
+
+
+
+
+        helper = ConfigReconstructionHelper(graph_mock)
+        helper.reconstruct_full_configuration({}, )
+

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
@@ -382,8 +382,7 @@ class TestConfigHelper:
         (build_aw_node(abits=(4, 8, 16), wbits=(2, 6, 10)), 8),
         (build_aw_node(abits=(4, 8, 16), wbits=(2, 6, 10)), 1),
         (build_aw_node(abits=(5,), wbits=(2, 4, 8)), 1),
-        (build_aw_node(abits=(4, 8, 16), wbits=(5,)), 2),
-        (build_a_node(abits=(5, 3, 7)), 0)
+        (build_aw_node(abits=(4, 8, 16), wbits=(5,)), 2)
     ])
     def test_retrieve_w_candidates_regular_node(self, graph_mock, n, ind):
         graph_mock.nodes = [n]
@@ -596,66 +595,3 @@ class TestConfigHelper:
     @staticmethod
     def _get_weights_cfg(n, ind):
         return n.candidates_quantization_cfg[ind].weights_quantization_cfg
-
-    # def test_config(self, graph_mock, fw_info_mock):
-    #     mpa_mpw = self.build_aw_node('mpa_mpw', abits=(4, 8, 16), wbits=(2, 6, 10))
-    #     mpa_spw = self.build_aw_node('mpa_spw', abits=(5, 7, 10), wbits=(2,))
-    #     spa_mpw = self.build_aw_node('spa_mpw', abits=(3,), wbits=(2, 4, 8))
-    #     spa_spw = self.build_aw_node('spa_spw', abits=(3,), wbits=(8,))
-    #     mpa = self.build_a_node('mpa', abits=(2, 4, 8))
-    #     spa = self.build_a_node('spa', abits=(5,))
-    #     graph_mock.nodes = [mpa_mpw, mpa_spw, spa_mpw, spa_spw, mpa, spa]
-    #     fw_info_mock.get_kernel_op_attributes = lambda nt: 'w' if DummyLayer1 else DEFAULT_KERNEL_ATTRIBUTES
-    #
-    #
-    #
-    #     helper = ConfigReconstructionHelper(graph_mock)
-    #
-    #
-    #     # mp virt a, mp virt w
-    #     va = VirtualSplitActivationNode(mpa_mpw, ALayer, {})
-    #
-    #     ret_cfg = helper.reconstruct_configuration({va: 2})
-    #     assert len(ret_cfg) == 1 and mpa_mpw in ret_cfg
-    #     assert get_activation_cfg(mpa_mpw, ret_cfg[mpa_mpw]) == get_activation_cfg(va, 2)
-    #
-    #     vaw = VirtualActivationWeightsNode(va, VirtualSplitWeightsNode(mpa_mpw), fw_info_mock)
-    #     ret_cfg = helper.reconstruct_configuration({va2: 2})
-    #     assert len(ret_cfg) == 1 and mpa_mpw in ret_cfg
-    #     assert get_activation_cfg(mpa_mpw, ret_cfg[mpa_mpw]) == get_activation_cfg(va, 2)
-    #
-    #     assert len(ret_cfg) == 1 and mpa in ret_cfg
-    #     assert get_activation_cfg(mpa, ret_cfg[mpa]) == get_activation_cfg(va1, 2)
-    #
-    #     # va2 = VirtualSplitActivationNode(mpa_mpw, ALayer, {})
-    #     # vaw1 = VirtualActivationWeightsNode(spa, VirtualSplitWeightsNode(spa_mpw), fw_info_mock)
-    #     # vaw2 = VirtualActivationWeightsNode(va1, VirtualSplitWeightsNode(mpa_mpw), fw_info_mock)
-    #     #
-    #     #
-    #     # virtual_cfg = {va1: 2, va2: 1, vaw1: 1, vaw2: 7}
-    #     # ret_cfg = helper.reconstruct_configuration(virtual_cfg)
-        # assert set(ret_cfg.keys()) == {mpa, va1, spa_mpw, mpa_mpw}
-        # assert get_activation_cfg(mpa, ret_cfg[mpa]) == get_activation_cfg(va1, virtual_cfg[va1])
-        #
-        #
-        #
-        #
-        # # va2 = VirtualSplitActivationNode(spa, ALayer, {})
-        # # vw1 = VirtualSplitWeightsNode(spa_mpw)
-        # # vw1 = VirtualSplitWeightsNode(mpa_spw)
-        # # vaw3 = VirtualActivationWeightsNode(mpa, VirtualSplitWeightsNode(mpa_spw), fw_info_mock)
-        # # vaw4 = VirtualActivationWeightsNode(spa, VirtualSplitWeightsNode(spa_spw), fw_info_mock)
-        # #
-        # # vaw7 = VirtualActivationWeightsNode(va2, VirtualSplitWeightsNode(spa_spw), fw_info_mock)
-
-
-
-
-
-
-
-
-
-        helper = ConfigReconstructionHelper(graph_mock)
-        helper.reconstruct_full_configuration({}, )
-

--- a/tests_pytest/keras_tests/integration_tests/core/mixed_precision/test_resource_utilization.py
+++ b/tests_pytest/keras_tests/integration_tests/core/mixed_precision/test_resource_utilization.py
@@ -23,8 +23,8 @@ from tests_pytest.keras_tests.keras_test_util.keras_test_mixin import KerasFwMix
 
 
 class TestRUIntegrationKeras(BaseRUIntegrationTester, KerasFwMixin):
-    def test_orig_vs_virtual_graph_ru(self):
-        super().test_orig_vs_virtual_graph_ru()
+    def test_compute_ru(self):
+        super().test_compute_ru()
 
     def test_mult_output_activation(self):
         super().test_mult_output_activation()

--- a/tests_pytest/pytorch_tests/integration_tests/core/mixed_precision/test_resource_utilization.py
+++ b/tests_pytest/pytorch_tests/integration_tests/core/mixed_precision/test_resource_utilization.py
@@ -21,8 +21,8 @@ from tests_pytest.pytorch_tests.torch_test_util.torch_test_mixin import TorchFwM
 
 
 class TestRUIntegrationTorch(BaseRUIntegrationTester, TorchFwMixin):
-    def test_orig_vs_virtual_graph_ru(self):
-        super().test_orig_vs_virtual_graph_ru()
+    def test_compute_ru(self):
+        super().test_compute_ru()
 
     def test_mult_output_activation(self):
         super().test_mult_output_activation()


### PR DESCRIPTION
## Pull Request Description:
* Rewrite virtual config reconstruction helper. Add support for separate configuration for activation and weights, in preparation for float mp baseline model - so that we can quantize layers activation only or weights only, even though candidates quantize both.
* Remove activation candidates from virtual weights split node (it was a hack needed when computing RU on virtual graph, which is not done anymore).
* Remove support for virtual graph from RU calculator, enable calculating bops for case when input activation has multiple outputs (still results in underestimation, but less so).

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).