### PR TITLE
[SSS Review] Disable weight quantization for Sin, Cos, and Exp

### DIFF
--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v5_0/tpc.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v5_0/tpc.py
@@ -342,9 +342,9 @@ def generate_tpc(default_config: OpQuantizationConfig,
     gelu = schema.OperatorsSet(name=schema.OperatorSetNames.GELU, qc_options=default_config_options_16bit)
     tanh = schema.OperatorsSet(name=schema.OperatorSetNames.TANH, qc_options=default_config_options_16bit)
     hard_tanh = schema.OperatorsSet(name=schema.OperatorSetNames.HARD_TANH, qc_options=default_config_options_16bit)
-    exp = schema.OperatorsSet(name=schema.OperatorSetNames.EXP, qc_options=const_configuration_options_inout16)
-    sin = schema.OperatorsSet(name=schema.OperatorSetNames.SIN, qc_options=const_configuration_options_inout16)
-    cos = schema.OperatorsSet(name=schema.OperatorSetNames.COS, qc_options=const_configuration_options_inout16)
+    exp = schema.OperatorsSet(name=schema.OperatorSetNames.EXP, qc_options=default_config_options_16bit)
+    sin = schema.OperatorsSet(name=schema.OperatorSetNames.SIN, qc_options=default_config_options_16bit)
+    cos = schema.OperatorsSet(name=schema.OperatorSetNames.COS, qc_options=default_config_options_16bit)
 
     operator_set.extend(
         [conv, conv_transpose, depthwise_conv, fc, relu, relu6, leaky_relu, add, sub, mul, div, prelu, swish, hardswish,

--- a/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v6_0/tpc.py
+++ b/model_compression_toolkit/target_platform_capabilities/tpc_models/imx500_tpc/v6_0/tpc.py
@@ -346,9 +346,9 @@ def generate_tpc(default_config: OpQuantizationConfig,
     gelu = schema.OperatorsSet(name=schema.OperatorSetNames.GELU, qc_options=default_config_options_16bit)
     tanh = schema.OperatorsSet(name=schema.OperatorSetNames.TANH, qc_options=default_config_options_16bit)
     hard_tanh = schema.OperatorsSet(name=schema.OperatorSetNames.HARD_TANH, qc_options=default_config_options_16bit)
-    exp = schema.OperatorsSet(name=schema.OperatorSetNames.EXP, qc_options=const_configuration_options_inout16)
-    sin = schema.OperatorsSet(name=schema.OperatorSetNames.SIN, qc_options=const_configuration_options_inout16)
-    cos = schema.OperatorsSet(name=schema.OperatorSetNames.COS, qc_options=const_configuration_options_inout16)
+    exp = schema.OperatorsSet(name=schema.OperatorSetNames.EXP, qc_options=default_config_options_16bit)
+    sin = schema.OperatorsSet(name=schema.OperatorSetNames.SIN, qc_options=default_config_options_16bit)
+    cos = schema.OperatorsSet(name=schema.OperatorSetNames.COS, qc_options=default_config_options_16bit)
 
     operator_set.extend(
         [conv, conv_transpose, depthwise_conv, fc, relu, relu6, leaky_relu, add, sub, mul, div, prelu, swish, hardswish,

--- a/tests_pytest/common_tests/unit_tests/target_platform_capabilities/test_tpc_sin_cos_exp.py
+++ b/tests_pytest/common_tests/unit_tests/target_platform_capabilities/test_tpc_sin_cos_exp.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import pytest
+from model_compression_toolkit import get_target_platform_capabilities
+
+
+@pytest.mark.parametrize("tpc_version", [
+    '5.0',
+    '6.0',
+])
+def test_sin_cos_exp(tpc_version):
+
+    tpc = get_target_platform_capabilities(tpc_version=tpc_version)
+    operators = [opset.name for opset in tpc.operator_set]
+    assert 'Sin' in operators
+    assert 'Cos' in operators
+    assert 'Exp' in operators
+
+    for opset in tpc.operator_set:
+        if opset.name in ['Sin', 'Cos', 'Exp']:
+            for qc in opset.qc_options.quantization_configurations:
+                assert qc.default_weight_attr_config.enable_weights_quantization == False
+                assert qc.enable_activation_quantization == True
+                assert qc.supported_input_activation_n_bits == (8, 16)

--- a/tests_pytest/pytorch_tests/e2e_tests/test_constant_sin_cos_exp.py
+++ b/tests_pytest/pytorch_tests/e2e_tests/test_constant_sin_cos_exp.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import pytest
+from typing import Iterator, List
+import torch
+import torch.nn as nn
+import model_compression_toolkit as mct
+from mct_quantizers import PytorchQuantizationWrapper
+
+
+class Model(nn.Module):
+
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+
+        self.conv = nn.Conv2d(3, 3, kernel_size=3, padding=1)
+        self.const = nn.Parameter(torch.ones([32, 32]))
+
+    def forward(self, x):
+        x = self.conv(x)
+
+        if self.name == 'sin':
+            y = torch.sin(self.const) * x
+        elif self.name == 'cos':
+            y = torch.cos(self.const) * x
+        elif self.name == 'exp':
+            y = torch.exp(self.const) * x
+
+        return y
+
+
+def get_representative_dataset(n_iter=1):
+
+    def representative_dataset() -> Iterator[List]:
+        for _ in range(n_iter):
+            yield [torch.randn(1, 3, 32, 32)]
+    return representative_dataset
+
+
+@pytest.mark.parametrize("tpc_version", [
+    '5.0',
+    '6.0',
+])
+@pytest.mark.parametrize("layer", [
+    'sin',
+    'cos',
+    'exp',
+])
+def test_constant_sin_cos_exp(tpc_version, layer):
+
+    weight_quantizers = []
+    
+    float_model = Model(layer)
+    tpc = mct.get_target_platform_capabilities(tpc_version=tpc_version)
+    quantized_model, _ = mct.ptq.pytorch_post_training_quantization(float_model, 
+                                                                    get_representative_dataset(n_iter=1),
+                                                                    target_platform_capabilities=tpc)
+    
+    weight_quantizers.extend([name for name, module in quantized_model.named_modules() if isinstance(module, PytorchQuantizationWrapper)])
+
+    assert f'{layer}' not in weight_quantizers  # Check that sin, cos, and exp layers do not have the weight quantizer
+    assert hasattr(quantized_model, f'{layer}_activation_holder_quantizer')


### PR DESCRIPTION
## Pull Request Description:
- Disable weight quantization for sin/cos/exp layers in TPC V5.0 and V6.0
- Add tests for inputting constant tensors to sin/cos/exp layers

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).