### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
@@ -46,7 +46,7 @@ class ChangeFinalWeightQCAttrTest(BaseKerasFeatureNetworkTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
         self.unit_test.assertTrue(conv_layer.layer.bias is None)  # If bias correction is enabled, a bias should be added -
-        # This asserts the editing occured
+        # This asserts the editing occurred
 
 
 class ChangeFinalActivationQCAttrTest(BaseKerasFeatureNetworkTest):


### PR DESCRIPTION
Fixes a typo in a test comment.

- occured → occurred