### PR TITLE
Fix issue in mixed precision with reused layers

### DIFF
--- a/model_compression_toolkit/core/pytorch/back2framework/mixed_precision_model_builder.py
+++ b/model_compression_toolkit/core/pytorch/back2framework/mixed_precision_model_builder.py
@@ -174,7 +174,7 @@ class MixedPrecisionPyTorchModelBuilder(PyTorchModelBuilder):
         Logger.critical(f"PytorchActivationQuantizationHolder expects a single quantizer, but ({len(activation_quantizers)}) quantizers were found for node {n}.")# pragma: no cover
 
     def build_model(self) -> Tuple[torch.nn.Module, UserInformation,
-                                   Dict[str, Union[PytorchQuantizationWrapper, PytorchActivationQuantizationHolder]]]:
+                                   Dict[str, List[Union[PytorchQuantizationWrapper, PytorchActivationQuantizationHolder]]]]:
         """
         Build a PyTorch float model and return it.
         Returns: Float PyTorch model and user information.


### PR DESCRIPTION
## Pull Request Description:
Fixes an issue where, during activation with mixed precision, layers that are reused do not receive the appropriate configurable activation candidates.
To retrieve the matching activation holder layer for a reused node, we need to build a mapping during the mixed precision model builder execution.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).