### PR TITLE
[RedSuns Review] Support NumPy 2.4.0 for feature_log_onoff Branch

### DIFF
--- a/.github/workflows/run_keras_tests.yml
+++ b/.github/workflows/run_keras_tests.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   run-tensorflow-tests:
+    #  Tensorflow uses Numpy<2,
+    #  so it does not support testing by Numpy version (<2.4 or 2.4) as seen in Pytorch (run_pytorch_tests.yml).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +27,7 @@ jobs:
           pip install -r requirements.txt
           pip install tensorflow==${{ inputs.tf-version }} sony-custom-layers 
           pip install pytest pytest-mock
+          pip list | grep -e tensorflow -e numpy
           pip check
       - name: Run pytest
         run: |

--- a/.github/workflows/run_pytorch_tests.yml
+++ b/.github/workflows/run_pytorch_tests.yml
@@ -12,7 +12,18 @@ on:
 
 jobs:
   run-pytorch-tests:
+    #  Regression testing for Numpy 2.4.
+    #  It was performed on combinations of Python (3.10, 3.11, 3.12), Pytorch (2.3, 2.4, 2.5, 2.6),
+    #  and NumPy (<2.4 or 2.4) versions.
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "${{ inputs.python-version }}" ]
+        np_ver: [ "<2.4", "2.4" ]
+        exclude:
+          - np_ver: "2.4"
+            python-version: "3.10"  # Numpy 2.4 is not supported on Python 3.10
     steps:
       - uses: actions/checkout@v4
       - name: Install Python 3
@@ -26,11 +37,18 @@ jobs:
           echo "numpy<2" >> temp_requirements.txt
           mv temp_requirements.txt requirements.txt
       - name: Install dependencies
+        #  For Python 3.10, no need to reinstall Numpy<2.4 because it is installed in requirements.txt.
+        #  For Python 3.11 and 3.12, Numpy<2.4 is reinstalled after Numpy 2.4 is installed in requirements.txt.
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt          
           pip install torch==${{ inputs.torch-version }} torchvision onnx onnxruntime "onnxruntime-extensions<0.14"
+          if [ "${{ matrix.np_ver }}" == "<2.4" ] && [ "${{ matrix.python-version }}" != "3.10" ]; then
+            echo "Installing numpy<2.4"
+            pip install numpy 'numpy<2.4'
+          fi
           pip install pytest pytest-mock
+          pip list | grep -e torch -e onnx -e numpy
           pip check
       - name: Run pytest
         run: |

--- a/.github/workflows/tests_common.yml
+++ b/.github/workflows/tests_common.yml
@@ -11,7 +11,13 @@ concurrency:
 
 jobs:
   build:
+    #  Regression testing for Numpy 2.4.
+    #  It was performed on combinations of Python 3.11 and NumPy (<2.4 or 2.4) versions.
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        np_ver: [ "<2.4", "2.4" ]
     steps:
       - uses: actions/checkout@v4
       - name: Install Python 3
@@ -22,7 +28,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt 
+          if [[ "${{ matrix.np_ver }}" == "<2.4" ]]; then
+            pip install numpy 'numpy<2.4'
+          fi
           pip install pytest pytest-mock
+          pip list | grep numpy
           pip check
 
       - name: Run unittests

--- a/model_compression_toolkit/core/common/quantization/quantizers/uniform_quantizers.py
+++ b/model_compression_toolkit/core/common/quantization/quantizers/uniform_quantizers.py
@@ -26,7 +26,8 @@ def threshold_is_power_of_two(threshold: np.ndarray, per_channel: bool) -> bool:
         thresholds_per_channel = threshold.flatten()
         return (np.log2(thresholds_per_channel) == list(map(int, np.log2(thresholds_per_channel)))).all()
 
-    return np.log2(threshold) == int(np.log2(threshold))
+    # Conversion of an array with ndim > 0 to a scalar was deprecated in NumPy1.25, and raised error in NumPy2.4.
+    return np.log2(threshold) == int(np.log2(threshold).item())
 
 
 def power_of_two_quantizer(tensor_data: np.ndarray,


### PR DESCRIPTION
## Pull Request Description:
* Remove conversion of an array(np.ndarray) with ndim > 0 to a scalar.
* Support numpy version (<2.4 or 2.4) on CI/CD

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).