### PR TITLE
[SSS Review] Change the activation quantization error tolerance when exporting

### DIFF
--- a/tests_pytest/pytorch_tests/e2e_tests/test_exporter.py
+++ b/tests_pytest/pytorch_tests/e2e_tests/test_exporter.py
@@ -336,7 +336,7 @@ class TestExporter:
                                              output_names=output_names)
         self._assert_outputs_names(output_names=output_names)
 
-    @pytest.mark.parametrize('abits, tol', ([8, 1e-4], [16, 1e-2]))
+    @pytest.mark.parametrize('abits, tol', ([8, 1e-2], [16, 1e-4]))
     def test_mct_ptq_and_exporter_fq(self, abits, tol):
         quantized_model = self._run_mct(self.get_model(), self.representative_dataset(1), abits, mctq.QuantizationMethod.POWER_OF_TWO)
         onnx_model_dict = self._run_exporter(quantized_model, self.representative_dataset(1), QuantizationFormat.FAKELY_QUANT)
@@ -371,7 +371,7 @@ class TestExporter:
         self._assert_quant_params_match(quantized_model, onnx_model_dict, a_qmethod)
         self._assert_outputs_match(quantized_model, self.representative_dataset(1), QuantizationFormat.MCTQ, tol=tol)
 
-    @pytest.mark.parametrize('abits, tol', ([8, 1e-8], [16, 1e-2]))
+    @pytest.mark.parametrize('abits, tol', ([8, 1e-2], [16, 1e-4]))
     def test_mct_qat_and_exporter_fq(self, abits, tol):
         quantized_model = self._run_mct_qat(self.get_model(), self.representative_dataset(1), abits, mctq.QuantizationMethod.POWER_OF_TWO)
         onnx_model_dict = self._run_exporter(quantized_model, self.representative_dataset(1), QuantizationFormat.FAKELY_QUANT)


### PR DESCRIPTION
## Pull Request Description:
Change the activation quantization error tolerance when exporting.
- Activation 8bit : tolerance 1e-2
- Activation 16bit : tolerance 1e-4

The validation code remains commented out.

This PR addresses the following [issue](https://github.com/SonySemiconductorSolutions/mct-model-optimization/issues/1479)

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).