### PR TITLE
Use float mp model baseline instead of maxbit configuration

### DIFF
--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_facade.py
@@ -98,10 +98,11 @@ def search_bit_width(graph: Graph,
 
     # Search manager and LP are highly coupled, so LP search method was moved inside search manager.
     search_manager = MixedPrecisionSearchManager(graph,
-                                                 fw_info,
-                                                 fw_impl,
-                                                 se,
-                                                 target_resource_utilization)
+                                                 fw_info=fw_info,
+                                                 fw_impl=fw_impl,
+                                                 sensitivity_evaluator=se,
+                                                 target_resource_utilization=target_resource_utilization,
+                                                 mp_config=mp_config)
     nodes_bit_cfg = search_manager.search()
 
     graph.skip_validation_check = False

--- a/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
+++ b/model_compression_toolkit/core/common/mixed_precision/mixed_precision_search_manager.py
@@ -178,6 +178,8 @@ class MixedPrecisionSearchManager:
         def ensure_maxbit_minimal_metric(node_candidates_metrics, max_ind):
             if eps is None:
                 return node_candidates_metrics
+            # We want maxbit configuration to have the minimal distance metric (so that optimization objective
+            # doesn't prefer lower bits). If we got a smaller metric for non-maxbit, we update it to metric(maxbit)+eps.
             max_val = node_candidates_metrics[max_ind]
             metrics = np.maximum(node_candidates_metrics, max_val + eps)
             metrics[max_ind] = max_val

--- a/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
+++ b/model_compression_toolkit/core/common/mixed_precision/sensitivity_evaluation.py
@@ -287,7 +287,7 @@ class SensitivityEvaluation:
             raise ValueError(f'Requested configuration is either empty or contain only None values.')
 
         # defined here so that it can't be used directly
-        def configure(a_cfg, w_cfg):
+        def apply_bitwidth_config(a_cfg, w_cfg):
             node_names = set(a_cfg.keys()).union(set(w_cfg.keys()))
             for n in node_names:
                 node_quant_layers = self.conf_node2layers.get(n)
@@ -306,11 +306,11 @@ class SensitivityEvaluation:
                 raise ValueError(f'Not all mp configs were consumed, remaining activation config {a_cfg}, '
                                  f'weights config {w_cfg}.')
 
-        configure(mp_a_cfg.copy(), mp_w_cfg.copy())
+        apply_bitwidth_config(mp_a_cfg.copy(), mp_w_cfg.copy())
         try:
             yield
         finally:
-            configure({n: None for n in mp_a_cfg}, {n: None for n in mp_w_cfg})
+            apply_bitwidth_config({n: None for n in mp_a_cfg}, {n: None for n in mp_w_cfg})
 
     def _compute_points_distance(self,
                                  baseline_tensors: List[Any],

--- a/model_compression_toolkit/core/common/mixed_precision/set_layer_to_bitwidth.py
+++ b/model_compression_toolkit/core/common/mixed_precision/set_layer_to_bitwidth.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Optional, TYPE_CHECKING
+import typing
+from typing import Any, Optional
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
 
 
@@ -31,8 +32,7 @@ def set_activation_quant_layer_to_bitwidth(quantization_layer: Any,
         fw_impl: framework implementation object.
     """
     assert isinstance(quantization_layer, fw_impl.activation_quant_layer_cls)
-    # TODO irena enable after float mp
-    # assert isinstance(quantization_layer.activation_holder_quantizer, fw_impl.configurable_activation_quantizer_cls)
+    assert isinstance(quantization_layer.activation_holder_quantizer, fw_impl.configurable_activation_quantizer_cls)
     quantization_layer.activation_holder_quantizer.set_active_activation_quantizer(bitwidth_idx)
 
 
@@ -51,7 +51,6 @@ def set_weights_quant_layer_to_bitwidth(quantization_layer: Any,
     assert isinstance(quantization_layer, fw_impl.weights_quant_layer_cls)
     configurable_quantizers = [q for q in quantization_layer.weights_quantizers.values()
                                if isinstance(q, fw_impl.configurable_weights_quantizer_cls)]
-    # TODO irena enable after float mp
-    # assert configurable_quantizers
+    assert configurable_quantizers
     for quantizer in configurable_quantizers:
         quantizer.set_weights_bit_width_index(bitwidth_idx)

--- a/model_compression_toolkit/core/common/mixed_precision/set_layer_to_bitwidth.py
+++ b/model_compression_toolkit/core/common/mixed_precision/set_layer_to_bitwidth.py
@@ -15,7 +15,7 @@
 import typing
 from typing import Any, Optional
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:    # pragma: no cover
     from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
 
 

--- a/model_compression_toolkit/core/common/mixed_precision/solution_refinement_procedure.py
+++ b/model_compression_toolkit/core/common/mixed_precision/solution_refinement_procedure.py
@@ -104,10 +104,11 @@ def greedy_solution_refinement_procedure(mp_solution: Dict[BaseNode, int],
             new_solution[node_idx_to_upgrade] = nodes_next_candidate[node_idx_to_upgrade]
             changed = True
 
-    if any([mp_solution[n] != new_solution[n] for n in mp_solution]):
-        Logger.info(f'Greedy MP algorithm changed configuration from (numbers represent indices of the '
-                    f'chosen bit-width candidate for each layer):\n{mp_solution}\nto\n{new_solution}')
-
+    changed_solutions = {n: (sol, new_solution[n]) for n, sol in mp_solution.items() if sol != new_solution[n]}
+    if changed_solutions:
+        msg = '\n'.join(f'{n.name}: {mp_solution[n]} -> {new_solution[n]}' for n in changed_solutions)
+        Logger.info(f'Greedy MP algorithm changed configuration for {len(changed_solutions)} out of {len(mp_solution)} '
+                    f'layers (numbers represent indices of the chosen bit-width candidate for each layer):\n{msg}')
     return new_solution
 
 

--- a/model_compression_toolkit/core/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/node_quantization_config.py
@@ -549,6 +549,13 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
         """
         return {attr: self.get_attr_config(attr) for attr in self.all_weight_attrs}
 
+    def disable_all_weights_quantization(self):
+        """ Disable quantization for all weights. """
+        for w_cfg in self.pos_attributes_config_mapping.values():
+            w_cfg.enable_weights_quantization = False
+        for w_cfg in self.attributes_config_mapping.values():
+            w_cfg.enable_weights_quantization = False
+
     def _extract_config_for_attributes_with_name(self, attr_name) -> Dict[str, WeightsAttrQuantizationConfig]:
         """
         Extract the saved attributes that contain the given attribute name.

--- a/model_compression_toolkit/core/common/similarity_analyzer.py
+++ b/model_compression_toolkit/core/common/similarity_analyzer.py
@@ -194,7 +194,7 @@ def compute_cs(float_tensor: np.ndarray,
     cs = np.sum(float_flat * fxp_flat, axis=axis) / ((float_norm * fxp_norm) + eps)
 
     # Return a non-negative float (smaller value -> more similarity)
-    return (1.0 - cs) / 2.0
+    return np.maximum((1.0 - cs) / 2.0, 0)
 
 
 def compute_lp_norm(float_tensor: np.ndarray,

--- a/tests_pytest/_fw_tests_common_base/base_sensitivity_eval_integ_test.py
+++ b/tests_pytest/_fw_tests_common_base/base_sensitivity_eval_integ_test.py
@@ -1,0 +1,289 @@
+# Copyright 2025 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Copyright 2025 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import abc
+from typing import Dict, Optional, Type, Callable, Tuple
+
+import numpy as np
+import pytest
+
+from model_compression_toolkit.core import MixedPrecisionQuantizationConfig, CoreConfig, QuantizationConfig, \
+    FrameworkInfo
+from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
+from model_compression_toolkit.core.common.mixed_precision.sensitivity_evaluation import SensitivityEvaluation
+from model_compression_toolkit.core.quantization_prep_runner import quantization_preparation_runner
+from model_compression_toolkit.target_platform_capabilities import AttributeQuantizationConfig, OpQuantizationConfig, \
+    Signedness, QuantizationConfigOptions, OperatorSetNames, TargetPlatformCapabilities, QuantizationMethod
+from model_compression_toolkit.target_platform_capabilities.constants import KERNEL_ATTR, BIAS_ATTR
+from tests_pytest._test_util.fw_test_base import BaseFWIntegrationTest
+from tests_pytest._test_util.tpc_util import configure_mp_opsets_for_kernel_bias_ops, configure_mp_activation_opsets
+
+
+def build_tpc(w_nbits=(8, 4, 2), a_nbits=(16, 8)):
+    default_w_cfg = AttributeQuantizationConfig(weights_quantization_method=QuantizationMethod.POWER_OF_TWO,
+                                                weights_n_bits=8,
+                                                weights_per_channel_threshold=False,
+                                                enable_weights_quantization=True)
+    default_op_cfg = OpQuantizationConfig(
+        default_weight_attr_config=default_w_cfg.clone_and_edit(enable_weights_quantization=False),
+        attr_weights_configs_mapping={},
+        activation_quantization_method=QuantizationMethod.POWER_OF_TWO,
+        activation_n_bits=8,
+        supported_input_activation_n_bits=[16, 8],
+        enable_activation_quantization=True,
+        quantization_preserving=False,
+        fixed_scale=None, fixed_zero_point=None, simd_size=32, signedness=Signedness.AUTO)
+
+    # make bias quantizable
+    default_w_op_cfg = default_op_cfg.clone_and_edit(
+        attr_weights_configs_mapping={KERNEL_ATTR: default_w_cfg, BIAS_ATTR: default_w_cfg}
+    )
+    default_cfg = QuantizationConfigOptions(quantization_configurations=[default_op_cfg])
+
+    # configurable activation + weights
+    ops_conv, _ = configure_mp_opsets_for_kernel_bias_ops(opset_names=[OperatorSetNames.CONV],
+                                                          base_w_config=default_w_cfg, base_op_config=default_w_op_cfg,
+                                                          w_nbits=w_nbits, a_nbits=a_nbits)
+    # configurable activations
+    ops_relu, _ = configure_mp_activation_opsets(opset_names=[OperatorSetNames.RELU],
+                                                 base_op_config=default_op_cfg, a_nbits=a_nbits)
+    # configurable activation
+    ops_convtr, _ = configure_mp_opsets_for_kernel_bias_ops(opset_names=[OperatorSetNames.CONV_TRANSPOSE],
+                                                            base_w_config=default_w_cfg, base_op_config=default_w_op_cfg,
+                                                            w_nbits=[default_w_cfg.weights_n_bits], a_nbits=a_nbits)
+
+    # configurable weights
+    ops_fc, _ = configure_mp_opsets_for_kernel_bias_ops(opset_names=[OperatorSetNames.FULLY_CONNECTED],
+                                                        base_w_config=default_w_cfg, base_op_config=default_w_op_cfg,
+                                                        w_nbits=w_nbits, a_nbits=[default_op_cfg.activation_n_bits])
+
+    tpc = TargetPlatformCapabilities(default_qco=default_cfg, tpc_platform_type='test',
+                                     operator_set=ops_conv+ops_convtr+ops_fc+ops_relu, fusing_patterns=None)
+    return tpc
+
+
+class BaseSensitivityEvaluationIntegTester(BaseFWIntegrationTest, abc.ABC):
+    """ Test quantization layers and quantizers configuration when building the models and configuring mp model. """
+    BIAS: str
+    KERNEL: str
+    conv_cls: Type
+    relu_cls: Type
+    convtr_cls: Type
+    fc_cls: Type
+
+    # these will come from FwMixin
+    fw_info: FrameworkInfo
+    fw_impl: FrameworkImplementation
+    fetch_model_layers_by_cls: Callable
+
+    input_shape = (1, 3, 16, 16)
+
+    @abc.abstractmethod
+    def build_model(self, input_shape):
+        """ Build fw model: conv -> relu -> convtr -> flatten -> fc. """
+        pass
+
+    @abc.abstractmethod
+    def infer_models(self, orig_model, mp_model, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """ Run inference for input model and mp model on a given input. """
+        pass
+
+    def repr_datagen(self):
+        yield [np.random.rand(*self.input_shape)]
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.model = self.build_model(self.input_shape)
+        tpc = build_tpc(w_nbits=(8, 4, 2), a_nbits=(16, 8))
+        core_config = CoreConfig(quantization_config=QuantizationConfig(),
+                                 mixed_precision_config=MixedPrecisionQuantizationConfig())
+        g = self.run_graph_preparation(self.model, self.repr_datagen, tpc=tpc,
+                                       quant_config=core_config.quantization_config, mp=True)
+        self.g = quantization_preparation_runner(g, self.repr_datagen, core_config=core_config,
+                                                 fw_info=self.fw_info, fw_impl=self.fw_impl, hessian_info_service=None)
+        self.se = SensitivityEvaluation(g, core_config.mixed_precision_config, self.repr_datagen,
+                                        fw_info=self.fw_info, fw_impl=self.fw_impl,
+                                        disable_activation_for_metric=False, hessian_info_service=None)
+
+    def test_build_models(self):
+        """ Test quant layers and quantizers are built and configured correctly for the mp model,
+            and the mapping from nodes to configurable quant layers is correct. """
+        model, g, se = self.model, self.g, self.se
+        # sanity check that we set up the configuration we intended, and it was correctly configured
+        conf_a_nodes = [n for n in g.get_topo_sorted_nodes() if n.has_configurable_activation()]
+        assert [n.layer_class for n in conf_a_nodes] == [self.conv_cls, self.relu_cls, self.convtr_cls]
+        conf_w_nodes = [n for n in g.get_topo_sorted_nodes() if n.has_any_configurable_weight()]
+        assert [n.layer_class for n in conf_w_nodes] == [self.conv_cls, self.fc_cls]
+        # we quantize biases, to make sure their quantization is going to be disabled since they are not configurable
+        assert all(n.is_weights_quantization_enabled(self.BIAS) for n in conf_w_nodes)
+
+        # only configurable activations / weights should have quantization layers
+        # and all quantizers should be disabled. They will be turned on one by one per candidate.
+        activation_holders = self.fetch_model_layers_by_cls(se.model_mp, self.fw_impl.activation_quant_layer_cls)
+        assert len(activation_holders) == len(conf_a_nodes)
+        for ah in activation_holders:
+            assert isinstance(ah.activation_holder_quantizer, self.fw_impl.configurable_activation_quantizer_cls)
+            assert ah.activation_holder_quantizer.active_quantization_config_index is None
+        weight_wrappers = self.fetch_model_layers_by_cls(se.model_mp, self.fw_impl.weights_quant_layer_cls)
+        for ww in weight_wrappers:
+            # bias should not have quantizer
+            assert len(ww.weights_quantizers) == 1
+            assert isinstance(ww.weights_quantizers[self.KERNEL], self.fw_impl.configurable_weights_quantizer_cls)
+            assert ww.weights_quantizers[self.KERNEL].active_quantization_config_index is None
+
+        # verify mapping from graph nodes to configurable model layers
+        assert len(se.conf_node2layers) == 4
+        conv, relu, convtr = conf_a_nodes
+        _, fc = conf_w_nodes
+        assert len(se.conf_node2layers[conv.name]) == 2
+        assert set(se.conf_node2layers[conv.name]) == {activation_holders[0], weight_wrappers[0]}
+        assert len(se.conf_node2layers[relu.name]) == 1 and se.conf_node2layers[relu.name][0] == activation_holders[1]
+        assert len(se.conf_node2layers[convtr.name]) == 1 and se.conf_node2layers[convtr.name][0] == activation_holders[2]
+        assert len(se.conf_node2layers[fc.name]) == 1 and se.conf_node2layers[fc.name][0] == weight_wrappers[1]
+
+        # baseline float model doesn't contain any quant layers
+        activation_holders = self.fetch_model_layers_by_cls(se.baseline_model, self.fw_impl.activation_quant_layer_cls)
+        weight_wrappers = self.fetch_model_layers_by_cls(se.baseline_model, self.fw_impl.weights_quant_layer_cls)
+        assert not activation_holders and not weight_wrappers
+
+        # sanity check that initial mp model is indeed un-quantized (identical to original model)
+        x = next(self.repr_datagen())[0]
+        y, y_mp = self.infer_models(model, se.model_mp, x)
+        assert np.array_equal(y, y_mp)
+        # sanity check that baseline model is identical to original model
+        _, y_float = self.infer_models(model, se.baseline_model, x)
+        assert np.array_equal(y, y_float)
+
+    def test_build_models_disable_activations(self):
+        """ Test mp model with disabled activation flag. """
+        model, g = self.model, self.g
+        se = SensitivityEvaluation(g, MixedPrecisionQuantizationConfig(), self.repr_datagen,
+                                   fw_info=self.fw_info, fw_impl=self.fw_impl,
+                                   disable_activation_for_metric=True, hessian_info_service=None)
+        activation_holders = self.fetch_model_layers_by_cls(se.model_mp, self.fw_impl.activation_quant_layer_cls)
+        assert not activation_holders
+        weight_wrappers = self.fetch_model_layers_by_cls(se.model_mp, self.fw_impl.weights_quant_layer_cls)
+        assert len(weight_wrappers) == 2
+
+    def test_configure_mp_model(self):
+        """ Test mp model configuration. """
+        model, g, se = self.model, self.g, self.se
+        # a x w: conv 2x2, relu 2, conv_tr 2x1, fc 1x2
+        conv, relu, conv_tr = [n.name for n in g.get_topo_sorted_nodes() if n.has_configurable_activation()]
+        conv_, fc = [n.name for n in g.get_topo_sorted_nodes() if n.has_any_configurable_weight()]
+        assert conv is conv_
+
+        with se._configured_mp_model(mp_a_cfg={conv: 2}, mp_w_cfg={conv: 1}):
+            self._validate_mpmodel_quant_layers(se, {conv: 2, relu: None, conv_tr: None}, {conv: 1, fc: None})
+            # sanity test that model was indeed quantized
+            y, y_mp = self.infer_models(model, se.model_mp, next(self.repr_datagen())[0])
+            assert not np.allclose(y, y_mp)
+
+        # restored to un-quantized
+        self._validate_mpmodel_quant_layers(se, {conv: None, relu: None, conv_tr: None}, {conv: None, fc: None})
+
+        with se._configured_mp_model(mp_a_cfg={conv: 1}, mp_w_cfg={}):
+            self._validate_mpmodel_quant_layers(se, {conv: 1, relu: None, conv_tr: None}, {conv: None, fc: None})
+
+        with se._configured_mp_model(mp_a_cfg={}, mp_w_cfg={conv: 3}):
+            self._validate_mpmodel_quant_layers(se, {conv: None, relu: None, conv_tr: None}, {conv: 3, fc: None})
+
+        with se._configured_mp_model(mp_a_cfg={conv: None, relu: 1, conv_tr: 0}, mp_w_cfg={fc: 2}):
+            self._validate_mpmodel_quant_layers(se, {conv: None, relu: 1, conv_tr: 0}, {conv: None, fc: 2})
+
+        # restored to un-quantized
+        self._validate_mpmodel_quant_layers(se, {conv: None, relu: None, conv_tr: None}, {conv: None, fc: None})
+
+    def test_configure_mp_model_errors(self):
+        """ Test errors during model configuration. """
+        model, g, se = self.model, self.g, self.se
+        with pytest.raises(ValueError, match='Requested configuration is either empty or contain only None values'):
+            with se._configured_mp_model({}, {}):
+                pass
+
+        conv, relu, conv_tr = [n.name for n in g.get_topo_sorted_nodes() if n.has_configurable_activation()]
+        _, fc = [n.name for n in g.get_topo_sorted_nodes() if n.has_any_configurable_weight()]
+        with pytest.raises(ValueError, match='Requested configuration is either empty or contain only None values'):
+            with se._configured_mp_model({relu: None}, {conv: None}):
+                pass
+
+        with pytest.raises(ValueError, match='Not all mp configs were consumed'):
+            with se._configured_mp_model({conv: 1}, {conv: 0, relu: None}):
+                pass
+
+        with pytest.raises(ValueError, match='Not all mp configs were consumed'):
+            with se._configured_mp_model({conv: 1, fc: 0}, {conv: 0}):
+                pass
+
+    def test_compute_metric_method(self):
+        """ Test compute_metric method (not the metric computation itself) """
+        model, g, se = self.model, self.g, self.se
+        conv, relu, conv_tr = [n.name for n in g.get_topo_sorted_nodes() if n.has_configurable_activation()]
+        conv_, fc = [n.name for n in g.get_topo_sorted_nodes() if n.has_any_configurable_weight()]
+        # initial model is un-quantized
+        self._validate_mpmodel_quant_layers(se, {conv: None, relu: None, conv_tr: None}, {conv: None, fc: None})
+        mp_a_cfg = {conv: 2, relu: 0}
+        mp_w_cfg = {fc: 1}
+
+        def mock_compute_metric(*args):
+            # validate correct configuration inside compute metric
+            self._validate_mpmodel_quant_layers(se, {conv: 2, relu: 0, conv_tr: None}, {conv: None, fc: 1})
+            return 5
+        se._compute_metric = mock_compute_metric
+
+        res = se.compute_metric(mp_a_cfg, mp_w_cfg)
+        assert res == 5
+        # restored to un-quantized
+        self._validate_mpmodel_quant_layers(se, {conv: None, relu: None, conv_tr: None}, {conv: None, fc: None})
+
+    def _validate_mpmodel_quant_layers(self, se: SensitivityEvaluation, exp_node_a_indices: Dict[str, Optional[int]],
+                                       exp_node_w_indices: Dict[str, Optional[int]]):
+        self._validate_mpmodel_a_quant_layers(se, exp_node_a_indices)
+        self._validate_mpmodel_w_quant_layers(se, exp_node_w_indices)
+
+    def _validate_mpmodel_a_quant_layers(self, se: SensitivityEvaluation, exp_node_indices: Dict[str, Optional[int]]):
+        exp_a_layer_indicies = {}
+        for n, ind in exp_node_indices.items():
+            layers = [ql for ql in se.conf_node2layers[n] if isinstance(ql, self.fw_impl.activation_quant_layer_cls)]
+            assert len(layers) == 1
+            exp_a_layer_indicies[layers[0]] = ind
+
+        activation_holders = self.fetch_model_layers_by_cls(se.model_mp, self.fw_impl.activation_quant_layer_cls)
+        for ah in activation_holders:
+            assert ah.activation_holder_quantizer.active_quantization_config_index == exp_a_layer_indicies[ah]
+
+    def _validate_mpmodel_w_quant_layers(self, se: SensitivityEvaluation, exp_node_indices: Dict[str, Optional[int]]):
+        exp_w_layer_indicies = {}
+        for n, ind in exp_node_indices.items():
+            layers = [ql for ql in se.conf_node2layers[n] if isinstance(ql, self.fw_impl.weights_quant_layer_cls)]
+            assert len(layers) == 1
+            exp_w_layer_indicies[layers[0]] = ind
+
+        weight_wrappers = self.fetch_model_layers_by_cls(se.model_mp, self.fw_impl.configurable_weights_quantizer_cls)
+        for ww in weight_wrappers:
+            assert ww.weights_quantizers[self.KERNEL].active_quantization_config_index == exp_w_layer_indicies[ww]

--- a/tests_pytest/_fw_tests_common_base/base_sensitivity_eval_integ_test.py
+++ b/tests_pytest/_fw_tests_common_base/base_sensitivity_eval_integ_test.py
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-# Copyright 2025 Sony Semiconductor Israel, Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 import abc
 from typing import Dict, Optional, Type, Callable, Tuple
 

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_custom_metric_function.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_custom_metric_function.py
@@ -15,7 +15,7 @@
 import pytest
 import numpy as np
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.common.mixed_precision.sensitivity_evaluation import SensitivityEvaluation
@@ -49,29 +49,20 @@ def get_sensitivity_evaluator(custom_metric_fn):
 
     mock_fw_info = Mock()
 
-    def custom_model_builder_return_value(*args, **kwargs):
-        mode = kwargs.get('mode')
-        if mode == ModelBuilderMode.FLOAT:
-            return (None, None)
-        else:
-            return (None, None, None)
-
     def custom_to_tensor(img):
         return img
 
     mock_fw_impl = Mock()
-    mock_fw_impl.model_builder.side_effect = custom_model_builder_return_value
     mock_fw_impl.to_tensor.side_effect = custom_to_tensor
 
     mp_cfg = MixedPrecisionQuantizationConfig(custom_metric_fn=custom_metric_fn)
-
-    sensitivity_eval = SensitivityEvaluation(graph=mock_graph,
-                                             quant_config=mp_cfg,
-                                             representative_data_gen=representative_data_gen,
-                                             fw_info=mock_fw_info,
-                                             fw_impl=mock_fw_impl)
+    with patch.object(SensitivityEvaluation, '_build_models', return_value=(Mock(), Mock(), Mock())):
+        sensitivity_eval = SensitivityEvaluation(graph=mock_graph,
+                                                 quant_config=mp_cfg,
+                                                 representative_data_gen=representative_data_gen,
+                                                 fw_info=mock_fw_info,
+                                                 fw_impl=mock_fw_impl)
     sensitivity_eval._configure_bitwidths_model = lambda *args, **kwargs: None  # Method does nothing
-    sensitivity_eval.model_mp = Mock()
     return sensitivity_eval
 
 
@@ -84,7 +75,7 @@ class TestMPCustomMetricFunction:
     def test_valid_metric_function(self, metric_fn, expected):
         sensitivity_eval = get_sensitivity_evaluator(metric_fn)
         assert len(sensitivity_eval.interest_points) == 0
-        assert sensitivity_eval.compute_metric(Mock()) == expected
+        assert sensitivity_eval.compute_metric({'test': 0}, {'test': 0}) == expected
 
     @pytest.mark.parametrize("metric_fn, expected", [
         (custom_str_metric, str.__name__),
@@ -94,4 +85,4 @@ class TestMPCustomMetricFunction:
         sensitivity_eval = get_sensitivity_evaluator(metric_fn)
         assert len(sensitivity_eval.interest_points) == 0
         with pytest.raises(TypeError, match=f'The custom_metric_fn is expected to return float or numpy float, got {expected}'):
-            sensitivity_metric = sensitivity_eval.compute_metric(Mock())
+            sensitivity_metric = sensitivity_eval.compute_metric(Mock(), Mock())

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_custom_metric_function.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_custom_metric_function.py
@@ -15,11 +15,10 @@
 import pytest
 import numpy as np
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 from model_compression_toolkit.core import MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.common.mixed_precision.sensitivity_evaluation import SensitivityEvaluation
-from model_compression_toolkit.core.common.model_builder_mode import ModelBuilderMode
 
 
 def custom_float_metric(model_mp) -> float:
@@ -62,7 +61,7 @@ def get_sensitivity_evaluator(custom_metric_fn):
                                                  representative_data_gen=representative_data_gen,
                                                  fw_info=mock_fw_info,
                                                  fw_impl=mock_fw_impl)
-    sensitivity_eval._configure_bitwidths_model = lambda *args, **kwargs: None  # Method does nothing
+    sensitivity_eval._configured_mp_model = MagicMock()
     return sensitivity_eval
 
 

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
@@ -12,27 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Optional
-
 import copy
 
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import numpy as np
 
-from model_compression_toolkit.core import ResourceUtilization
+from model_compression_toolkit.core import ResourceUtilization, MixedPrecisionQuantizationConfig
 from model_compression_toolkit.core.common import Graph
 from model_compression_toolkit.core.common.framework_info import DEFAULT_KERNEL_ATTRIBUTES
 from model_compression_toolkit.core.common.graph.edge import Edge
 from model_compression_toolkit.core.common.graph.virtual_activation_weights_node import VirtualActivationWeightsNode, \
     VirtualSplitActivationNode, VirtualSplitWeightsNode
+from model_compression_toolkit.core.common.mixed_precision.mixed_precision_quantization_config import \
+    MpMetricNormalization
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_ru_helper import MixedPrecisionRUHelper
 from model_compression_toolkit.core.common.mixed_precision.mixed_precision_search_manager import \
     MixedPrecisionSearchManager, ConfigReconstructionHelper
 from model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.resource_utilization import \
     RUTarget
-from tests_pytest._test_util.graph_builder_utils import build_node, build_nbits_qc
+from model_compression_toolkit.core.common.mixed_precision.sensitivity_evaluation import SensitivityEvaluation
+from tests_pytest._test_util.graph_builder_utils import build_node, build_nbits_qc, DummyLayer
 
 
 class DummyLayer1:
@@ -91,7 +92,6 @@ class TestMixedPrecisionSearchManager:
                                           sensitivity_evaluator=Mock(), target_resource_utilization=ru,
                                           mp_config=Mock())
         assert mgr.min_ru_config == {n3: 2, n4: 1}
-        assert mgr.max_ru_config == {n3: 1, n4: 0}
         assert mgr.min_ru == {RUTarget.WEIGHTS: 3 * 14 * 2 / 8 + 2 * 71 * 4 / 8}
 
         rel_ru = mgr._compute_relative_ru_matrices()
@@ -108,7 +108,6 @@ class TestMixedPrecisionSearchManager:
                                           mp_config=Mock())
         # 6 x [8], 120 x [8, 2, 4], 40 x [4, 8], 273 x [2], 34 x [8]
         assert mgr.min_ru_config == {n2: 1, n3: 0}
-        assert mgr.max_ru_config == {n2: 0, n3: 1}
         self._assert_dict_allclose(mgr.min_ru,
                                    {RUTarget.ACTIVATION: np.array([48, 48+240, 240+160, 160+546, 546+272, 272])/8},
                                    sort_axis=0)
@@ -135,7 +134,6 @@ class TestMixedPrecisionSearchManager:
                                           sensitivity_evaluator=Mock(), target_resource_utilization=ru,
                                           mp_config=Mock())
         assert mgr.min_ru_config == {n2: 1, n3: 2, n4: 1}
-        assert mgr.max_ru_config == {n2: 0, n3: 4, n4: 0}
 
         self._assert_dict_allclose(mgr.min_ru,
                                    {RUTarget.TOTAL: 81.5 + np.array([48, 288, 400, 706, 818, 272]) / 8},
@@ -190,7 +188,7 @@ class TestMixedPrecisionSearchManager:
 
         # max config solution, tight max cut ru constraint
         res, mgr = run(a_mem=1280/8, sensitivity={n2: [1, 2, 3], n3: [5, 4]}, exp_cfg={n2: 0, n3: 1})
-        assert res == mgr.max_ru_config
+        assert res == {n2: 0, n3: 1}
 
         run(a_mem=1280/8-1, sensitivity={n2: [1, 2, 4], n3: [6, 4]}, exp_cfg={n2: 1, n3: 1})
 
@@ -212,7 +210,7 @@ class TestMixedPrecisionSearchManager:
         ru = ResourceUtilization(activation_memory=160, weights_memory=255, total_memory=415)
         sensitivity = {n2: [1, 2, 4], n3: [4, 4, 4, 4, 1, 4], n4: [1, 4, 3]}
         res, mgr = run(ru, sensitivity, exp_cfg={n2: 0, n3: 4, n4: 0})
-        assert res == mgr.max_ru_config
+        assert res == {n2: 0, n3: 4, n4: 0}
 
         # reduce each ru target one at a time and check it's taken into account
         ru = ResourceUtilization(activation_memory=159, weights_memory=255, total_memory=415)
@@ -245,8 +243,14 @@ class TestMixedPrecisionSearchManager:
         ru_res = mgr.compute_resource_utilization_for_config(cfg)
         assert ru_res == ResourceUtilization(weights_memory=113, activation_memory=866/8, total_memory=221.25)
 
-    def test_bops_no_bops_flow(self, fw_info_mock, fw_impl_mock, mocker):
-        g, _ = build_graph(fw_info_mock, w_mp=True, a_mp=True)
+    @pytest.mark.parametrize('w_mp, a_mp, target_ru, exp_virtual', [
+        (True, True, ResourceUtilization(activation_memory=1, weights_memory=2, total_memory=3), False),
+        (True, True, ResourceUtilization(bops=1), True),
+        (True, False, ResourceUtilization(bops=1), False),
+        (False, True, ResourceUtilization(bops=1), False)
+    ])
+    def test_bops_no_bops_flow(self, fw_info_mock, fw_impl_mock, mocker, w_mp, a_mp, target_ru, exp_virtual):
+        g, _ = build_graph(fw_info_mock, w_mp=w_mp, a_mp=a_mp)
 
         substitute_mock = mocker.patch('model_compression_toolkit.core.common.mixed_precision.'
                                        'mixed_precision_search_manager.substitute')
@@ -260,28 +264,109 @@ class TestMixedPrecisionSearchManager:
         virt_sub_mock = Mock()
         fw_impl_mock.get_substitutions_virtual_weights_activation_coupling = virt_sub_mock
 
-        # no bops
-        ru_no_bops = ResourceUtilization(activation_memory=1, weights_memory=2, total_memory=3)
         mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock, sensitivity_evaluator=Mock(),
-                                          target_resource_utilization=ru_no_bops, mp_config=Mock())
+                                          target_resource_utilization=target_ru, mp_config=Mock())
         mgr.search()
+        if exp_virtual:
+            res = mgr.search()
+            substitute_mock.assert_called_with(copy_mock.return_value, virt_sub_mock.return_value)
+            assert mgr.mp_graph is substitute_mock.return_value
+            assert mgr.original_graph is g
+            assert mgr.using_virtual_graph is True
+            recon_cfg_mock.assert_called()
+            assert res == recon_cfg_mock.return_value
+        else:
+            substitute_mock.assert_not_called()
+            assert mgr.using_virtual_graph is False
+            assert mgr.mp_graph is g and mgr.original_graph is g
+            recon_cfg_mock.assert_not_called()
 
-        substitute_mock.assert_not_called()
-        assert mgr.using_virtual_graph is False
-        assert mgr.mp_graph is g and mgr.original_graph is g
-        recon_cfg_mock.assert_not_called()
+    def test_build_sensitivity_metric(self, fw_info_mock, fw_impl_mock):
+        """ Test that correct configs are passed to SensitivityEvaluator and results are aggregated correctly. """
+        a_conf = build_node('a_conf', layer_class=DummyLayer2, qcs=[build_nbits_qc(nb) for nb in (4, 2)])
+        a_conf_w = build_node('a_conf_w',
+                              canonical_weights={'foo': np.ones(10)},
+                              qcs=[build_nbits_qc(nb, w_attr={'foo': (8, True)}) for nb in (4, 16)])
+        w_conf = build_node('w_conf',
+                            canonical_weights={'foo': np.ones(10)},
+                            qcs=[build_nbits_qc(4, w_attr={'foo': (nb, True)}) for nb in (8, 16)])
+        aw_conf = build_node('aw_conf', canonical_weights={'foo': np.ones(10)},
+                             qcs=[build_nbits_qc(ab, w_attr={'foo': (wb, True)})
+                                  for ab, wb in [(4, 8), (4, 4), (8, 8), (8, 4)]])
+        g = Graph(name='g', input_nodes=[a_conf], output_nodes=[aw_conf], nodes=[a_conf_w, aw_conf],
+                  edge_list=[Edge(a_conf, a_conf_w, 0, 0), Edge(a_conf_w, w_conf, 0, 0), Edge(w_conf, aw_conf, 0, 0)])
 
-        # with bops
-        ru_bops = ResourceUtilization(activation_memory=1, bops=2)
-        mgr = MixedPrecisionSearchManager(g, fw_info=g.fw_info, fw_impl=fw_impl_mock, sensitivity_evaluator=Mock(),
-                                          target_resource_utilization=ru_bops, mp_config=Mock())
-        res = mgr.search()
-        substitute_mock.assert_called_with(copy_mock.return_value, virt_sub_mock.return_value)
-        assert mgr.mp_graph is substitute_mock.return_value
-        assert mgr.original_graph is g
-        assert mgr.using_virtual_graph is True
-        recon_cfg_mock.assert_called()
-        assert res == recon_cfg_mock.return_value
+        se = Mock(spec_set=SensitivityEvaluation)
+
+        def compute_metric_mock(mp_a_cfg, mp_w_cfg):
+            a = list(mp_a_cfg.values())[0] if mp_a_cfg else 0
+            w = list(mp_w_cfg.values())[0] if mp_w_cfg else 0
+            return a + 0.1*w
+        se.compute_metric = Mock(side_effect=compute_metric_mock)
+
+        fw_info_mock.get_kernel_op_attributes = lambda nt: ['foo'] if nt is DummyLayer else DEFAULT_KERNEL_ATTRIBUTES
+        fw_info_mock.is_kernel_op = lambda nt: nt is DummyLayer
+        mp_config = MixedPrecisionQuantizationConfig(metric_normalization=MpMetricNormalization.NONE,
+                                                     metric_epsilon=None)
+        mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock,
+                                          sensitivity_evaluator=se,
+                                          target_resource_utilization=ResourceUtilization(total_memory=100),
+                                          mp_config=mp_config)
+        res = mgr._build_sensitivity_mapping()
+        call_args = se.compute_metric.call_args_list
+        for i in range(2):
+            assert call_args[i] == call(mp_a_cfg={'a_conf': i}, mp_w_cfg={}), i
+        for i in range(2):
+            assert call_args[2+i] == call(mp_a_cfg={'a_conf_w': i}, mp_w_cfg={}), i
+        for i in range(2):
+            assert call_args[4+i] == call(mp_a_cfg={}, mp_w_cfg={'w_conf': i})
+        for i in range(4):
+            assert call_args[6+i] == call(mp_a_cfg={'aw_conf': i}, mp_w_cfg={'aw_conf': i}), i
+        assert len(res) == 4
+        assert np.allclose(res[a_conf], np.array([0, 1]))
+        assert np.allclose(res[a_conf_w], np.array([0, 1]))
+        assert np.allclose(res[w_conf], np.array([0, 0.1]))
+        assert np.allclose(res[aw_conf], np.array([0, 1.1, 2.2, 3.3]))
+
+    @pytest.mark.parametrize('norm, eps, max_thresh, exp1, exp2', [
+        (MpMetricNormalization.NONE, None, 10, [1, 2, 3, 4], [1, 2, 3]),
+        (MpMetricNormalization.NONE, None, 3.9, [.25, .5, .75, 1], [.25, .5, .75]),
+        (MpMetricNormalization.NONE, 0, 10, [3, 3, 3, 4], [2, 2, 3]),
+        (MpMetricNormalization.NONE, 0.1, 10, [3.1, 3.1, 3, 4], [2.1, 2, 3]),
+        (MpMetricNormalization.MAXBIT, None, 10, [1 / 3, 2 / 3, 1, 4 / 3], [1 / 2, 1, 3 / 2]),
+        (MpMetricNormalization.MAXBIT, 0, 10, [1, 1, 1, 4 / 3], [1, 1, 3 / 2]),
+        (MpMetricNormalization.MINBIT, None, 10, [.5, 1, 1.5, 2], [1/3, 2/3, 1]),
+        (MpMetricNormalization.MINBIT, 0.1, 10, [1.6, 1.6, 1.5, 2], [2 / 3 + .1, 2 / 3, 1]),
+        (MpMetricNormalization.MINBIT, 0.1, 2, [.8, .8, .75, 1], [1 / 3 + .05, 1 / 3, .5])
+    ])
+    def test_build_sensitivity_mapping_params(self, fw_impl_mock, fw_info_mock, norm, eps, max_thresh, exp1, exp2):
+        """ Tests sensitivity normalization method, epsilon and threshold. """
+        ph = build_node('ph', qcs=[build_nbits_qc()])
+        n1 = build_node('n1', qcs=[build_nbits_qc(nb) for nb in (4, 2, 16, 8)])
+        n2 = build_node('n2', qcs=[build_nbits_qc(nb) for nb in (4, 8, 2)])
+        g = Graph(name='g', input_nodes=[ph], nodes=[n1], output_nodes=[n2],
+                  edge_list=[Edge(ph, n1, 0, 0), Edge(n1, n2, 0, 0)])
+
+        se = Mock(spec_set=SensitivityEvaluation)
+        se.compute_metric = lambda mp_a_cfg, mp_w_cfg: list(mp_a_cfg.values())[0] + 1
+
+        fw_info_mock.get_kernel_op_attributes = lambda nt: DEFAULT_KERNEL_ATTRIBUTES
+        fw_info_mock.is_kernel_op = lambda nt: False
+
+        mp_config = MixedPrecisionQuantizationConfig(metric_normalization=norm,
+                                                     metric_epsilon=eps,
+                                                     metric_normalization_threshold=max_thresh)
+        mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock,
+                                          sensitivity_evaluator=se,
+                                          target_resource_utilization=ResourceUtilization(activation_memory=100),
+                                          mp_config=mp_config)
+        mgr._finalize_distance_metric = Mock(wraps=mgr._finalize_distance_metric)
+
+        res = mgr._build_sensitivity_mapping()
+        assert set(res.keys()) == {n1, n2}
+        assert np.allclose(res[n1], np.array(exp1))
+        assert np.allclose(res[n2], np.array(exp2))
+        mgr._finalize_distance_metric.assert_called_with(res)
 
     def _assert_dict_allclose(self, res, exp_res, sort_axis=None):
         assert len(exp_res) == len(res)

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/test_mp_search_manager.py
@@ -88,7 +88,8 @@ class TestMixedPrecisionSearchManager:
         g, [n1, n2, n3, n4, n5] = build_graph(fw_info_mock, w_mp=True, a_mp=False)
         ru = ResourceUtilization(weights_memory=100)
         mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock,
-                                          sensitivity_evaluator=Mock(), target_resource_utilization=ru)
+                                          sensitivity_evaluator=Mock(), target_resource_utilization=ru,
+                                          mp_config=Mock())
         assert mgr.min_ru_config == {n3: 2, n4: 1}
         assert mgr.max_ru_config == {n3: 1, n4: 0}
         assert mgr.min_ru == {RUTarget.WEIGHTS: 3 * 14 * 2 / 8 + 2 * 71 * 4 / 8}
@@ -103,7 +104,8 @@ class TestMixedPrecisionSearchManager:
         g, [n1, n2, n3, n4, n5] = build_graph(fw_info_mock, w_mp=False, a_mp=True)
         ru = ResourceUtilization(activation_memory=150)
         mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock,
-                                          sensitivity_evaluator=Mock(), target_resource_utilization=ru)
+                                          sensitivity_evaluator=Mock(), target_resource_utilization=ru,
+                                          mp_config=Mock())
         # 6 x [8], 120 x [8, 2, 4], 40 x [4, 8], 273 x [2], 34 x [8]
         assert mgr.min_ru_config == {n2: 1, n3: 0}
         assert mgr.max_ru_config == {n2: 0, n3: 1}
@@ -130,7 +132,8 @@ class TestMixedPrecisionSearchManager:
         g, [n1, n2, n3, n4, n5] = build_graph(fw_info_mock, w_mp=True, a_mp=True)
         ru = ResourceUtilization(total_memory=200)
         mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock,
-                                          sensitivity_evaluator=Mock(), target_resource_utilization=ru)
+                                          sensitivity_evaluator=Mock(), target_resource_utilization=ru,
+                                          mp_config=Mock())
         assert mgr.min_ru_config == {n2: 1, n3: 2, n4: 1}
         assert mgr.max_ru_config == {n2: 0, n3: 4, n4: 0}
 
@@ -233,7 +236,7 @@ class TestMixedPrecisionSearchManager:
         g, [n1, n2, n3, n4, n5] = build_graph(fw_info_mock, w_mp=True, a_mp=True)
         ru = ResourceUtilization(weights_memory=100, activation_memory=200, total_memory=300)
         mgr = MixedPrecisionSearchManager(g, fw_info=g.fw_info, fw_impl=fw_impl_mock, sensitivity_evaluator=Mock(),
-                                          target_resource_utilization=ru)
+                                          target_resource_utilization=ru, mp_config=Mock())
 
         cfg = mgr.copy_config_with_replacement(mgr.min_ru_config, n3, 4)
         # make sure original cfg was not changed in place
@@ -260,7 +263,7 @@ class TestMixedPrecisionSearchManager:
         # no bops
         ru_no_bops = ResourceUtilization(activation_memory=1, weights_memory=2, total_memory=3)
         mgr = MixedPrecisionSearchManager(g, fw_info=fw_info_mock, fw_impl=fw_impl_mock, sensitivity_evaluator=Mock(),
-                                          target_resource_utilization=ru_no_bops)
+                                          target_resource_utilization=ru_no_bops, mp_config=Mock())
         mgr.search()
 
         substitute_mock.assert_not_called()
@@ -271,7 +274,7 @@ class TestMixedPrecisionSearchManager:
         # with bops
         ru_bops = ResourceUtilization(activation_memory=1, bops=2)
         mgr = MixedPrecisionSearchManager(g, fw_info=g.fw_info, fw_impl=fw_impl_mock, sensitivity_evaluator=Mock(),
-                                          target_resource_utilization=ru_bops)
+                                          target_resource_utilization=ru_bops, mp_config=Mock())
         res = mgr.search()
         substitute_mock.assert_called_with(copy_mock.return_value, virt_sub_mock.return_value)
         assert mgr.mp_graph is substitute_mock.return_value
@@ -290,7 +293,7 @@ class TestMixedPrecisionSearchManager:
 
     def _run_search_test(self, g, ru, sensitivity, exp_cfg, fw_impl):
         mgr = MixedPrecisionSearchManager(g, fw_info=g.fw_info, fw_impl=fw_impl, sensitivity_evaluator=Mock(),
-                                          target_resource_utilization=ru)
+                                          target_resource_utilization=ru, mp_config=Mock())
         mgr._build_sensitivity_mapping = Mock(return_value=sensitivity)
         res = mgr.search()
         assert res == exp_cfg

--- a/tests_pytest/keras_tests/integration_tests/core/mixed_precision/test_sensitivity_evaluation.py
+++ b/tests_pytest/keras_tests/integration_tests/core/mixed_precision/test_sensitivity_evaluation.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+
+from model_compression_toolkit.core.keras import constants
+from tests_pytest._fw_tests_common_base.base_sensitivity_eval_integ_test import BaseSensitivityEvaluationIntegTester
+from tests_pytest.keras_tests.keras_test_util.keras_test_mixin import KerasFwMixin
+
+import keras
+
+
+class TestSensitivityEvaluation(BaseSensitivityEvaluationIntegTester, KerasFwMixin):
+    BIAS = constants.BIAS
+    KERNEL = constants.KERNEL
+    conv_cls = keras.layers.Conv2D
+    relu_cls = keras.layers.ReLU
+    convtr_cls = keras.layers.Conv2DTranspose
+    fc_cls = keras.layers.Dense
+
+    input_shape = (1, 16, 16, 3)
+
+    def build_model(self, input_shape):
+        model = keras.Sequential([
+            keras.layers.Input(self.input_shape[1:]),
+            keras.layers.Conv2D(4, kernel_size=3),
+            keras.layers.ReLU(),
+            keras.layers.Conv2DTranspose(8, kernel_size=3),
+            keras.layers.Flatten(),
+            keras.layers.Dense(10)
+        ])
+        return model
+
+    def infer_models(self, orig_model, mp_model, x: np.ndarray):
+        y = orig_model(x)
+        y_mp = mp_model(x)[-1]
+        return y.numpy(), y_mp.numpy()
+
+    def test_build_models(self):
+        super().test_build_models()
+
+    def test_build_models_disable_activations(self):
+        super().test_build_models_disable_activations()
+
+    def test_configure_mp_model(self):
+        super().test_configure_mp_model()
+
+    def test_configure_mp_model_errors(self):
+        super().test_configure_mp_model_errors()
+
+    def test_compute_metric_method(self):
+        super().test_compute_metric_method()

--- a/tests_pytest/keras_tests/keras_test_util/keras_test_mixin.py
+++ b/tests_pytest/keras_tests/keras_test_util/keras_test_mixin.py
@@ -33,3 +33,8 @@ class KerasFwMixin:
         def f():
             yield [np.random.randn(*shape).astype(np.float32) for shape in shapes]
         return f
+
+    @staticmethod
+    def fetch_model_layers_by_cls(model, cls):
+        """ Fetch layers from keras model by layer class type. """
+        return [m for m in model.layers if isinstance(m, cls)]

--- a/tests_pytest/pytorch_tests/integration_tests/core/mixed_precision/test_sensitivity_evaluation.py
+++ b/tests_pytest/pytorch_tests/integration_tests/core/mixed_precision/test_sensitivity_evaluation.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+from torch import nn
+
+from model_compression_toolkit.core.pytorch import constants
+from model_compression_toolkit.core.pytorch.pytorch_device_config import get_working_device
+from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
+from tests_pytest._fw_tests_common_base.base_sensitivity_eval_integ_test import BaseSensitivityEvaluationIntegTester
+from tests_pytest.pytorch_tests.torch_test_util.torch_test_mixin import TorchFwMixin
+
+
+class Model(nn.Module):
+    def __init__(self, input_chw):
+        super().__init__()
+        c, h, w = input_chw
+        self.conv = nn.Conv2d(c, 4, kernel_size=3)
+        self.relu = nn.ReLU()
+        self.conv_tr = nn.ConvTranspose2d(4, 8, kernel_size=3)
+        self.flatten = nn.Flatten()
+        self.fc = nn.Linear(h*w*8, 10)
+
+    def forward(self, x):
+        y = self.conv(x)
+        y = self.relu(y)
+        y = self.conv_tr(y)
+        y = self.flatten(y)
+        y = self.fc(y)
+        return y
+
+
+class TestSensitivityEvaluation(BaseSensitivityEvaluationIntegTester, TorchFwMixin):
+    BIAS = constants.BIAS
+    KERNEL = constants.KERNEL
+    conv_cls = nn.Conv2d
+    relu_cls = nn.ReLU
+    convtr_cls = nn.ConvTranspose2d
+    fc_cls = nn.Linear
+
+    def build_model(self, input_shape):
+        return Model(input_chw=input_shape[1:])
+
+    def infer_models(self, orig_model, mp_model, x: np.ndarray):
+        x = to_torch_tensor(x)
+        y = orig_model.to(get_working_device())(x)
+        y_mp = mp_model(x)[-1]
+        return y.detach().cpu().numpy(), y_mp.detach().cpu().numpy()
+
+    def test_build_models(self):
+        super().test_build_models()
+
+    def test_build_models_disable_activations(self):
+        super().test_build_models_disable_activations()
+
+    def test_configure_mp_model(self):
+        super().test_configure_mp_model()
+
+    def test_configure_mp_model_errors(self):
+        super().test_configure_mp_model_errors()
+
+    def test_compute_metric_method(self):
+        super().test_compute_metric_method()

--- a/tests_pytest/pytorch_tests/torch_test_util/torch_test_mixin.py
+++ b/tests_pytest/pytorch_tests/torch_test_util/torch_test_mixin.py
@@ -56,6 +56,11 @@ class TorchFwMixin:
         assert isinstance(layer, PytorchQuantizationWrapper)
         return layer.weights_quantizers[weight_name]
 
+    @staticmethod
+    def fetch_model_layers_by_cls(model, cls):
+        """ Fetch layers from torch module by layer class type. """
+        return [m for m in model.modules() if isinstance(m, cls)]
+
 
 class BaseTorchIntegrationTest(BaseFWIntegrationTest, TorchFwMixin, abc.ABC):
     """ Base class for Torch integration tests. """

--- a/tests_pytest/pytorch_tests/torch_test_util/torch_test_mixin.py
+++ b/tests_pytest/pytorch_tests/torch_test_util/torch_test_mixin.py
@@ -58,7 +58,7 @@ class TorchFwMixin:
 
     @staticmethod
     def fetch_model_layers_by_cls(model, cls):
-        """ Fetch layers from torch module by layer class type. """
+        """ Fetch layers from torch module by layer class type.  """
         return [m for m in model.modules() if isinstance(m, cls)]
 
 


### PR DESCRIPTION
## Pull Request Description:
* Use float mp model baseline instead of maxbit configuration
* Add unit test for MPSearchManager sensitivity matrix building
* Add integration tests for SensitivityEvaluation quant layers and quantizers configuration
* Ensure positive value in shifted cosine similarity metric (if it's negative due to float precision lp program is unbounded). 
* Fix refinement solutions unreadable (by recent change) printout, and only print the changed solutions

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).