### PR TITLE
Remove generate_pytorch_tpc

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/latest/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/latest/__init__.py
@@ -12,9 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.verify_packages import FOUND_TORCH
 from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.v1_0.tpc import get_tpc, generate_tpc, \
     get_op_quantization_configs
-if FOUND_TORCH:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
-        get_tpc_model as generate_pytorch_tpc

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/latest/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/qnnpack_tpc/latest/__init__.py
@@ -12,8 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.verify_packages import FOUND_TORCH
 from model_compression_toolkit.target_platform_capabilities.tpc_models.qnnpack_tpc.v1_0.tpc import get_tpc, generate_tpc, get_op_quantization_configs
-if FOUND_TORCH:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
-        get_tpc_model as generate_pytorch_tpc, get_tpc_model as generate_pytorch_tpc

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/latest/__init__.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/tflite_tpc/latest/__init__.py
@@ -12,8 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from model_compression_toolkit.verify_packages import FOUND_TORCH
 from model_compression_toolkit.target_platform_capabilities.tpc_models.tflite_tpc.v1_0.tpc import get_tpc, generate_tpc, get_op_quantization_configs
-if FOUND_TORCH:
-    from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
-        get_tpc_model as generate_pytorch_tpc

--- a/tests/pytorch_tests/exporter_tests/base_pytorch_export_test.py
+++ b/tests/pytorch_tests/exporter_tests/base_pytorch_export_test.py
@@ -22,10 +22,6 @@ from model_compression_toolkit.core.pytorch.pytorch_device_config import get_wor
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
 from model_compression_toolkit.exporter.model_exporter.pytorch.pytorch_export_facade import DEFAULT_ONNX_OPSET_VERSION
 
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import \
-    generate_pytorch_tpc
-from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-
 
 class BasePytorchExportTest(unittest.TestCase):
 

--- a/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_lut_symmetric_onnx_quantizers.py
+++ b/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_lut_symmetric_onnx_quantizers.py
@@ -16,8 +16,8 @@
 import numpy as np
 import torch
 from mct_quantizers import QuantizationMethod
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import \
-    generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.exporter_tests.base_pytorch_onnx_export_test import BasePytorchONNXCustomOpsExportTest
 from tests.pytorch_tests.exporter_tests.custom_ops_tests.test_export_pot_onnx_quantizers import OneLayer

--- a/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_pot_onnx_quantizers.py
+++ b/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_pot_onnx_quantizers.py
@@ -12,25 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-import tempfile
-import unittest
-
 import numpy as np
 import torch
-from torchvision.models.mobilenetv2 import mobilenet_v2
 
-import mct_quantizers
-import model_compression_toolkit as mct
-from model_compression_toolkit.verify_packages import FOUND_ONNXRUNTIME, FOUND_ONNX
 from model_compression_toolkit.exporter.model_exporter.pytorch.pytorch_export_facade import DEFAULT_ONNX_OPSET_VERSION
 
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import \
-    generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.exporter_tests.base_pytorch_onnx_export_test import BasePytorchONNXCustomOpsExportTest
-from tests.pytorch_tests.model_tests.feature_models.qat_test import dummy_train
-import onnx
 
 
 class OneLayer(torch.nn.Module):

--- a/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_symmetric_onnx_quantizers.py
+++ b/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_symmetric_onnx_quantizers.py
@@ -12,27 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-import tempfile
-import unittest
-
 import numpy as np
 import torch
-from torchvision.models.mobilenetv2 import mobilenet_v2
 
-import mct_quantizers
-import model_compression_toolkit as mct
 from mct_quantizers import QuantizationMethod
-from model_compression_toolkit.verify_packages import FOUND_ONNXRUNTIME, FOUND_ONNX
 from model_compression_toolkit.exporter.model_exporter.pytorch.pytorch_export_facade import DEFAULT_ONNX_OPSET_VERSION
 
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import \
-    generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.exporter_tests.base_pytorch_onnx_export_test import BasePytorchONNXCustomOpsExportTest
 from tests.pytorch_tests.exporter_tests.custom_ops_tests.test_export_pot_onnx_quantizers import OneLayer
-from tests.pytorch_tests.model_tests.feature_models.qat_test import dummy_train
-import onnx
 
 
 class TestExportONNXWeightSymmetric2BitsQuantizers(BasePytorchONNXCustomOpsExportTest):

--- a/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_uniform_onnx_quantizers.py
+++ b/tests/pytorch_tests/exporter_tests/custom_ops_tests/test_export_uniform_onnx_quantizers.py
@@ -17,13 +17,11 @@ import numpy as np
 import torch
 
 from mct_quantizers import QuantizationMethod
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import \
-    generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.exporter_tests.base_pytorch_onnx_export_test import BasePytorchONNXCustomOpsExportTest
 from tests.pytorch_tests.exporter_tests.custom_ops_tests.test_export_pot_onnx_quantizers import OneLayer
-
-
 
 
 class TestExportONNXWeightUniform2BitsQuantizers(BasePytorchONNXCustomOpsExportTest):

--- a/tests/pytorch_tests/exporter_tests/test_exporting_qat_models.py
+++ b/tests/pytorch_tests/exporter_tests/test_exporting_qat_models.py
@@ -23,8 +23,8 @@ from torchvision.models.mobilenetv2 import mobilenet_v2
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.pytorch_device_config import get_working_device
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import \
-    generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.model_tests.feature_models.qat_test import dummy_train
 

--- a/tests/pytorch_tests/function_tests/get_gptq_config_test.py
+++ b/tests/pytorch_tests/function_tests/get_gptq_config_test.py
@@ -16,16 +16,15 @@ import numpy as np
 import torch
 from torch import nn
 
-import model_compression_toolkit as mct
 from mct_quantizers import QuantizationMethod
 from model_compression_toolkit.gptq import get_pytorch_gptq_config, pytorch_gradient_post_training_quantization, RoundingType
 from model_compression_toolkit.core import CoreConfig, QuantizationConfig, QuantizationErrorMethod
 from model_compression_toolkit import DefaultDict
 from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEARNING_STR, MAX_LSB_STR
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
-
 
 
 class TestModel(nn.Module):

--- a/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
+++ b/tests/pytorch_tests/function_tests/test_activation_quantization_holder_gptq.py
@@ -16,7 +16,8 @@ from model_compression_toolkit.gptq.common.gradual_activation_quantization impor
     GradualActivationQuantizerWrapper
 from model_compression_toolkit.target_platform_capabilities.targetplatform2framework.attach2pytorch import \
     AttachTpcToPytorch
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from model_compression_toolkit.trainable_infrastructure import TrainingMethod
 from model_compression_toolkit.trainable_infrastructure.common.base_trainable_quantizer import VariableGroup
 from model_compression_toolkit.trainable_infrastructure.pytorch.activation_quantizers import \

--- a/tests/pytorch_tests/function_tests/test_export_pytorch_fully_quantized_model.py
+++ b/tests/pytorch_tests/function_tests/test_export_pytorch_fully_quantized_model.py
@@ -26,7 +26,8 @@ import onnx
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
 from model_compression_toolkit.exporter import pytorch_export_model
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from model_compression_toolkit import get_target_platform_capabilities
 

--- a/tests/pytorch_tests/function_tests/test_hessian_info_calculator.py
+++ b/tests/pytorch_tests/function_tests/test_hessian_info_calculator.py
@@ -24,7 +24,8 @@ from model_compression_toolkit.core.pytorch.default_framework_info import DEFAUL
 from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
 from model_compression_toolkit.target_platform_capabilities.targetplatform2framework.attach2pytorch import \
     AttachTpcToPytorch
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.prep_graph_for_func_test import prepare_graph_with_configs
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 import model_compression_toolkit.core.common.hessian as hessian_common

--- a/tests/pytorch_tests/function_tests/test_hessian_service.py
+++ b/tests/pytorch_tests/function_tests/test_hessian_service.py
@@ -23,7 +23,8 @@ from model_compression_toolkit.core.pytorch.default_framework_info import DEFAUL
 from model_compression_toolkit.core.pytorch.pytorch_implementation import PytorchImplementation
 from model_compression_toolkit.target_platform_capabilities.targetplatform2framework.attach2pytorch import \
     AttachTpcToPytorch
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.prep_graph_for_func_test import prepare_graph_with_configs
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 

--- a/tests/pytorch_tests/function_tests/test_quantization_configurations.py
+++ b/tests/pytorch_tests/function_tests/test_quantization_configurations.py
@@ -21,9 +21,11 @@ import torch.nn
 
 import model_compression_toolkit as mct
 from mct_quantizers import QuantizationMethod
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 import torch
+
 
 class ModelToTest(torch.nn.Module):
 

--- a/tests/pytorch_tests/function_tests/test_sensitivity_eval_non_supported_output.py
+++ b/tests/pytorch_tests/function_tests/test_sensitivity_eval_non_supported_output.py
@@ -25,7 +25,8 @@ from model_compression_toolkit.target_platform_capabilities.targetplatform2frame
     AttachTpcToPytorch
 from tests.common_tests.helpers.prep_graph_for_func_test import prepare_graph_with_quantization_parameters
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 
 
 class argmax_output_model(torch.nn.Module):

--- a/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
+++ b/tests/pytorch_tests/layer_tests/base_pytorch_layer_test.py
@@ -34,7 +34,8 @@ from torch.nn import Module
 from model_compression_toolkit.core import FrameworkInfo
 from model_compression_toolkit.ptq import pytorch_post_training_quantization
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from model_compression_toolkit.core.pytorch.constants import CALL_FUNCTION, OUTPUT, CALL_METHOD, PLACEHOLDER
 from model_compression_toolkit.core.pytorch.reader.node_holders import DummyPlaceHolder
 from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy, to_torch_tensor

--- a/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/const_representation_test.py
@@ -19,9 +19,9 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
-
 
 
 class ConstRepresentationNet(nn.Module):

--- a/tests/pytorch_tests/model_tests/feature_models/constant_conv_substitution_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/constant_conv_substitution_test.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 import numpy as np
-
 
 
 class BaseConstantConvSubstitutionTest(BasePytorchFeatureNetworkTest):

--- a/tests/pytorch_tests/model_tests/feature_models/gptq_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/gptq_test.py
@@ -26,7 +26,8 @@ from model_compression_toolkit.gptq.common.gptq_config import GradientPTQConfig,
     GPTQHessianScoresConfig, GradualActivationQuantizationConfig
 from model_compression_toolkit.gptq.common.gptq_constants import QUANT_PARAM_LEARNING_STR, MAX_LSB_STR
 from model_compression_toolkit.gptq.pytorch.gptq_loss import multiple_tensors_mse_loss
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.pytorch_tests.utils import extract_model_weights

--- a/tests/pytorch_tests/model_tests/feature_models/linear_collapsing_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/linear_collapsing_test.py
@@ -19,9 +19,9 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
-
 
 
 class BaseConv2DCollapsingTest(BasePytorchFeatureNetworkTest, ABC):

--- a/tests/pytorch_tests/model_tests/feature_models/matmul_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/matmul_test.py
@@ -14,7 +14,8 @@
 # ==============================================================================
 import torch
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 
 """

--- a/tests/pytorch_tests/model_tests/feature_models/permute_substitution_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/permute_substitution_test.py
@@ -18,7 +18,8 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 
 
 class BasePermuteSubstitutionTest(BasePytorchFeatureNetworkTest):

--- a/tests/pytorch_tests/model_tests/feature_models/qat_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/qat_test.py
@@ -35,8 +35,9 @@ from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
 from model_compression_toolkit.qat.pytorch.quantizer.base_pytorch_qat_weight_quantizer import \
     BasePytorchQATWeightTrainableQuantizer
 from model_compression_toolkit.core.common.quantization.quantization_config import CustomOpsetLayers
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc, \
-    get_op_quantization_configs
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import get_op_quantization_configs
 from model_compression_toolkit.trainable_infrastructure import TrainingMethod
 from model_compression_toolkit.trainable_infrastructure.common.base_trainable_quantizer import VariableGroup
 from model_compression_toolkit.trainable_infrastructure.pytorch.activation_quantizers.base_activation_quantizer import \

--- a/tests/pytorch_tests/model_tests/feature_models/reshape_substitution_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/reshape_substitution_test.py
@@ -18,7 +18,8 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 
 
 class BaseReshapeSubstitutionTest(BasePytorchFeatureNetworkTest):

--- a/tests/pytorch_tests/model_tests/feature_models/residual_collapsing_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/residual_collapsing_test.py
@@ -19,7 +19,8 @@ import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy, set_model
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.tensors_compare import cosine_similarity
 
 

--- a/tests/pytorch_tests/model_tests/feature_models/symmetric_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/symmetric_activation_test.py
@@ -21,7 +21,8 @@ from mct_quantizers import QuantizationMethod
 from model_compression_toolkit.constants import THRESHOLD
 from model_compression_toolkit.core.common.user_info import UserInformation
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 

--- a/tests/pytorch_tests/model_tests/feature_models/uniform_activation_test.py
+++ b/tests/pytorch_tests/model_tests/feature_models/uniform_activation_test.py
@@ -19,7 +19,8 @@ import torch
 import model_compression_toolkit as mct
 from mct_quantizers import QuantizationMethod
 from model_compression_toolkit.core.common.user_info import UserInformation
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.model_tests.base_pytorch_test import BasePytorchTest
 

--- a/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/conv2d_pruning_test.py
+++ b/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/conv2d_pruning_test.py
@@ -15,8 +15,6 @@
 
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
-from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 import numpy as np
 
 from tests.common_tests.pruning.constant_importance_metric import add_const_importance_metric, ConstImportanceMetric

--- a/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/conv2dtranspose_conv2d_pruning_test.py
+++ b/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/conv2dtranspose_conv2d_pruning_test.py
@@ -15,8 +15,6 @@
 
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
-from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 import numpy as np
 
 from tests.common_tests.pruning.constant_importance_metric import add_const_importance_metric, ConstImportanceMetric

--- a/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/conv2dtranspose_pruning_test.py
+++ b/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/conv2dtranspose_pruning_test.py
@@ -15,8 +15,6 @@
 
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
-from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 import numpy as np
 
 from tests.common_tests.pruning.constant_importance_metric import add_const_importance_metric, ConstImportanceMetric

--- a/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/linear_pruning_test.py
+++ b/tests/pytorch_tests/pruning_tests/feature_networks/network_tests/linear_pruning_test.py
@@ -15,8 +15,6 @@
 
 import model_compression_toolkit as mct
 from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
-from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 import numpy as np
 
 from tests.common_tests.pruning.constant_importance_metric import add_const_importance_metric, ConstImportanceMetric

--- a/tests/pytorch_tests/pruning_tests/feature_networks/pruning_pytorch_feature_test.py
+++ b/tests/pytorch_tests/pruning_tests/feature_networks/pruning_pytorch_feature_test.py
@@ -20,7 +20,8 @@ import numpy as np
 
 from model_compression_toolkit.core.pytorch.pytorch_device_config import get_working_device
 from model_compression_toolkit.core.pytorch.utils import to_torch_tensor, torch_tensor_to_numpy
-from model_compression_toolkit.target_platform_capabilities.tpc_models.imx500_tpc.latest import generate_pytorch_tpc
+from model_compression_toolkit.target_platform_capabilities.tpc_models.get_target_platform_capabilities import \
+    get_tpc_model as generate_pytorch_tpc
 from tests.common_tests.helpers.generate_test_tpc import generate_test_tpc
 from tests.pytorch_tests.model_tests.base_pytorch_feature_test import BasePytorchFeatureNetworkTest
 from tests.pytorch_tests.utils import count_model_prunable_params


### PR DESCRIPTION
## Pull Request Description:
Remove `generate_pytorch_tpc`

- If `generate_pytorch_tpc` is imported but unused, delete the import
- If `generate_pytorch_tpc` is used, fix the import

Note: The CICD link error will be fixed in a separate PR.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).