### PR TITLE
Move TPC and SDSP versions to a constant file

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/constants.py
+++ b/model_compression_toolkit/target_platform_capabilities/constants.py
@@ -25,6 +25,17 @@ IMX500_TP_MODEL = 'imx500'
 TFLITE_TP_MODEL = 'tflite'
 QNNPACK_TP_MODEL = 'qnnpack'
 
+# TPC versions.
+TPC_V1_0 = '1.0'
+TPC_V4_0 = '4.0'
+TPC_V5_0 = '5.0'
+TPC_V6_0 = '6.0'
+
+# SDSP converter versions
+SDSP_V3_14 = '3.14'
+SDSP_V3_16 = '3.16'
+SDSP_V3_17 = '3.17'
+
 # TP Attributes
 KERNEL_ATTR = "kernel_attr"
 BIAS_ATTR = "bias_attr"

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/get_target_platform_capabilities.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/get_target_platform_capabilities.py
@@ -12,18 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.target_platform_capabilities.constants import IMX500_TP_MODEL
+from model_compression_toolkit.target_platform_capabilities.constants import IMX500_TP_MODEL, TPC_V1_0, TPC_V4_0, TPC_V5_0, \
+    SDSP_V3_14, SDSP_V3_16, SDSP_V3_17
 from model_compression_toolkit.target_platform_capabilities.schema.mct_current_schema import TargetPlatformCapabilities
 from model_compression_toolkit.target_platform_capabilities.tpc_models import generate_tpc_func
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc import V1_0, V4_0, V5_0
-
-# SDSP converter versions
-SDSP_V3_14 = '3.14'
-SDSP_V3_16 = '3.16'
-SDSP_V3_17 = '3.17'
 
 
-def get_target_platform_capabilities(tpc_version: str = '1.0',
+def get_target_platform_capabilities(tpc_version: str = TPC_V1_0,
                                      device_type: str = IMX500_TP_MODEL) -> TargetPlatformCapabilities:
     """
     Retrieves target platform capabilities model based on tpc version and the specified device type.
@@ -45,7 +40,7 @@ def get_target_platform_capabilities(tpc_version: str = '1.0',
     return tpc
 
 
-def get_target_platform_capabilities_sdsp(sdsp_version: str = '3.14') -> TargetPlatformCapabilities:
+def get_target_platform_capabilities_sdsp(sdsp_version: str = SDSP_V3_14) -> TargetPlatformCapabilities:
     """
     Retrieves target platform capabilities model based on sdsp converter version.
 
@@ -58,9 +53,9 @@ def get_target_platform_capabilities_sdsp(sdsp_version: str = '3.14') -> TargetP
     sdsp_version = str(sdsp_version)
     # Get the corresponding tpc version from sdsp converter version.
     sdsp_to_tpc_version = {
-        SDSP_V3_14: V1_0,
-        SDSP_V3_16: V4_0,
-        SDSP_V3_17: V5_0,
+        SDSP_V3_14: TPC_V1_0,
+        SDSP_V3_16: TPC_V4_0,
+        SDSP_V3_17: TPC_V5_0,
     }
 
     msg = (f"Error: The specified sdsp converter version '{sdsp_version}' is not valid. "

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/__init__.py
@@ -14,12 +14,7 @@
 # ==============================================================================
 import importlib
 from model_compression_toolkit.target_platform_capabilities.schema.mct_current_schema import TargetPlatformCapabilities
-
-# TPC versions.
-V1_0 = '1.0'
-V4_0 = '4.0'
-V5_0 = '5.0'
-V6_0 = '6.0'
+from model_compression_toolkit.target_platform_capabilities.constants import TPC_V1_0, TPC_V4_0, TPC_V5_0, TPC_V6_0
 
 
 def generate_imx500_tpc(tpc_version: str) -> TargetPlatformCapabilities:
@@ -35,10 +30,10 @@ def generate_imx500_tpc(tpc_version: str) -> TargetPlatformCapabilities:
 
     # Organize all tpc versions into tpcs_dict.
     tpcs_dict = {
-        V1_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc",
-        V4_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v4_0.tpc",
-        V5_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v5_0.tpc",
-        V6_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v6_0.tpc"
+        TPC_V1_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc",
+        TPC_V4_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v4_0.tpc",
+        TPC_V5_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v5_0.tpc",
+        TPC_V6_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v6_0.tpc"
     }
 
     msg = (f"Error: The specified tpc version '{tpc_version}' is not valid. "

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/__init__.py
@@ -14,9 +14,7 @@
 # ==============================================================================
 import importlib
 from model_compression_toolkit.target_platform_capabilities.schema.mct_current_schema import TargetPlatformCapabilities
-
-# TPC versions.
-V1_0 = '1.0'
+from model_compression_toolkit.target_platform_capabilities.constants import TPC_V1_0
 
 
 def generate_qnnpack_tpc(tpc_version: str) -> TargetPlatformCapabilities:
@@ -32,7 +30,7 @@ def generate_qnnpack_tpc(tpc_version: str) -> TargetPlatformCapabilities:
 
     # Organize all tpc versions into tpcs_dict.
     tpcs_dict = {
-        V1_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1_0.tpc",
+        TPC_V1_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1_0.tpc",
     }
 
     msg = (f"Error: The specified tpc version '{tpc_version}' is not valid. "

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/__init__.py
@@ -14,9 +14,7 @@
 # ==============================================================================
 import importlib
 from model_compression_toolkit.target_platform_capabilities.schema.mct_current_schema import TargetPlatformCapabilities
-
-# TPC versions.
-V1_0 = '1.0'
+from model_compression_toolkit.target_platform_capabilities.constants import TPC_V1_0
 
 
 def generate_tflite_tpc(tpc_version: str) -> TargetPlatformCapabilities:
@@ -32,7 +30,7 @@ def generate_tflite_tpc(tpc_version: str) -> TargetPlatformCapabilities:
 
     # Organize all tpc versions into tpcs_dict.
     tpcs_dict = {
-        V1_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.tflite_tpc.v1_0.tpc"
+        TPC_V1_0: "model_compression_toolkit.target_platform_capabilities.tpc_models.tflite_tpc.v1_0.tpc"
     }
 
     msg = (f"Error: The specified tpc version '{tpc_version}' is not valid. "


### PR DESCRIPTION
## Pull Request Description:
- Change name of TPC versions `TPC_V*_*`
- Move TPC `TPC_V*_*` and SDSP `SDSP_V*_**` versions to a constant file (constants.py)

Note: The CICD link error will be fixed in a separate PR.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).