### PR TITLE
Remove get_keras_tpc_latest and get_pytorch_tpc_latest

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/latest/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/latest/__init__.py
@@ -16,10 +16,8 @@ from model_compression_toolkit.verify_packages import FOUND_TORCH, FOUND_TF
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc import get_tpc, generate_tpc, \
     get_op_quantization_configs
 if FOUND_TF:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc import get_tpc as get_keras_tpc_latest
     from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
         get_tpc_model as generate_keras_tpc
 if FOUND_TORCH:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc import get_tpc as get_pytorch_tpc_latest
     from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
         get_tpc_model as generate_pytorch_tpc

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/latest/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/latest/__init__.py
@@ -15,12 +15,8 @@
 from model_compression_toolkit.verify_packages import FOUND_TORCH, FOUND_TF
 from model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1_0.tpc import get_tpc, generate_tpc, get_op_quantization_configs
 if FOUND_TF:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1_0.tpc import get_tpc as \
-        get_keras_tpc_latest
     from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
         get_tpc_model as generate_keras_tpc, get_tpc_model as generate_keras_tpc
 if FOUND_TORCH:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1_0.tpc import get_tpc as \
-        get_pytorch_tpc_latest
     from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
         get_tpc_model as generate_pytorch_tpc, get_tpc_model as generate_pytorch_tpc

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/latest/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/latest/__init__.py
@@ -15,11 +15,8 @@
 from model_compression_toolkit.verify_packages import FOUND_TORCH, FOUND_TF
 from model_compression_toolkit.target_platform_capabilities.tpc_models.tflite_tpc.v1_0.tpc import get_tpc, generate_tpc, get_op_quantization_configs
 if FOUND_TF:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.tflite_tpc.v1_0.tpc import get_keras_tpc as get_keras_tpc_latest
     from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
         get_tpc_model as generate_keras_tpc
 if FOUND_TORCH:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.tflite_tpc.v1_0.tpc import \
-        get_tpc as get_pytorch_tpc_latest
     from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
         get_tpc_model as generate_pytorch_tpc

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -19,7 +19,7 @@ from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.constants import SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS
 from model_compression_toolkit.core.common.network_editors import EditRule, node_filters, actions
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import get_keras_tpc_latest
+from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc import get_tpc as get_tpc_v1_0
 from tests.keras_tests.tpc_keras import get_16bit_tpc
 from packaging import version
 
@@ -121,7 +121,7 @@ class ShiftNegActivationPostAddTest(ShiftNegActivationTest):
         self.post_add_nbits = post_add_nbits
 
     def get_tpc(self):
-        return get_keras_tpc_latest()
+        return get_tpc_v1_0()
 
     def get_debug_config(self):
         return mct.core.DebugConfig(network_editor=[EditRule(filter=node_filters.NodeNameScopeFilter('activation'),


### PR DESCRIPTION
## Pull Request Description:
Remove `get_keras_tpc_latest` and `get_pytorch_tpc_latest`

Note: The CICD link error will be fixed in a separate PR.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).