### PR TITLE
Fix channel axis when creating stat collector for layers with scalar input shape

### DIFF
--- a/model_compression_toolkit/core/common/model_collector.py
+++ b/model_compression_toolkit/core/common/model_collector.py
@@ -45,9 +45,10 @@ def create_stats_collector_for_node(node: common.BaseNode,
     """
 
     if node.is_activation_quantization_enabled():
+        out_channel_axis = -1 if len(node.input_shape) == 1 else fw_info.out_channel_axis_mapping.get(node.type)
         min_output = getattr(node.prior_info, 'min_output', None)
         max_output = getattr(node.prior_info, 'max_output', None)
-        stats_collector = common.StatsCollector(out_channel_axis=fw_info.out_channel_axis_mapping.get(node.type),
+        stats_collector = common.StatsCollector(out_channel_axis=out_channel_axis,
                                                 init_min_value=min_output,
                                                 init_max_value=max_output)
     else:

--- a/tests_pytest/common_tests/unit_tests/test_model_collector.py
+++ b/tests_pytest/common_tests/unit_tests/test_model_collector.py
@@ -57,6 +57,7 @@ class TestStatisticsCollectors:
         node.is_activation_quantization_enabled.return_value = True
         node.type = DummyLayer
         node.prior_info = Mock(min_output=-1, max_output=9)
+        node.input_shape = [4, 4]
 
         collector = create_stats_collector_for_node(node, fw_info_mock)
         assert isinstance(collector, StatsCollector)


### PR DESCRIPTION
## Pull Request Description:
The output channel axis is taken from the default value from the framework information object but is not verifying compatibility with the input shape

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).