### PR TITLE
Fix FQ exporter for 16bit act quant and constant quantization

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/pytorch/base_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/base_pytorch_exporter.py
@@ -135,16 +135,3 @@ class BasePyTorchExporter(Exporter):
         for layer in self.model.modules():
             if isinstance(layer, PytorchQuantizationWrapper):
                 _set_quantized_weights_in_wrapper(layer)
-
-        # Replace PytorchQuantizationWrapper layers with their internal layers
-        self._replace_wrapped_with_unwrapped()
-
-    def _replace_wrapped_with_unwrapped(self):
-        """
-        Replaces the PytorchQuantizationWrapper modules in the model with their underlying wrapped modules.
-        Iterates through the model's children and replaces the PytorchQuantizationWrapper instances with their
-        internal layers.
-        """
-        for name, module in self.model.named_children():
-            if isinstance(module, PytorchQuantizationWrapper):
-                setattr(self.model, name, module.layer)

--- a/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/pytorch/fakely_quant_onnx_pytorch_exporter.py
@@ -73,6 +73,15 @@ if FOUND_ONNX:
             Returns:
                 Fake-quant PyTorch model.
             """
+            # List all activation quantization holders with num_bits>8 and replace them with Identity, because
+            # ONNX doesn't support quantization of mote than 8 bits for torch.fake_quantize_per_tensor_affine.
+            act_holder_list = [n for n, m in self.model.named_modules()
+                               if isinstance(m, PytorchActivationQuantizationHolder) and
+                               m.activation_holder_quantizer.num_bits > 8]
+            for act_holder in act_holder_list:
+                delattr(self.model, act_holder)
+                setattr(self.model, act_holder, torch.nn.Identity())
+
             for layer in self.model.children():
                 self.is_layer_exportable_fn(layer)
                 # Set reuse for weight quantizers if quantizer is reused


### PR DESCRIPTION
## Pull Request Description:
1. Remove _replace_wrapped_with_unwrapped from FQ exporter as it's not needed.
2. Remove PytorchActivationQuantizationHolder with num_bits > 8, because ONNX doesn't support it.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).