### PR TITLE
Change the activation quantization error tolerance when exporting

### DIFF
--- a/tests_pytest/pytorch_tests/e2e_tests/test_exporter.py
+++ b/tests_pytest/pytorch_tests/e2e_tests/test_exporter.py
@@ -231,7 +231,7 @@ class TestExporter:
         # if not isinstance(torch_outputs, (list, tuple)):
         #     torch_outputs = [torch_outputs]
         # torch_outputs = [o.detach().cpu().numpy() for o in torch_outputs]
-        
+        #
         # assert np.all([np.isclose(rmse(onnx_output, torch_output), 0, atol=tol)
         #                for onnx_output, torch_output in zip(onnx_outputs, torch_outputs)])
 


### PR DESCRIPTION
## Pull Request Description:
Change the activation quantization error tolerance when exporting
- Activation 8bit : tolerance 1e-2
- Activation 16bit : tolerance 1e-4

This PR addresses the following [issue](https://github.com/SonySemiconductorSolutions/mct-model-optimization/issues/1479)

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).