### PR TITLE
[SSS Review] Support for scalar and 1d-tensor in statistics collector

### DIFF
--- a/model_compression_toolkit/core/common/model_collector.py
+++ b/model_compression_toolkit/core/common/model_collector.py
@@ -46,9 +46,17 @@ def create_stats_collector_for_node(node: common.BaseNode,
     """
 
     if node.is_activation_quantization_enabled() or quant_node_in_fln:
+        out_channel_axis = fw_info.out_channel_axis_mapping.get(node.type)
+
+        if node.type not in fw_info.out_channel_axis_mapping.keys() and len(node.get_output_shapes_list()[0]) < 2:
+            # In case of PyTorch, the output channel axis is set to 1 for layers other than conv and linear. 
+            # If the output shape of node is 1D or scalar, change to -1.
+            # In case of Keras, the output channel axis is set to -1, so it is already set to -1 by default.
+            out_channel_axis = -1
+
         min_output = getattr(node.prior_info, 'min_output', None)
         max_output = getattr(node.prior_info, 'max_output', None)
-        stats_collector = common.StatsCollector(out_channel_axis=fw_info.out_channel_axis_mapping.get(node.type),
+        stats_collector = common.StatsCollector(out_channel_axis=out_channel_axis,
                                                 init_min_value=min_output,
                                                 init_max_value=max_output)
     else:

--- a/model_compression_toolkit/core/pytorch/utils.py
+++ b/model_compression_toolkit/core/pytorch/utils.py
@@ -86,7 +86,9 @@ def torch_tensor_to_numpy(tensor: Union[torch.Tensor, list, tuple]) -> Union[np.
     elif isinstance(tensor, tuple):
         return tuple([torch_tensor_to_numpy(t) for t in tensor])
     elif isinstance(tensor, torch.Tensor):
-        return tensor.cpu().detach().contiguous().numpy()
+        np_tensor = tensor.cpu().detach().contiguous().numpy()
+        # For scalar tensors, return a 1D array with a single element.
+        return np.array([np_tensor]) if np_tensor.ndim == 0 else np_tensor
     else:
         Logger.critical(f'Unsupported type for conversion to Numpy array: {type(tensor)}.')
 

--- a/tests/pytorch_tests/function_tests/test_torch_utils.py
+++ b/tests/pytorch_tests/function_tests/test_torch_utils.py
@@ -29,6 +29,9 @@ class TestTorchUtils(unittest.TestCase):
         self.list_of_numbers = [1, 2, 3]
         self.tuple_of_numbers = (1, 2, 3)
 
+        self.scalar_numpy_array = np.array([1.25])
+        self.scalar_torch_tensor = torch.tensor(1.25)
+
     @patch('model_compression_toolkit.core.pytorch.pytorch_device_config.get_working_device')
     def test_to_torch_tensor_with_numpy_array(self, mock_get_device):
         mock_get_device.return_value = 'cpu'
@@ -68,15 +71,32 @@ class TestTorchUtils(unittest.TestCase):
         result = torch_tensor_to_numpy(self.torch_tensor)
         np.testing.assert_array_almost_equal(result, self.numpy_array)
 
+    def test_torch_tensor_to_numpy_with_scalar_tensor(self):
+        result = torch_tensor_to_numpy(self.scalar_torch_tensor)
+        self.assertEqual(result.shape, (1,))
+        np.testing.assert_array_almost_equal(result, self.scalar_numpy_array)
+
     def test_torch_tensor_to_numpy_with_list(self):
         result = torch_tensor_to_numpy([self.torch_tensor, self.torch_tensor])
         self.assertEqual(len(result), 2)
         self.assertTrue(all(isinstance(x, np.ndarray) for x in result))
 
+    def test_torch_tensor_to_numpy_with_scalar_list(self):
+        result = torch_tensor_to_numpy([self.scalar_torch_tensor, self.scalar_torch_tensor])
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(x, np.ndarray) for x in result))
+        self.assertTrue(all(x.shape == (1,) for x in result))
+
     def test_torch_tensor_to_numpy_with_tuple(self):
         result = torch_tensor_to_numpy((self.torch_tensor, self.torch_tensor))
         self.assertEqual(len(result), 2)
         self.assertTrue(all(isinstance(x, np.ndarray) for x in result))
+
+    def test_torch_tensor_to_numpy_with_scalar_tuple(self):
+        result = torch_tensor_to_numpy((self.scalar_torch_tensor, self.scalar_torch_tensor))
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(x, np.ndarray) for x in result))
+        self.assertTrue(all(x.shape == (1,) for x in result))
 
     @patch('model_compression_toolkit.logger.Logger')
     def test_torch_tensor_to_numpy_with_unsupported_type(self, mock_logger):

--- a/tests_pytest/keras_tests/unit_tests/core/test_create_stats_collector_for_node.py
+++ b/tests_pytest/keras_tests/unit_tests/core/test_create_stats_collector_for_node.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from unittest.mock import Mock
+import pytest
+from model_compression_toolkit.core.common.model_collector import create_stats_collector_for_node
+from model_compression_toolkit.defaultdict import DefaultDict
+
+
+class Conv2D:
+    pass
+
+class DepthwiseConv2D:
+    pass
+
+class Dense:
+    pass
+
+class Conv2DTranspose:
+    pass
+
+class DummyLayer:
+    pass
+
+@pytest.fixture
+def fw_info_mock():
+    fw_info = Mock()
+    fw_info.out_channel_axis_mapping = DefaultDict({Conv2D: -1, Dense: -1, Conv2DTranspose: -1, DepthwiseConv2D: -1}, -1)
+    return fw_info
+
+@pytest.fixture
+def node_mock():
+    node = Mock()
+    node.is_activation_quantization_enabled.return_value = True
+    return node
+
+
+class TestCreateStatsCollectorForNode:
+
+    def test_create_stats_collector_for_node_conv(self, node_mock, fw_info_mock):
+        node_mock.type = Conv2D
+        node_mock.get_output_shapes_list.return_value = [(1, 3, 32, 32)]
+
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == -1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1
+
+    def test_create_stats_collector_for_node_dense(self, node_mock, fw_info_mock):
+        node_mock.type = Dense
+        node_mock.get_output_shapes_list.return_value = [(1, 10)]
+
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == -1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1
+
+    def test_create_stats_collector_for_node_2d_tensor(self, node_mock, fw_info_mock):
+        node_mock.type = DummyLayer
+        node_mock.get_output_shapes_list.return_value = [(1, 3)] # Output shape is 2D tensor
+
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == -1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1
+
+    def test_create_stats_collector_for_node_1d_tensor(self, node_mock, fw_info_mock):
+        node_mock.type = DummyLayer
+        node_mock.get_output_shapes_list.return_value = [(1,)] # Output shape is 1D tensor
+
+        # Check that axis remains -1
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == -1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1
+
+    def test_create_stats_collector_for_node_scalar(self, node_mock, fw_info_mock):
+        node_mock.type = DummyLayer
+        node_mock.get_output_shapes_list.return_value = [()] # Output shape is scalar
+
+        # Check that axis remains -1
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == -1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1

--- a/tests_pytest/pytorch_tests/e2e_tests/test_quantization_for_1d_tensor.py
+++ b/tests_pytest/pytorch_tests/e2e_tests/test_quantization_for_1d_tensor.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import model_compression_toolkit as mct
+import torch
+import torch.nn as nn
+import pytest
+
+# This test checks whether an ActivationQuantizationHolder can be attached to a layer that produces 1D tensor output.
+# These layers were selected from operators supported by the SDSP converter.
+
+class Model(nn.Module):
+
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+        self.conv = nn.Conv2d(3, 3, kernel_size=3, padding=1)
+        self.relu = nn.ReLU()
+        self.tensor = nn.Parameter(2.0 * torch.ones([1])) # 1D tensor
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.relu(x)
+
+        if self.name == 'add':
+            const = torch.add(self.tensor, 1)
+        elif self.name == 'relu6':
+            const = torch.nn.functional.relu6(self.tensor)
+        elif self.name == 'relu':
+            const = torch.nn.functional.relu(self.tensor)
+        elif self.name == 'sigmoid':
+            const = torch.nn.functional.sigmoid(self.tensor)
+        elif self.name == 'leaky_relu':
+            const = torch.nn.functional.leaky_relu(self.tensor)
+        elif self.name == 'mul':
+            const = torch.mul(self.tensor, 2)
+        elif self.name == 'sub':
+            const = torch.sub(self.tensor, 1)
+        elif self.name == 'div':
+            const = torch.div(self.tensor, 1)
+        elif self.name == 'softmax':
+            const = torch.nn.functional.softmax(self.tensor)
+        elif self.name == 'tanh':
+            const = torch.nn.functional.tanh(self.tensor)
+        elif self.name == 'negative':
+            const = torch.negative(self.tensor)
+        elif self.name == 'abs':
+            const = torch.abs(self.tensor)
+        elif self.name == 'sqrt':
+            const = torch.sqrt(torch.clamp(self.tensor, min=1e-6))
+        elif self.name == 'rsqrt':
+            const = torch.rsqrt(torch.clamp(self.tensor, min=1e-6))
+        elif self.name == 'silu':
+            const = torch.nn.functional.silu(self.tensor)
+        elif self.name == 'hardswish':
+            const = torch.nn.functional.hardswish(self.tensor)
+        elif self.name == 'hardsigmoid':
+            const = torch.nn.functional.hardsigmoid(self.tensor)
+        elif self.name == 'pow':
+            const = torch.pow(self.tensor, 1)
+        elif self.name == 'gelu':
+            const = torch.nn.functional.gelu(self.tensor)
+        elif self.name == 'cos':
+            const = torch.cos(self.tensor)
+        elif self.name == 'sin':
+            const = torch.sin(self.tensor)
+        elif self.name == 'exp':
+            const = torch.exp(self.tensor)
+        elif self.name == 'mean':
+            const = torch.mean(self.tensor, dim=0, keepdim=True)
+        elif self.name == 'amax':
+            const = torch.amax(self.tensor, dim=0, keepdim=True)
+        elif self.name == 'maximum':
+            const = torch.maximum(self.tensor, torch.tensor(0.0))
+        elif self.name == 'minimum':
+            const = torch.minimum(self.tensor, torch.tensor(0.0))
+        elif self.name == 'sum':
+            const = torch.sum(self.tensor, dim=0, keepdim=True)
+        elif self.name == 'linalg_norm':
+            const = torch.linalg.norm(self.tensor, dim=0, keepdim=True)
+
+        y = x + const
+        return y
+
+def representative_data_gen():
+    yield [torch.randn(1, 3, 8, 8)]
+
+@pytest.mark.parametrize("layer", [
+    'add', 'relu6', 'relu', 'sigmoid', 'leaky_relu', 'mul', 'sub', 'div', 'mean', 'amax', 'softmax',
+    'tanh', 'negative', 'maximum', 'minimum', 'abs', 'sqrt', 'sum', 'rsqrt', 'silu', 'hardswish', 'hardsigmoid',
+    'linalg_norm', 'pow', 'gelu', 'cos', 'sin', 'exp', 
+])
+def test_ptq_1d_tensor(layer):
+
+    float_model = Model(name=layer)
+
+    tpc = mct.get_target_platform_capabilities("6.0")
+    quantized_model, _ = mct.ptq.pytorch_post_training_quantization(float_model,
+                                                                    representative_data_gen=representative_data_gen,
+                                                                    target_platform_capabilities=tpc)
+    
+    if layer in ['abs', 'sum', 'pow']:
+        activation_holder = f'{layer}_1_activation_holder_quantizer'
+    else:
+        activation_holder = f'{layer}_activation_holder_quantizer'
+
+    assert hasattr(quantized_model, activation_holder)
+
+
+@pytest.mark.parametrize("layer", [
+    'add', 'relu6', 'relu', 'sigmoid', 'leaky_relu', 'mul', 'sub', 'div', 'mean', 'amax', 'softmax',
+    'tanh', 'negative', 'maximum', 'minimum', 'abs', 'sqrt', 'sum', 'rsqrt', 'silu', 'hardswish', 'hardsigmoid',
+    'linalg_norm', 'pow', 'gelu', 'cos', 'sin', 'exp', 
+])
+def test_ptq_mixed_precision_1d_tensor(layer):
+
+    float_model = Model(name=layer)
+
+    tpc = mct.get_target_platform_capabilities("6.0")
+    core_config = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                                                                       use_hessian_based_scores=False))
+    resource_utilization_data = mct.core.pytorch_resource_utilization_data(float_model,
+                                                                           representative_data_gen,
+                                                                           core_config,
+                                                                           target_platform_capabilities=tpc)
+    resource_utilization = mct.core.ResourceUtilization(resource_utilization_data.weights_memory * 0.9)
+    quantized_model, _ = mct.ptq.pytorch_post_training_quantization(float_model,
+                                                                    representative_data_gen,
+                                                                    target_resource_utilization=resource_utilization,
+                                                                    core_config=core_config,
+                                                                    target_platform_capabilities=tpc)
+    
+    if layer in ['abs', 'sum', 'pow']:
+        activation_holder = f'{layer}_1_activation_holder_quantizer'
+    else:
+        activation_holder = f'{layer}_activation_holder_quantizer'
+
+    assert hasattr(quantized_model, activation_holder)
+
+
+@pytest.mark.parametrize("layer", [
+    'add', 'relu6', 'relu', 'sigmoid', 'leaky_relu', 'mul', 'sub', 'div', 'mean', 'amax', 'softmax',
+    'tanh', 'negative', 'maximum', 'minimum', 'abs', 'sqrt', 'sum', 'rsqrt', 'silu', 'hardswish', 'hardsigmoid',
+    'linalg_norm', 'pow', 'gelu', 'cos', 'sin', 'exp', 
+])
+def test_gptq_1d_tensor(layer):
+
+    float_model = Model(name=layer)
+
+    tpc = mct.get_target_platform_capabilities("6.0")
+    gptq_config = mct.gptq.get_pytorch_gptq_config(n_epochs=5)
+    quantized_model, _ = mct.gptq.pytorch_gradient_post_training_quantization(float_model,
+                                                                              representative_data_gen,
+                                                                              gptq_config=gptq_config,
+                                                                              target_platform_capabilities=tpc)
+    
+    if layer in ['abs', 'sum', 'pow']:
+        activation_holder = f'{layer}_1_activation_holder_quantizer'
+    else:
+        activation_holder = f'{layer}_activation_holder_quantizer'
+
+    assert hasattr(quantized_model, activation_holder)

--- a/tests_pytest/pytorch_tests/e2e_tests/test_quantization_for_scalar.py
+++ b/tests_pytest/pytorch_tests/e2e_tests/test_quantization_for_scalar.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import model_compression_toolkit as mct
+import torch
+import torch.nn as nn
+import pytest
+
+# This test checks whether an ActivationQuantizationHolder can be attached to a layer that produces scalar output.
+# These layers were selected from operators supported by the SDSP converter.
+
+class Model(nn.Module):
+
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+        self.conv = nn.Conv2d(3, 3, kernel_size=3, padding=1)
+        self.relu = nn.ReLU()
+        self.scalar = nn.Parameter(2.0 * torch.ones([])) # Scalar
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.relu(x)
+
+        if self.name == 'add':
+            const = torch.add(self.scalar, 1)
+        elif self.name == 'relu6':
+            const = torch.nn.functional.relu6(self.scalar)
+        elif self.name == 'relu':
+            const = torch.nn.functional.relu(self.scalar)
+        elif self.name == 'sigmoid':
+            const = torch.nn.functional.sigmoid(self.scalar)
+        elif self.name == 'leaky_relu':
+            const = torch.nn.functional.leaky_relu(self.scalar)
+        elif self.name == 'mul':
+            const = torch.mul(self.scalar, 2)
+        elif self.name == 'sub':
+            const = torch.sub(self.scalar, 1)
+        elif self.name == 'div':
+            const = torch.div(self.scalar, 1)
+        elif self.name == 'softmax':
+            const = torch.nn.functional.softmax(self.scalar)
+        elif self.name == 'tanh':
+            const = torch.nn.functional.tanh(self.scalar)
+        elif self.name == 'negative':
+            const = torch.negative(self.scalar)
+        elif self.name == 'abs':
+            const = torch.abs(self.scalar)
+        elif self.name == 'sqrt':
+            const = torch.sqrt(self.scalar)
+        elif self.name == 'rsqrt':
+            const = torch.rsqrt(self.scalar)
+        elif self.name == 'silu':
+            const = torch.nn.functional.silu(self.scalar)
+        elif self.name == 'hardswish':
+            const = torch.nn.functional.hardswish(self.scalar)
+        elif self.name == 'hardsigmoid':
+            const = torch.nn.functional.hardsigmoid(self.scalar)
+        elif self.name == 'pow':
+            const = torch.pow(self.scalar, 1)
+        elif self.name == 'gelu':
+            const = torch.nn.functional.gelu(self.scalar)
+        elif self.name == 'cos':
+            const = torch.cos(self.scalar)
+        elif self.name == 'sin':
+            const = torch.sin(self.scalar)
+        elif self.name == 'exp':
+            const = torch.exp(self.scalar)
+        
+        y = x + const
+        return y
+
+def representative_data_gen():
+    yield [torch.randn(1, 3, 8, 8)]
+
+@pytest.mark.parametrize("layer", [
+    'add', 'relu6', 'relu', 'sigmoid', 'leaky_relu', 'mul', 'sub', 'div', 'softmax',
+    'tanh', 'negative', 'abs', 'sqrt', 'rsqrt', 'silu', 'hardswish', 'hardsigmoid',
+    'pow', 'gelu', 'cos', 'sin', 'exp'
+])
+def test_ptq_scalar(layer):
+
+    float_model = Model(name=layer)
+
+    tpc = mct.get_target_platform_capabilities("6.0")
+    quantized_model, _ = mct.ptq.pytorch_post_training_quantization(float_model,
+                                                                    representative_data_gen=representative_data_gen,
+                                                                    target_platform_capabilities=tpc)
+    
+    if layer in ['abs', 'pow']:
+        activation_holder = f'{layer}_1_activation_holder_quantizer'
+    else:
+        activation_holder = f'{layer}_activation_holder_quantizer'
+
+    assert hasattr(quantized_model, activation_holder)
+
+
+@pytest.mark.parametrize("layer", [
+    'add', 'relu6', 'relu', 'sigmoid', 'leaky_relu', 'mul', 'sub', 'div', 'softmax',
+    'tanh', 'negative', 'abs', 'sqrt', 'rsqrt', 'silu', 'hardswish', 'hardsigmoid',
+    'pow', 'gelu', 'cos', 'sin', 'exp'
+])
+def test_ptq_mixed_precision_scalar(layer):
+
+    float_model = Model(name=layer)
+
+    tpc = mct.get_target_platform_capabilities("6.0")
+    core_config = mct.core.CoreConfig(mixed_precision_config=mct.core.MixedPrecisionQuantizationConfig(num_of_images=1,
+                                                                                                       use_hessian_based_scores=False))
+    resource_utilization_data = mct.core.pytorch_resource_utilization_data(float_model,
+                                                                           representative_data_gen,
+                                                                           core_config,
+                                                                           target_platform_capabilities=tpc)
+    resource_utilization = mct.core.ResourceUtilization(resource_utilization_data.weights_memory * 0.9)
+    quantized_model, _ = mct.ptq.pytorch_post_training_quantization(float_model,
+                                                                    representative_data_gen,
+                                                                    target_resource_utilization=resource_utilization,
+                                                                    core_config=core_config,
+                                                                    target_platform_capabilities=tpc)
+    
+    if layer in ['abs', 'pow']:
+        activation_holder = f'{layer}_1_activation_holder_quantizer'
+    else:
+        activation_holder = f'{layer}_activation_holder_quantizer'
+
+    assert hasattr(quantized_model, activation_holder)
+
+
+@pytest.mark.parametrize("layer", [
+    'add', 'relu6', 'relu', 'sigmoid', 'leaky_relu', 'mul', 'sub', 'div', 'softmax',
+    'tanh', 'negative', 'abs', 'sqrt', 'rsqrt', 'silu', 'hardswish', 'hardsigmoid',
+    'pow', 'gelu', 'cos', 'sin', 'exp'
+])
+def test_gptq_scalar(layer):
+
+    float_model = Model(name=layer)
+
+    tpc = mct.get_target_platform_capabilities("6.0")
+    gptq_config = mct.gptq.get_pytorch_gptq_config(n_epochs=5)
+    quantized_model, _ = mct.gptq.pytorch_gradient_post_training_quantization(float_model,
+                                                                              representative_data_gen,
+                                                                              gptq_config=gptq_config,
+                                                                              target_platform_capabilities=tpc)
+    
+    if layer in ['abs', 'pow']:
+        activation_holder = f'{layer}_1_activation_holder_quantizer'
+    else:
+        activation_holder = f'{layer}_activation_holder_quantizer'
+
+    assert hasattr(quantized_model, activation_holder)

--- a/tests_pytest/pytorch_tests/integration_tests/core/test_model_collector_for_scalar.py
+++ b/tests_pytest/pytorch_tests/integration_tests/core/test_model_collector_for_scalar.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import pytest
+from tests_pytest._test_util.graph_builder_utils import build_node
+from unittest.mock import Mock
+import numpy as np
+import torch
+from model_compression_toolkit.core.pytorch.utils import torch_tensor_to_numpy
+from model_compression_toolkit.core.common import StatsCollector, Graph
+from model_compression_toolkit.core.common.graph.base_graph import OutTensor
+from model_compression_toolkit.core.common.graph.edge import Edge
+from model_compression_toolkit.core.common.model_collector import ModelCollector
+from model_compression_toolkit.defaultdict import DefaultDict
+
+
+class Conv2D:
+    pass
+
+class Linear:
+    pass
+
+class ConvTranspose2d:
+    pass
+
+class DummyLayer:
+    pass
+
+@pytest.fixture
+def fw_impl_mock():
+    fw_impl = Mock()
+    fw_impl.model_builder.return_value = (Mock(), None)
+    return fw_impl
+
+@pytest.fixture
+def fw_info_mock():
+    fw_info = Mock()
+    fw_info.out_channel_axis_mapping = DefaultDict({Conv2D: 1, Linear: -1, ConvTranspose2d: 1}, 1)
+    return fw_info
+
+
+class TestModelCollectorInit:
+
+    def test_init(self, fw_impl_mock, fw_info_mock):
+        node0 = build_node('node0', output_shape=[[1, 3, 2, 2]])   # 4D tensor
+        node1 = build_node('node1', output_shape=[[3, 2]]) # 2D tensor
+        node2 = build_node('node2', output_shape=[[4]])   # 1D tensor
+        node3 = build_node('node3', output_shape=[[]])     # Scalar
+
+        mock_nodes_list = [node0, node1, node2, node3]
+        for node in mock_nodes_list:
+            node.is_activation_quantization_enabled = Mock(return_value=True)
+            node.is_fln_quantization = Mock(return_value=False)
+
+        graph = Graph('g',
+                      input_nodes=[node0],
+                      nodes=mock_nodes_list,
+                      output_nodes=[OutTensor(node3, 0)],
+                      edge_list=[Edge(node0, node1, 0, 0), Edge(node1, node2, 0, 0), Edge(node2, node3, 0, 0)])
+        graph.set_out_stats_collector_to_node = Mock(wraps=graph.set_out_stats_collector_to_node)
+
+        fw_info_mock.get_kernel_op_attributes.return_value = [None]
+
+        mc = ModelCollector(graph, fw_impl_mock, fw_info_mock)
+
+        # If output shape is scalar or 1D tensor, the axis should be -1.
+        # If output shape is 2D tensor, the axis should be 1.
+        expected_axis = [1, 1, -1, -1]
+        for node, expected in zip(graph.nodes, expected_axis):
+            out_stats_container = graph.get_out_stats_collector(node)
+            assert isinstance(out_stats_container, StatsCollector)
+
+            assert out_stats_container.mpcc.axis == expected
+            assert out_stats_container.mc.axis == expected
+
+
+class TestModelCollectorInfer:
+
+    def test_infer(self, fw_impl_mock, fw_info_mock):
+        node0 = build_node('node0', output_shape=[[1, 3, 2, 2]])   # 4D tensor
+        node1 = build_node('node1', output_shape=[[3, 2]])   # 2D tensor
+        node2 = build_node('node2', output_shape=[[4]])     # 1D tensor
+        node3 = build_node('node3', output_shape=[[]])       # scalar
+
+        mock_nodes_list = [node0, node1, node2, node3]
+        for node in mock_nodes_list:
+            node.is_activation_quantization_enabled = Mock(return_value=True)
+            node.is_fln_quantization = Mock(return_value=False)
+
+        graph = Graph('g',
+                      input_nodes=[node0],
+                      nodes=mock_nodes_list,
+                      output_nodes=[OutTensor(node3, 0)],
+                      edge_list=[Edge(node0, node1, 0, 0), Edge(node1, node2, 0, 0), Edge(node2, node3, 0, 0)])
+
+        fw_info_mock.get_kernel_op_attributes.return_value = [None]
+
+        infer1 = [
+            torch.tensor(
+                [[
+                    [[1.0, 2.0], [3.0, 4.0]],
+                    [[-1.0, -2.0], [-3.0, -4.0]],
+                    [[10.0, 10.0], [10.0, 10.0]],
+                ]],
+                dtype=torch.float32,
+            ),
+            torch.tensor([[1.0, 3.0], [2.0, 4.0], [3.0, 5.0]], dtype=torch.float32),
+            torch.tensor([2.0, 6.0, 8.0, 10.0], dtype=torch.float32),
+            torch.tensor(10.0, dtype=torch.float32),
+        ]
+        infer2 = [
+            torch.tensor(
+                [[
+                    [[5.0, 6.0], [7.0, 8.0]],
+                    [[0.0, 1.0], [2.0, 3.0]],
+                    [[-10.0, -20.0], [-30.0, -40.0]],
+                ]],
+                dtype=torch.float32,
+            ),
+            torch.tensor([[5.0, -1.0], [6.0, -2.0], [7.0, -3.0]], dtype=torch.float32),
+            torch.tensor([4.0, 8.0, 12.0, 16.0], dtype=torch.float32),
+            torch.tensor(-2.0, dtype=torch.float32),
+        ]
+
+        fw_impl_mock.to_numpy.side_effect = torch_tensor_to_numpy
+        fw_impl_mock.run_model_inference.side_effect = [infer1, infer2]
+
+        mc = ModelCollector(graph, fw_impl_mock, fw_info_mock)
+
+        dummy_input = [np.random.randn(1, 3, 2, 2)]
+        mc.infer(dummy_input)
+        mc.infer(dummy_input)
+
+        sc0 = graph.get_out_stats_collector(node0)
+        sc1 = graph.get_out_stats_collector(node1)
+        sc2 = graph.get_out_stats_collector(node2)
+        sc3 = graph.get_out_stats_collector(node3)
+
+        # node0 (axis=1)
+        # infer1 channel means: [2.5, -2.5, 10.0]
+        # infer2 channel means: [6.5,  1.5, -25.0]
+        # final mean: [4.5, -0.5, -7.5]
+        np.testing.assert_allclose(sc0.get_mean(), np.array([4.5, -0.5, -7.5]))
+        min_v, max_v = sc0.get_min_max_values()
+        assert min_v == -40.0
+        assert max_v == 10.0
+        
+        # node1 (axis=1)
+        # infer1 channel means: [2.0, 4.0]
+        # infer2 channel means: [6.0, -2.0]
+        # final mean: [4.0, 1.0]
+        np.testing.assert_allclose(sc1.get_mean(), np.array([4.0, 1.0]))
+        min_v, max_v = sc1.get_min_max_values()
+        assert min_v == -3.0
+        assert max_v == 7.0
+        
+        # node2 (axis=-1)
+        # infer1 channel means: [2.0, 6.0, 8.0, 10.0]
+        # infer2 channel means: [4.0, 8.0, 12.0, 16.0]
+        # final mean: [3.0, 7.0, 10.0, 13.0]
+        np.testing.assert_allclose(sc2.get_mean(), np.array([3.0, 7.0, 10.0, 13.0]))
+        min_v, max_v = sc2.get_min_max_values()
+        assert min_v == 2.0
+        assert max_v == 16.0
+        
+        # node3 (axis=-1)
+        # infer1 channel means: 10.0
+        # infer2 channel means: -2.0
+        # final mean: 4.0
+        np.testing.assert_allclose(sc3.get_mean(), np.array([4.0]))
+        min_v, max_v = sc3.get_min_max_values()
+        assert min_v == -2.0
+        assert max_v == 10.0

--- a/tests_pytest/pytorch_tests/unit_tests/core/test_create_stats_collector_for_node.py
+++ b/tests_pytest/pytorch_tests/unit_tests/core/test_create_stats_collector_for_node.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Sony Semiconductor Solutions, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from unittest.mock import Mock
+import pytest
+from model_compression_toolkit.core.common.model_collector import create_stats_collector_for_node
+from model_compression_toolkit.defaultdict import DefaultDict
+
+
+class Conv2d:
+    pass
+
+class Linear:
+    pass
+
+class ConvTranspose2d:
+    pass
+
+class DummyLayer:
+    pass
+
+@pytest.fixture
+def fw_info_mock():
+    fw_info = Mock()
+    fw_info.out_channel_axis_mapping = DefaultDict({Conv2d: 1, Linear: -1, ConvTranspose2d: 1}, 1)
+    return fw_info
+
+@pytest.fixture
+def node_mock():
+    node = Mock()
+    node.is_activation_quantization_enabled.return_value = True
+    return node
+
+
+class TestCreateStatsCollectorForNode:
+
+    def test_create_stats_collector_for_node_conv(self, node_mock, fw_info_mock):
+        node_mock.type = Conv2d
+        node_mock.get_output_shapes_list.return_value = [(1, 3, 32, 32)]
+
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == 1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == 1
+        assert collector.mpcc.axis == 1
+
+    def test_create_stats_collector_for_node_linear(self, node_mock, fw_info_mock):
+        node_mock.type = Linear
+        node_mock.get_output_shapes_list.return_value = [(1, 10)]
+
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == -1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1
+
+    def test_create_stats_collector_for_node_2d_tensor(self, node_mock, fw_info_mock):
+        node_mock.type = DummyLayer
+        node_mock.get_output_shapes_list.return_value = [(1, 3)] # Output shape is 2D tensor
+
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == 1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == 1
+        assert collector.mpcc.axis == 1
+
+    def test_create_stats_collector_for_node_1d_tensor(self, node_mock, fw_info_mock):
+        node_mock.type = DummyLayer
+        node_mock.get_output_shapes_list.return_value = [(1,)] # Output shape is 1D tensor
+
+        # Check that axis changed to -1
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == 1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1
+
+    def test_create_stats_collector_for_node_scalar(self, node_mock, fw_info_mock):
+        node_mock.type = DummyLayer
+        node_mock.get_output_shapes_list.return_value = [()] # Output shape is scalar
+
+        # Check that axis changed to -1
+        assert fw_info_mock.out_channel_axis_mapping.get(node_mock.type) == 1
+        collector = create_stats_collector_for_node(node_mock, fw_info_mock, quant_node_in_fln=False)
+        assert collector.mc.axis == -1
+        assert collector.mpcc.axis == -1


### PR DESCRIPTION
## Pull Request Description:
This PR addresses the following https://github.com/SonySemiconductorSolutions/mct-model-optimization/issues/1451
In PyTorch, if the number of dimensions of the activation tensor is less than 2, an error occured in the statistics collection process.

[Cause]
1. When converting to a Numpy array, the scalar remains 0-dimensional, so the tensor's dimension `x.shape` cannot be obtained.
2. The default value of `out_channel_axis` is 1, which means that axes cannot be set correctly for tensors with dimensions less than 2.

[Solution]
1. Support for scalar in `torch_tensor_to_numpy`.
2. Modified `out_channel_axis` to -1 if the number of dimensions of the activation tensor < 2.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).